### PR TITLE
Add the mailing list archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,11 @@ We maintain two channels for comms:
 - Github issues and pull requests.
 - Slack: `#zig` in bazel.slack.com.
 
+Previously communications were over email; the past archive is in
+`mailing-list-archive.mbox`. It can be accessed like this:
+
+    mutt -f -R mailing-list-archive.mbox
+
 # Maintainers
 
 This section lists the driving forces behind bazel-zig-cc. Committers have push

--- a/mailing-list-archive.mbox
+++ b/mailing-list-archive.mbox
@@ -1,0 +1,17040 @@
+From MAILER-DAEMON Wed Mar  8 11:59:03 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=uber.com header.i=@uber.com
+Received: from mail-ed1-f48.google.com (mail-ed1-f48.google.com [209.85.208.48])
+	by mail-b.sr.ht (Postfix) with ESMTPS id DDF2111EEC2
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon,  6 Sep 2021 05:14:56 +0000 (UTC)
+Received: by mail-ed1-f48.google.com with SMTP id u19so7815945edb.3
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sun, 05 Sep 2021 22:14:56 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=uber.com; s=google;
+        h=mime-version:references:in-reply-to:from:date:message-id:subject:to
+         :cc:content-transfer-encoding;
+        bh=7Ep7iTYyg1DX8Hx9AdVtBxHJWPcMfNRMH8EVv7gJalA=;
+        b=0T3cef8TsPS2gcoAtVKBRrHY8D9aD8FJvFDsizN3PMB0F8l32dLdRv8+TvHspaJs5l
+         lJdSEzmJ6Hkn1T3DPxjr7qvm9s4+ThTSRkEwFtWerRuftLWxMlUml73Cs0fIhN7FohhH
+         LNbRleFGhs9sM2EueHyR7e7sc1qdxDd+644IQ=
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20161025;
+        h=x-gm-message-state:mime-version:references:in-reply-to:from:date
+         :message-id:subject:to:cc:content-transfer-encoding;
+        bh=7Ep7iTYyg1DX8Hx9AdVtBxHJWPcMfNRMH8EVv7gJalA=;
+        b=Nig0qyUf+TPvScOEAThWQagGYc0pZQnLXdiWR41czq9ODyMBe8281D+altQ/+U7QbU
+         6x+GKNecxPw/rLFsxDQ+FILzF4tRaV/oQ4nVBsq0ssVb1P4fY5IWlXSn2Rq3tZwSTKtP
+         Ax2Qz8BX72ywIcQo1ZM2JLhQF6UjvkbGBO0QyXiJT416xQLSjGQUB8arl+Q0fKNFcIJ9
+         UqwF8qkIyeMfjiL0faClIsNnXJhfa5qEyS6HwFDOdK7f344ExdzDmZNOxWnmhtZCIvpl
+         AU1dQ6HHK1qKY+VEbkvoq6w05PYihxHk7szMaahtw3USzpe6cF9YepAOxqZNyzM2NWWp
+         GUFg==
+X-Gm-Message-State: AOAM530RHZDN0bVwF4byjoCILBF7XpLVHfGKWcrFVgSdkYjbhCtTeR6T
+	GY+hwcM4PIIVUci3xE6TPMfllXXNuws916eSE25Cew==
+X-Google-Smtp-Source: ABdhPJx06von7JT53TGVZFlki01ijRhmL1GfVC0Mnhpi5vWifJyzoQeSjcDPzMuM5EjLg2LfBIJutd4b5I55Ak3kpsk=
+X-Received: by 2002:a05:6402:6cf:: with SMTP id n15mr11581412edy.85.1630905295539;
+ Sun, 05 Sep 2021 22:14:55 -0700 (PDT)
+MIME-Version: 1.0
+References: <CAMEgGpyFHe3f=VZgFEDMivQ_rGCmHngBPH5MAC2Va5NvJmRo5g@mail.gmail.com>
+ <CAK+t98XUb0EmzKu-zOPpZxQM_jcWS=K3AJUuz9tB93COdtJqFw@mail.gmail.com>
+ <CAEZVCP5BMvXc2W5L0_fYGws8A_GgXwZ4mgtduS3qBzNP97nqSw@mail.gmail.com>
+ <CAK+t98UYm5FhQFit4vix_RTUzXBfeH+CGVM8-1vQFHtYfLcgXw@mail.gmail.com> <CANeNeVSkKdpeN8BnXciTXBQQhoLFLGKCAKNXCRYyh8ymppdkfg@mail.gmail.com>
+In-Reply-To: <CANeNeVSkKdpeN8BnXciTXBQQhoLFLGKCAKNXCRYyh8ymppdkfg@mail.gmail.com>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@uber.com>
+Date: Mon, 6 Sep 2021 08:14:46 +0300
+Message-ID: <CAK+t98X2fo+_f+W1o8hzYX_CXmHVPMNfBN2CoM+soRGgMELOQQ@mail.gmail.com>
+Subject: Re: Cross-compilation with zig
+To: Adam Bouhenguel <adam@bouhenguel.com>, ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Steeve Morin <steeve.morin@gmail.com>, Zhongpeng Lin <zplin@uber.com>
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: RO
+Content-Length: 4092
+Lines: 104
+
++ ~motiejus/bazel-zig-cc@lists.sr.ht (please subscribe[0]). Also
+switching from top-down to bottom-up posting.
+
+On Sun, Sep 5, 2021 at 10:14 PM Adam Bouhenguel <adam@bouhenguel.com> wrote=
+:
+>
+> Thanks for adding me to the thread, Motiejus.
+>
+> Steeve, I'm very curious to hear how your investigation goes. Please keep=
+ me posted!
+>
+> I've been bitten a few times now by regressions in zig cc. Both 0.7.1 and=
+ 0.9-dev have problems with C++ exceptions and break runtime behavior of th=
+ird party libraries I'm using.
+
+Zig 0.7.1 to zig 0.9-dev moved from clang-11 to clang-12, so, from the
+surface, I would attribute behavior changes to this. Did you narrow
+this down to something specific?
+
+> Seems like the ability to build a set of specific projects in bazel (with=
+ a hermetic zig cc based toolchain) might be helpful for keeping everyone o=
+n the same page.
+
+Have you noticed regressions with `zig cc` when upgrading zig? Since
+it is covered by "bug stability program[1]", I expect zig upstream to
+be quite responsive with regressions there. If C++ behavior changes,
+it's probably a fault of a new clang, which should be reported to
+Apple (likely with help of zig developers, since they have done this
+many times).
+
+> To this end, what do you folks think about having a small suite of accept=
+ance tests for the toolchain?
+
+We already have //test:hello[2]. Feel free to add yours.
+
+> As a bonus we might be able to use qemu to ensure that the cross-compiled=
+ artifacts actually work.
+
+I am looking for multi-arch build support in sr.ht, which is "not yet
+available"[3], which would be ideal.
+
+Currently I am cross-compiling to a few architectures and checking
+whether the resulting "file" command returns an expected string. I
+agree qemu-system-<arch> is a good next step. What are your
+architectures of interest?
+
+Motiejus
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc
+[1]: https://ziglang.org/download/0.8.0/release-notes.html#zig-cc
+[2]: https://git.sr.ht/~motiejus/bazel-zig-cc/tree/main/item/test/BUILD
+[3]: https://man.sr.ht/builds.sr.ht/compatibility.md
+[4]: https://git.sr.ht/~motiejus/bazel-zig-cc/tree/main/item/.build.yml
+
+> Cheers,
+> Adam
+>
+> On Thu, Sep 2, 2021, 06:31 Motiejus Jak=C5=A1tys <motiejus@uber.com> wrot=
+e:
+>>
+>> Let me know how it goes. I set up a mailing list on srht for patches, if=
+ any.
+>>
+>> On Thu, Sep 2, 2021, 15:42 Steeve Morin <steeve.morin@gmail.com> wrote:
+>>>
+>>> Hey Motiejus,
+>>>
+>>> Thank for working on that!
+>>> I'll see if I can hack on it one weekend. What I'd like though is have =
+the `zig cc` toolchain have the same level of features as the "host" toolch=
+ain.
+>>> And it feels to me that doing the toolchain.bzl file by hand isn't the =
+right way to do it. I'm still looking into how bazel generates it and see i=
+f we can let it do it.
+>>>
+>>> Steeve
+>>>
+>>>
+>>> On Wed, 1 Sept 2021 at 21:03, Motiejus Jak=C5=A1tys <motiejus@uber.com>=
+ wrote:
+>>>>
+>>>> Zhongpeng, thank you for bringing the group together. +Adam, who creat=
+ed the initial toolchain (mine is a fork of Adam's initial hard work), and =
+he has obvious interest in the toolchain too.
+>>>>
+>>>> Steeve, my zig-cc toolchain is hosted here. I am obviously interested =
+in solving all the outlined issues, and rules_go#2894 is one of them. I am =
+currently very limited in capacity myself, but happy to merge improvements,=
+ either the mentioned issues or anything else you find reasonably necessary=
+ for usage of the toolchain.
+>>>>
+>>>> Motiejus
+>>>>
+>>>> On Wed, Sep 1, 2021 at 9:17 PM Zhongpeng Lin <zplin@uber.com> wrote:
+>>>>>
+>>>>> Hello Motiejus,
+>>>>>
+>>>>> In today's Bazel-Go maintainers meeting, Steeve (cc'ed) mentioned tha=
+t he wanted to work on zig-based toolchain for rules_go. Steeve is also an =
+expert in cgo support in rules_go. Checking the last email you sent, it see=
+ms you've made good progress on that. Do you still need help on rules_go#28=
+94? Steeve is probably the most knowledgeable person for you to talk to if =
+you need.
+>>>>>
+
+From MAILER-DAEMON Wed Mar  8 11:59:03 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=uber.com header.i=@uber.com
+Received: from mail-pf1-f176.google.com (mail-pf1-f176.google.com [209.85.210.176])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 7F60211F01D
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 14 Sep 2021 12:18:17 +0000 (UTC)
+Received: by mail-pf1-f176.google.com with SMTP id 18so11985902pfh.9
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 14 Sep 2021 05:18:17 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=uber.com; s=google;
+        h=mime-version:references:in-reply-to:from:date:message-id:subject:to
+         :cc;
+        bh=OrT2HLfEH5T84qiDOOT1fkL1jScAGScbvztl9Bh21pc=;
+        b=90ZPl0uDFnNAu2aY6Ya/MrR2y70iL0LQKpEOGY09XP+7MwX7/86CY6t52iN6YXoH2z
+         NyujV8NNjIvkDfTt9lTbuTlXfH6zw/zWuXooDeKhJ5F8EV51HksugrDVwRL7pnv8H7ir
+         a69BVlE46C9ZTXFo+uPGKG0LzUu/FB9bCESWQ=
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:references:in-reply-to:from:date
+         :message-id:subject:to:cc;
+        bh=OrT2HLfEH5T84qiDOOT1fkL1jScAGScbvztl9Bh21pc=;
+        b=Ce65X6V72tRXX3lsb+mUwj1Tl/p6n/UYy3NIcFZ4HyhO7r02nN9WV8dFapeKhWHcHq
+         aQUqblPaAUew8VnVJ76tt5ycFfyt0r+2uyq50xnoV6K6/1T3bvxJ6/KzUG2eEV/O7hVB
+         xkMaYXWM4X1d62n18Z0IYGwfH8oNvgS+gNjuaoPipRxDKW5oJ7/hNpWYNK3Bdg1klq0j
+         JcDZWDVt6Icz2V7bI/Hg5rm4jWjJT2UVhO2dU/ORhTei5G4x4bEB5K2vnBNnewmIZkla
+         aruAAoUK6ES8wGwDVEs4dkjrtcF4iG+Y+6VdNs7S4c/IK5YPqP3ZWnjiS9SYof/fx3hp
+         MjNg==
+X-Gm-Message-State: AOAM530UpTvU3UcNBbcQR2g9AazB7DLWy/Efj1NzsIcbZOWRJyxpGydG
+	Oc79jHwoMosaawx9gQ4QRMbjlwM9ThZOelu/hmh05g==
+X-Google-Smtp-Source: ABdhPJwrF4zc8+XPliKolcZkIgfEaf2EZWHhN4u3jxGdRRd12ErlTeUw0hq/4vbWlDizwNXDf/l1lw58uq4TfJsojxQ=
+X-Received: by 2002:a62:8c08:0:b0:434:652b:1319 with SMTP id
+ m8-20020a628c08000000b00434652b1319mr4534198pfd.24.1631621895297; Tue, 14 Sep
+ 2021 05:18:15 -0700 (PDT)
+MIME-Version: 1.0
+References: <CAMEgGpyFHe3f=VZgFEDMivQ_rGCmHngBPH5MAC2Va5NvJmRo5g@mail.gmail.com>
+ <CAK+t98XUb0EmzKu-zOPpZxQM_jcWS=K3AJUuz9tB93COdtJqFw@mail.gmail.com>
+ <CAEZVCP5BMvXc2W5L0_fYGws8A_GgXwZ4mgtduS3qBzNP97nqSw@mail.gmail.com>
+ <CAK+t98UYm5FhQFit4vix_RTUzXBfeH+CGVM8-1vQFHtYfLcgXw@mail.gmail.com>
+ <CANeNeVSkKdpeN8BnXciTXBQQhoLFLGKCAKNXCRYyh8ymppdkfg@mail.gmail.com>
+ <CAK+t98X2fo+_f+W1o8hzYX_CXmHVPMNfBN2CoM+soRGgMELOQQ@mail.gmail.com>
+ <CANeNeVTjtYd8vVzgprM7-LMBS67kugn_rvsocrP80W+rwvsUjQ@mail.gmail.com> <CAEZVCP4=r79nLRghL03Hi7CfKFjF2u3sL97hba9PHQzh7ZhFyg@mail.gmail.com>
+In-Reply-To: <CAEZVCP4=r79nLRghL03Hi7CfKFjF2u3sL97hba9PHQzh7ZhFyg@mail.gmail.com>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@uber.com>
+Date: Tue, 14 Sep 2021 15:18:04 +0300
+Message-ID: <CAK+t98Ww6cWU+MRtaPQ=_WVe_mwYmf0h9HHj_O0D-yuXyvoS3A@mail.gmail.com>
+Subject: Re: Cross-compilation with zig
+To: Steeve Morin <steeve.morin@gmail.com>
+Cc: Adam Bouhenguel <adam@bouhenguel.com>, ~motiejus/bazel-zig-cc@lists.sr.ht, 
+	Zhongpeng Lin <zplin@uber.com>
+Content-Type: text/plain; charset="UTF-8"
+Status: RO
+Content-Length: 964
+Lines: 24
+
+On Tue, Sep 14, 2021 at 2:21 AM Steeve Morin <steeve.morin@gmail.com> wrote:
+>
+> Alright you guys, I found a way to use bazel's auto toolchain configuration with zig!
+> It's rather archaic for now, but it works, I got protoc compiled and running for both macos and linux.
+>
+> Still needs some love, I'll post updates in the next few days.
+
+Looking forward to anything that will simplify it's setup/boilerplate.
+
+> The main idea is to give to @bazel_tools//tools/cpp:unix_cc_configure.bzl configure_unix_toolchain() what it want, and that's it!
+
+Interesting!
+
+I have slightly updated the toolchain today:
+- added support for darwin-arm64 and linux-arm64 host (though don't
+have an arm64 machine to test this with).
+- tried to upgrade zig itself, but cross-compilation to darwin-amd64
+fails with it; there seems to be a regression somewhere. I will look
+into it sometime soon.
+
+... so please rebase before sending patches.
+
+Regards,
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:03 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lf1-f45.google.com (mail-lf1-f45.google.com [209.85.167.45])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 7AA8311EF38
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 29 Oct 2021 04:45:34 +0000 (UTC)
+Received: by mail-lf1-f45.google.com with SMTP id p16so18563959lfa.2
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 28 Oct 2021 21:45:34 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:cc:subject:message-id:references:mime-version
+         :content-disposition:content-transfer-encoding:in-reply-to;
+        bh=e1CN1JJJM9joKaUlYnsska9HvRy43YfFeSGJYgiQjQs=;
+        b=N7pGbkjAvxhSXwB+tTVrJHBV8BHUuBWcqQlTvb/BtI/Jc5fNEvIj/GA7D/AxiqmIR1
+         27T8aTQ1DlzX+OQOW406lwGXbvZZL3V0ehPNMd7iusogsbnKu2EHBr+ThWpVtedV7vPU
+         /9iK0Z4ZmfsEN7uJIfRUN7dG+A2YhndnNXTgPJ25NCCICu4PpIOqbgYjywgE1GiC0Hay
+         YZymEWSaVLn7vKlbEkbxhKZ+UztEBLATrHZRKj5RfKyaqp2tlWgH+0o3I/gLxrtZVcX+
+         TKhoRqrxjGjYZrkdYwrVpHQ3k2w9/PTe7fRODmp9cYS9PRwEQC30OFWWz3eXgps+DMc8
+         LPbw==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:cc:subject:message-id
+         :references:mime-version:content-disposition
+         :content-transfer-encoding:in-reply-to;
+        bh=e1CN1JJJM9joKaUlYnsska9HvRy43YfFeSGJYgiQjQs=;
+        b=r89AESahTPDW+InsPvQBy5oShDlHrIWGg57AY8KjJBEXQgzGmw3EvmJjiLcsgSl+Wb
+         8zqr7NZ1dMcpon8GeT6jHeCKGHshHUqTFd6g52JIBGF/zUCVb56UUBDR3ioI7bGrPQxB
+         vPys0M00zxd8XxmgXoNXGlzsrPQb5Ey6G4c8LoGfByNU1MGq4QOeJalsLpZlqBRufnC8
+         KGaMUySwLmdUEJkvr6cwUVU0aH/NFH/a3SNJjqbErS7+BsG8L8c2mHfgXHRK5gKDSSW5
+         OeZFJhvSyckmkmydjakuc2ujue4AmXI0zHOqHG6x4BmRn9zLXGsubF3PTdnznc0FpSve
+         3QLw==
+X-Gm-Message-State: AOAM530q79ok7W8D4VaBKIDpBl3HwOetwH0gt33opT4qmBP6+foicf1Z
+	2uv9qkI/iyrmnil6tOaY/QE=
+X-Google-Smtp-Source: ABdhPJyuFdbOG4l8g9NVpT78xmShrZBBHNU8pGNzJkGl1MbHL1FDvr/UfAiOZ67yA0UmaKYiXhMxsQ==
+X-Received: by 2002:a05:6512:33c2:: with SMTP id d2mr7692886lfg.182.1635482732884;
+        Thu, 28 Oct 2021 21:45:32 -0700 (PDT)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id e22sm493971lfr.237.2021.10.28.21.45.31
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Thu, 28 Oct 2021 21:45:32 -0700 (PDT)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Fri, 29 Oct 2021 07:45:31 +0300
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@uber.com>
+Cc: Steeve Morin <steeve.morin@gmail.com>,
+	Adam Bouhenguel <adam@bouhenguel.com>,
+	~motiejus/bazel-zig-cc@lists.sr.ht, Zhongpeng Lin <zplin@uber.com>
+Subject: Re: Cross-compilation with zig
+Message-ID: <20211029044531.vvtv7btw2ur7u6zc@mtpad.i.jakstys.lt>
+References: <CAMEgGpyFHe3f=VZgFEDMivQ_rGCmHngBPH5MAC2Va5NvJmRo5g@mail.gmail.com>
+ <CAK+t98XUb0EmzKu-zOPpZxQM_jcWS=K3AJUuz9tB93COdtJqFw@mail.gmail.com>
+ <CAEZVCP5BMvXc2W5L0_fYGws8A_GgXwZ4mgtduS3qBzNP97nqSw@mail.gmail.com>
+ <CAK+t98UYm5FhQFit4vix_RTUzXBfeH+CGVM8-1vQFHtYfLcgXw@mail.gmail.com>
+ <CANeNeVSkKdpeN8BnXciTXBQQhoLFLGKCAKNXCRYyh8ymppdkfg@mail.gmail.com>
+ <CAK+t98X2fo+_f+W1o8hzYX_CXmHVPMNfBN2CoM+soRGgMELOQQ@mail.gmail.com>
+ <CANeNeVTjtYd8vVzgprM7-LMBS67kugn_rvsocrP80W+rwvsUjQ@mail.gmail.com>
+ <CAEZVCP4=r79nLRghL03Hi7CfKFjF2u3sL97hba9PHQzh7ZhFyg@mail.gmail.com>
+ <CAK+t98Ww6cWU+MRtaPQ=_WVe_mwYmf0h9HHj_O0D-yuXyvoS3A@mail.gmail.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Content-Transfer-Encoding: 8bit
+In-Reply-To: <CAK+t98Ww6cWU+MRtaPQ=_WVe_mwYmf0h9HHj_O0D-yuXyvoS3A@mail.gmail.com>
+Status: O
+Content-Length: 891
+Lines: 21
+
+On Tue, Sep 14, 2021 at 03:18:04PM +0300, Motiejus Jakštys wrote:
+> On Tue, Sep 14, 2021 at 2:21 AM Steeve Morin <steeve.morin@gmail.com> wrote:
+> >
+> > Alright you guys, I found a way to use bazel's auto toolchain configuration with zig!
+> > It's rather archaic for now, but it works, I got protoc compiled and running for both macos and linux.
+> >
+> > Still needs some love, I'll post updates in the next few days.
+> 
+> Looking forward to anything that will simplify it's setup/boilerplate.
+
+Hi all,
+
+the way plans are panning out now, at some point in 2022H1 bazel-zig-cc
+will be scrutinized by much more competent colleagues than myself,
+before being moved to github.com/uber (or equivalent). After that major
+changes will be much harder to make.
+
+Steeve, if you are still considering on major changes in bazel-zig-cc,
+this year is better than next year.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:03 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 57B3B11EF37
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri,  5 Nov 2021 13:23:34 +0000 (UTC)
+From: ~mjonaitis <mjonaitis@git.sr.ht>
+Date: Thu, 04 Nov 2021 18:54:42 +0200
+Subject: [PATCH bazel-zig-cc] add go_binary override
+Message-ID: <163611861421.17091.108675275474200386-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~mjonaitis <mjonaitis@uber.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 3856
+Lines: 124
+
+From: Mantas Jonaitis <mjonaitis@uber.com>
+
+---
+ BUILD                        |  2 ++
+ README.md                    |  7 +++++++
+ rules/BUILD                  |  0
+ rules/go_binary_override.bzl | 27 +++++++++++++++++++++++++++
+ test/BUILD                   | 15 ++++-----------
+ 5 files changed, 40 insertions(+), 11 deletions(-)
+ create mode 100644 rules/BUILD
+ create mode 100644 rules/go_binary_override.bzl
+
+diff --git a/BUILD b/BUILD
+index 07e6a04..a34acae 100644
+--- a/BUILD
++++ b/BUILD
+@@ -1,6 +1,8 @@
+ load("@bazel_gazelle//:def.bzl", "gazelle")
+ load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+=20
++# gazelle:map_kind go_binary go_binary //rules:go_binary_override.bzl
++
+ # gazelle:build_file_name BUILD
+ # gazelle:prefix github.com/motiejus/bazel-zig-cc
+ gazelle(name =3D "gazelle")
+diff --git a/README.md b/README.md
+index 8ae3935..7c83752 100644
+--- a/README.md
++++ b/README.md
+@@ -116,6 +116,13 @@ go_binary(
+ )
+ ```
+=20
++A workaround with [gazelle](https://github.com/bazelbuild/bazel-gazelle) `ma=
+p_kind` directive is possible. This will override rules_go `go_binary` rule w=
+ith `go_binary` which contains default `gc_linkopts` parameters. Add this lin=
+e to your BUILD files (usually adding to root BUILD file will suffice) and ru=
+n `gazelle` to automatically generate `load` statements.
++
++```
++# gazelle:map_kind go_binary go_binary @bazel-zig-cc//rules:go_binary_overri=
+de.bzl
++```
++
++
+ ## incorrect glibc version autodetection
+=20
+ **Severity: Low**
+diff --git a/rules/BUILD b/rules/BUILD
+new file mode 100644
+index 0000000..e69de29
+diff --git a/rules/go_binary_override.bzl b/rules/go_binary_override.bzl
+new file mode 100644
+index 0000000..6ac14cf
+--- /dev/null
++++ b/rules/go_binary_override.bzl
+@@ -0,0 +1,27 @@
++load("@io_bazel_rules_go//go:def.bzl", go_binary_rule =3D "go_binary")
++
++"""
++go_binary overrides go_binary from rules_go and provides default
++gc_linkopts values that are needed to compile for macos target.
++To use it, add this map_kind gazelle directive to your BUILD.bazel files
++where target binary needs to be compiled with zig toolchain.
++
++Example: if this toolchain is registered as bazel-zig-cc in your WORKSPACE, =
+add this to
++your root BUILD file
++# gazelle:map_kind go_binary go_binary @bazel-zig-cc//rules:go_binary_overri=
+de.bzl
++"""
++def go_binary(**args):
++  new_args =3D {}
++  new_args["gc_linkopts"] =3D select({
++      "@platforms//os:macos": [
++          "-s",
++          "-w",
++          "-buildmode=3Dpie",
++      ],
++      "//conditions:default": [],
++  })
++  for k, v in args.items():
++    new_args[k] =3D v
++    print("Key: {}".format(k))
++  go_binary_rule(**new_args)
++
+diff --git a/test/BUILD b/test/BUILD
+index 133fe5a..415b9c2 100644
+--- a/test/BUILD
++++ b/test/BUILD
+@@ -1,4 +1,5 @@
+-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
++load("//rules:go_binary_override.bzl", "go_binary")
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
+=20
+ go_library(
+     name =3D "hello_lib",
+@@ -7,22 +8,14 @@ go_library(
+     importpath =3D "github.com/motiejus/bazel-zig-cc/test",
+     visibility =3D ["//visibility:private"],
+     deps =3D [
+-        "@com_github_datadog_zstd//:go_default_library",
+-        "@com_github_mattn_go_sqlite3//:go_default_library",
++        "@com_github_datadog_zstd//:zstd",
++        "@com_github_mattn_go_sqlite3//:go-sqlite3",
+     ],
+ )
+=20
+ go_binary(
+     name =3D "hello",
+     embed =3D [":hello_lib"],
+-    gc_linkopts =3D select({
+-        "@platforms//os:macos": [
+-            "-s",
+-            "-w",
+-            "-buildmode=3Dpie",
+-        ],
+-        "//conditions:default": [],
+-    }),
+     static =3D "on",
+     visibility =3D ["//visibility:public"],
+ )
+--=20
+2.32.0
+
+From MAILER-DAEMON Wed Mar  8 11:59:03 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 3B44211EF37
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri,  5 Nov 2021 13:39:06 +0000 (UTC)
+From: ~mjonaitis <mjonaitis@git.sr.ht>
+Date: Thu, 04 Nov 2021 18:54:42 +0200
+Subject: [PATCH bazel-zig-cc v2] add go_binary override
+Message-ID: <163611954593.18596.9121656084211429991-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~mjonaitis <mjonaitis@uber.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 3822
+Lines: 123
+
+From: Mantas Jonaitis <mjonaitis@uber.com>
+
+---
+ BUILD                        |  2 ++
+ README.md                    |  7 +++++++
+ rules/BUILD                  |  0
+ rules/go_binary_override.bzl | 26 ++++++++++++++++++++++++++
+ test/BUILD                   | 15 ++++-----------
+ 5 files changed, 39 insertions(+), 11 deletions(-)
+ create mode 100644 rules/BUILD
+ create mode 100644 rules/go_binary_override.bzl
+
+diff --git a/BUILD b/BUILD
+index 07e6a04..a34acae 100644
+--- a/BUILD
++++ b/BUILD
+@@ -1,6 +1,8 @@
+ load("@bazel_gazelle//:def.bzl", "gazelle")
+ load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+=20
++# gazelle:map_kind go_binary go_binary //rules:go_binary_override.bzl
++
+ # gazelle:build_file_name BUILD
+ # gazelle:prefix github.com/motiejus/bazel-zig-cc
+ gazelle(name =3D "gazelle")
+diff --git a/README.md b/README.md
+index 8ae3935..7c83752 100644
+--- a/README.md
++++ b/README.md
+@@ -116,6 +116,13 @@ go_binary(
+ )
+ ```
+=20
++A workaround with [gazelle](https://github.com/bazelbuild/bazel-gazelle) `ma=
+p_kind` directive is possible. This will override rules_go `go_binary` rule w=
+ith `go_binary` which contains default `gc_linkopts` parameters. Add this lin=
+e to your BUILD files (usually adding to root BUILD file will suffice) and ru=
+n `gazelle` to automatically generate `load` statements.
++
++```
++# gazelle:map_kind go_binary go_binary @bazel-zig-cc//rules:go_binary_overri=
+de.bzl
++```
++
++
+ ## incorrect glibc version autodetection
+=20
+ **Severity: Low**
+diff --git a/rules/BUILD b/rules/BUILD
+new file mode 100644
+index 0000000..e69de29
+diff --git a/rules/go_binary_override.bzl b/rules/go_binary_override.bzl
+new file mode 100644
+index 0000000..cb37807
+--- /dev/null
++++ b/rules/go_binary_override.bzl
+@@ -0,0 +1,26 @@
++load("@io_bazel_rules_go//go:def.bzl", go_binary_rule =3D "go_binary")
++
++"""
++go_binary overrides go_binary from rules_go and provides default
++gc_linkopts values that are needed to compile for macos target.
++To use it, add this map_kind gazelle directive to your BUILD.bazel files
++where target binary needs to be compiled with zig toolchain.
++
++Example: if this toolchain is registered as bazel-zig-cc in your WORKSPACE, =
+add this to
++your root BUILD file
++# gazelle:map_kind go_binary go_binary @bazel-zig-cc//rules:go_binary_overri=
+de.bzl
++"""
++def go_binary(**args):
++  new_args =3D {}
++  new_args["gc_linkopts"] =3D select({
++      "@platforms//os:macos": [
++          "-s",
++          "-w",
++          "-buildmode=3Dpie",
++      ],
++      "//conditions:default": [],
++  })
++  for k, v in args.items():
++    new_args[k] =3D v
++  go_binary_rule(**new_args)
++
+diff --git a/test/BUILD b/test/BUILD
+index 133fe5a..415b9c2 100644
+--- a/test/BUILD
++++ b/test/BUILD
+@@ -1,4 +1,5 @@
+-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
++load("//rules:go_binary_override.bzl", "go_binary")
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
+=20
+ go_library(
+     name =3D "hello_lib",
+@@ -7,22 +8,14 @@ go_library(
+     importpath =3D "github.com/motiejus/bazel-zig-cc/test",
+     visibility =3D ["//visibility:private"],
+     deps =3D [
+-        "@com_github_datadog_zstd//:go_default_library",
+-        "@com_github_mattn_go_sqlite3//:go_default_library",
++        "@com_github_datadog_zstd//:zstd",
++        "@com_github_mattn_go_sqlite3//:go-sqlite3",
+     ],
+ )
+=20
+ go_binary(
+     name =3D "hello",
+     embed =3D [":hello_lib"],
+-    gc_linkopts =3D select({
+-        "@platforms//os:macos": [
+-            "-s",
+-            "-w",
+-            "-buildmode=3Dpie",
+-        ],
+-        "//conditions:default": [],
+-    }),
+     static =3D "on",
+     visibility =3D ["//visibility:public"],
+ )
+--=20
+2.32.0
+
+From MAILER-DAEMON Wed Mar  8 11:59:03 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-wr1-f50.google.com (mail-wr1-f50.google.com [209.85.221.50])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 758F711EF37
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri,  5 Nov 2021 17:51:50 +0000 (UTC)
+Received: by mail-wr1-f50.google.com with SMTP id b12so14932424wrh.4
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 05 Nov 2021 10:51:50 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:cc:subject:message-id:references:mime-version
+         :content-disposition:in-reply-to;
+        bh=7twJFp2dPdxRaWs/e7LS95o7UbEONAXKNGJm0Ob1Wjg=;
+        b=a1+afz8XHDlEPSMPQ1FTgCSKIt1O6BU6Rd4OMsdb+YfNN0HarXLbPXkX4nwcoQVJZl
+         x0TBYE3Lv3abwUPqgPzEvO2sLMXjYZr+ys2guFw/LE3OUQwzEaewfhGeM7mJKoc9wlcf
+         i5BNu3VV3MsDnylAcsasQ2W/9eEkhZbsQIILo+XOQjiBkEW7CmzR2aSg5bsTLYbGBjz5
+         4ERwpIY9uod2Z7w4cucD22+vJjRatF7upBT0EqPSw7Pkb5UUvac/z0u0tLh+uoIN+Xw9
+         d/X/U1GpLXoKyGTwMqq3JCNPXwaESWJdtRmzXXtW3fAC10J7Pa2a8suCwFYSiBOctRhd
+         wVXA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:cc:subject:message-id
+         :references:mime-version:content-disposition:in-reply-to;
+        bh=7twJFp2dPdxRaWs/e7LS95o7UbEONAXKNGJm0Ob1Wjg=;
+        b=LzlcGF6wJrQFFQM72QIjedm8gc+GZmW44ruRoyW2VSCL/XTPU47Ort7mBfXb51+d0/
+         HLI5U6348cQ393BjvT1Sl3xByrOLnM7E6rQLQ45WbTAjIbmXTKzOp3ngAAmeiSDuo9XN
+         IBZFmmu6Ztil9eyyBr1zN9u4yPyLS0OS44m1coDmUG7j4hqsWaUL/e6qZayoYMQyXBzI
+         g32V/kYSxO+2gcpzc2yI+xVewyST29fczusxH8F33q6ky3FK1nAgpTpSsOmpXQND9K3/
+         8+5lYmEXYeEIjmR73OlWwQ8qC4NJK6Q3vlaJf5ts7I8unS/E/mN6aNQyespWDRsEUZ4b
+         D9Aw==
+X-Gm-Message-State: AOAM532XofickUl56P1GLD+NqdFHGBckg60NosiMHdXkJsbJ8j24RYrE
+	rXjKqltKIHdehkIOocslQnc=
+X-Google-Smtp-Source: ABdhPJylZROyH/qdWll3OEJtLDTYrSm3ZUIC8mX0SUk/ck3AxLsAnvVQEyMX4exhznKgRF84qJrdFg==
+X-Received: by 2002:a05:6000:143:: with SMTP id r3mr5508367wrx.236.1636134709441;
+        Fri, 05 Nov 2021 10:51:49 -0700 (PDT)
+Received: from localhost ([195.235.63.50])
+        by smtp.gmail.com with ESMTPSA id n7sm8534493wro.68.2021.11.05.10.51.48
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Fri, 05 Nov 2021 10:51:48 -0700 (PDT)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Fri, 5 Nov 2021 19:51:54 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~mjonaitis <mjonaitis@uber.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: Re: [PATCH bazel-zig-cc v2] add go_binary override
+Message-ID: <20211105175154.bzfuu666zuaxyt27@mtpad.i.jakstys.lt>
+References: <163611954593.18596.9121656084211429991-0@git.sr.ht>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+In-Reply-To: <163611954593.18596.9121656084211429991-0@git.sr.ht>
+Status: O
+Content-Length: 808
+Lines: 20
+
+On Thu, Nov 04, 2021 at 06:54:42PM +0200, ~mjonaitis wrote:
+> From: Mantas Jonaitis <mjonaitis@uber.com>
+> 
+> ---
+>  BUILD                        |  2 ++
+>  README.md                    |  7 +++++++
+>  rules/BUILD                  |  0
+>  rules/go_binary_override.bzl | 26 ++++++++++++++++++++++++++
+>  test/BUILD                   | 15 ++++-----------
+>  5 files changed, 39 insertions(+), 11 deletions(-)
+>  create mode 100644 rules/BUILD
+>  create mode 100644 rules/go_binary_override.bzl
+
+Applied[1], thank you. Although I left only the acknowledgement in the
+README; see [2] for why.
+
+Motiejus
+
+[1]: https://git.sr.ht/~motiejus/bazel-zig-cc/commit/523943bd35d33f96f946be653311787426149135
+[2]: https://git.sr.ht/~motiejus/bazel-zig-cc/commit/22b5d3e8e38e762a35adbfd4e13bfe5c2fb07972
+
+From MAILER-DAEMON Wed Mar  8 11:59:03 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lf1-f45.google.com (mail-lf1-f45.google.com [209.85.167.45])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 9413211EF81
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon,  6 Dec 2021 20:01:32 +0000 (UTC)
+Received: by mail-lf1-f45.google.com with SMTP id n12so28168895lfe.1
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 06 Dec 2021 12:01:32 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:cc:subject:message-id:references:mime-version
+         :content-disposition:content-transfer-encoding:in-reply-to;
+        bh=XbmO1rVL6sHMTrVhfrqqOl/bwac3U2zY7lWAQ/rHyYI=;
+        b=Ui4E27zUkVkuxOSfzUqdvgjLvJt2zihUNYH6RF9nSLXybcoG1pmy2uszNB9mMp4OKE
+         cQuFWrQbItNulmWxf1DF3oAEgyKe7TzjEGgayv/9zDmBJzlYpVetrACw5cx1UZjxHK66
+         weYxKw7rBN4y9y9mADbf2HLqibIbE61Q2WRJ9N+q09jTqY3t5bOCQaN7NrTnXfvdrMHv
+         l2+1m2JnjwmHVWnpYNaKODmnO7yBl2G/JtBF7iaVx2gzP8oYtGHZREWaeYfHuAQJtaqB
+         53rMyZIceJJBpsNv0Od2W/gbBXEtiER5ESSg3zFwZySBYdF5KGfnsa3fclAAxZOKyEkc
+         n8jg==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:cc:subject:message-id
+         :references:mime-version:content-disposition
+         :content-transfer-encoding:in-reply-to;
+        bh=XbmO1rVL6sHMTrVhfrqqOl/bwac3U2zY7lWAQ/rHyYI=;
+        b=xItNJQnvwvQPGYo/eRO3rcIcghIeEYeqaHhNjWXULh3N/u95sFwCOaPITMuXYQGi3Q
+         Ob4+R3CDSl54/jzyIM9UTdXO7l9Cjoc46/uE3PcTBxchclkg5wvlW+gf7qqcOPh1CT6N
+         2yOR9Zm0lm5SsekIu7TZ/i/bt0ki+xegDDLDIkfpaS6FMbAwxpsC8UTU0+Cjro+6z6/b
+         VeL4OKWI/brQARrFG3ou2k3SEH/5fGDDosuDXuvJLNxHfL19epeM1wRwKu5DNMCN0Xwf
+         a87rrTOyys46rLwxGIiMzJ774y6pUlTWWyw4Wats/CmugLFoaaAXWLBqIQdvkSuhJm+V
+         GtXw==
+X-Gm-Message-State: AOAM530mwZuS8Zn37xIFZxYCoDokFqKGJTy4gP29snlm1IBQBAVALfoZ
+	gpL3eENl0BUbF1SG2YeWITc=
+X-Google-Smtp-Source: ABdhPJzSblFiitOVK4mUPDvYX2C+QgZFR6SJ06DAAEp2kDJ1On6O52o6QBmThDQZbAdysSZh0aIlgQ==
+X-Received: by 2002:a05:6512:2305:: with SMTP id o5mr37990569lfu.362.1638820890548;
+        Mon, 06 Dec 2021 12:01:30 -0800 (PST)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id q24sm1443528lfp.103.2021.12.06.12.01.29
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Mon, 06 Dec 2021 12:01:29 -0800 (PST)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Mon, 6 Dec 2021 22:01:28 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: Thomas Way <tway@cloudflare.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: Re: bazel-zig-cc contributions
+Message-ID: <20211206200128.vyx7b4r5h2moe5dk@mtpad.i.jakstys.lt>
+References: <CAO8CkMSaFSeYVsgczJPStPz9M3LDZCUdABRo8Pk1+=U6v-NT0Q@mail.gmail.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Content-Transfer-Encoding: 8bit
+In-Reply-To: <CAO8CkMSaFSeYVsgczJPStPz9M3LDZCUdABRo8Pk1+=U6v-NT0Q@mail.gmail.com>
+Status: O
+Content-Length: 1502
+Lines: 36
+
+On Mon, Dec 06, 2021 at 05:57:46PM +0000, Thomas Way wrote:
+>    Hey Motiejus!
+>    Thank you so much for your work on the Zig CC rules. They're been
+>    extremely helpful and a true gamechanger for the way we work with our
+>    repository.
+>    Per Zig's cache race conditions, we've made some changes to the rules and
+>    were wondering what the best way to contribute them would be?
+
+Hi Thomas!
+
+See [1]; I also recommend you to subscribe. I haven't heard of anyone
+using bazel-zig-cc, so I guess I'll need to be more careful/upfront
+about breaking changes.
+
+>    A quick summary:
+>    - Use an alias for the Go-style toolchain. This should be more efficient.
+>    - Some general cleanup of unused features (i.e unnecessary filegroups).
+>    - Most importantly: Use a cache location inside Bazel. We found that
+>    sometimes Zig's cache would become corrupt on the host and would become
+>    irrecoverable even after running `bazel clean --expunge`. Using a cache
+>    location inside Bazel fixes this issue and is good practise in general I
+>    believe.
+
+These sound great, send them over!
+
+>    I look forward to hearing from you.
+
+Have you found a need/way to specify a different default url for the zig
+bundle? I've been playing with it[2], but unsatisfied with the API so
+far.
+
+Motiejus
+
+[1]: https://sr.ht/~motiejus/bazel-zig-cc/#contribution-guidelines 
+[2]:
+https://git.sr.ht/~motiejus/bazel-zig-cc/commit/8f5f249227aa6a9d3de441058eb9d3aae330620b
+
+From MAILER-DAEMON Wed Mar  8 11:59:03 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lf1-f42.google.com (mail-lf1-f42.google.com [209.85.167.42])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 9975311EF93
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 10 Dec 2021 07:57:40 +0000 (UTC)
+Received: by mail-lf1-f42.google.com with SMTP id m27so16481755lfj.12
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 09 Dec 2021 23:57:40 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:mime-version
+         :content-disposition;
+        bh=HQ/hL64B6GWzGaNBVZUn4QLaOj38mBj6tYEQkF5T6Hc=;
+        b=HRbxSWHJkd1mlvqgFdlGyFOVOlXJr8/e2Tz9lm1YMGwoH50u/oTHT0Qv3csF9/DxXs
+         0vAyK8YeTncB6iGP/uyCF2mzrTRLsWaJXwYMmRGq0Q32iQkHjURwdbaruxZF/EAHx4V9
+         1O20KHVUapedNnIzdC940UhaYnwTolyUi7tHj6dQLPyA26ukzQK6TYjrlNRZa5qyogX5
+         W3OTN1Kk0mfU8IOWyCJocFb0sozLbzT//HP/L+UfXkid4IvtpuEfTLIkBr/Ez0fZEXtY
+         0HW3+PZKwNBV8A1eMNfmX+aW0XPfPpek8mCZ41iGi/5TEBdO2O75520iDnYXYqfc4VZ2
+         VuCA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :mime-version:content-disposition;
+        bh=HQ/hL64B6GWzGaNBVZUn4QLaOj38mBj6tYEQkF5T6Hc=;
+        b=rgCpluQpBDnpflGkjPs3XJ4t/c293EfjPhwWqR6bwA+eGn12gq6HsZ8ZC+aPW2TBVX
+         rdcNzG6RWq4v4asAp8Ng3pDESOGLPADxlsLqS/RxW6pqTzZXNE67kCvoEDEzZ6mE8bIg
+         AK56XSqB6bfUkl9PJbd4R7l6O4EZjM/7AQGoSY3xW1OQ2XXvQ8PjMNWrSuF6rZVq02y6
+         MuxhGBzQer/LQmI8M6XL9lNAYKJzeimwG2zVzmGWX+d1cJig37qc3QF1HBK57PG6rxnw
+         gteWVE/yPY5J3ul1aBTW0VV3seXnb8KixoihOsvc7aH0/PqxjyV6Fga8WbFQvwpDat7c
+         JRhQ==
+X-Gm-Message-State: AOAM533n1LpdCI+K//K6+CY/Cqn/Tw+F334UDBFn1SSG0G+TDXt+3kt+
+	8NFjbzbVpYsCB/CYuQVrhM+W99Yg5Ck=
+X-Google-Smtp-Source: ABdhPJz07XVpRcQkYipcpP+OcZMq1nSXbEg5HLv7ziv6SBn8gWkNFCfBr4BGn3fJkpaD+Ur7p/dZpg==
+X-Received: by 2002:ac2:5f85:: with SMTP id r5mr10983167lfe.566.1639123055422;
+        Thu, 09 Dec 2021 23:57:35 -0800 (PST)
+Received: from localhost (m90-131-39-222.cust.tele2.lt. [90.131.39.222])
+        by smtp.gmail.com with ESMTPSA id a1sm262188lfb.190.2021.12.09.23.57.34
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Thu, 09 Dec 2021 23:57:34 -0800 (PST)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Fri, 10 Dec 2021 09:57:33 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: recent changes in bazel-zig-cc
+Message-ID: <20211210075733.ihb2b57lyges4l6d@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Status: O
+Content-Length: 1921
+Lines: 46
+
+Hi bazel-zig-cc users,
+
+Due to a recent bug-fixing spree in zig, bazel-zig-cc improved quite a
+bit:
+
+- `zig c++` no longer errs with the dreaded FileNotFound[1]. This was
+  very prominent on many-core machines, and now unblocked larger-scale
+  tests.
+- can compile Darwin again: x86_64[2] and aarch64[3]. Although if you
+  are interested in compiling for Darwin, Jakub's comments in [3] are
+  must-read.
+
+My only short-term wish-list from Zig today is [4]: if Foundation
+framework is requested, but zig doesn't find it, the compiler should
+fail. Currently only a warning is emitted, and the binary is wedged with
+a possibly "difficult to track runtime exception"[5]:
+
+```
+warning(link): framework not found for '-framework CoreFoundation'
+warning(link): Framework search paths:
+```
+
+I added an Upcoming Wishlist category to the README[6], which is:
+
+- Move Zig cache path to bazel root, so bazel clean --expunge clears the
+  zig cache.
+- Provide a way to specify alternative URLs for the zig toolchain
+  (currently zig is downloaded from jakstys.lt, which is nuts).
+- Rename @zig_sdk//:<toolchain>_toolchain to
+  @zig_sdk//toolchain:<toolchain> or similar; so the user-facing targets
+  are in their own namespace.
+- Provide a way to specify sysroot for Darwin (OSX). See [#Compiling OS X
+  executables] for an ongoing discussion.
+
+As bazel-zig-cc is only ~10% of my $dayjob, I am not planning to work on
+the above any time soon. But it gives a nice starting point for a
+question "how do I help/contribute"?
+
+Zig 0.9.0 is 10 days away, I will cut bazel-zig-cc 0.4.0 once that
+happens.
+
+[1]: https://github.com/ziglang/zig/issues/9431
+[2]: https://github.com/ziglang/zig/issues/10297
+[3]: https://github.com/ziglang/zig/issues/10299
+[4]: https://github.com/ziglang/zig/issues/10299#issuecomment-990404953
+[5]: https://github.com/ziglang/zig/issues/10299#issuecomment-989153750
+
+From MAILER-DAEMON Wed Mar  8 11:59:03 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lj1-f177.google.com (mail-lj1-f177.google.com [209.85.208.177])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 6E05E11EF94
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 13 Dec 2021 02:38:20 +0000 (UTC)
+Received: by mail-lj1-f177.google.com with SMTP id bn20so21731895ljb.8
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sun, 12 Dec 2021 18:38:20 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:mime-version
+         :content-disposition;
+        bh=yoiGVjBHZN2xJAtcYYTqPfPA8yxvgKQ0VkBgA3ZSX20=;
+        b=f1258iMcV/Wbk9swTsCSoWGYASEwg9aI6PY4Ee8hYi1a6CQMkWzwFdEiaaYyCOpABn
+         4AtFWDrTM3fZ+ctksbg+tDl782Z9o929B/4SAcfXInX9oKHsobmzO0ChoS7QaFX3JK32
+         /sKmWTcN6rLg8BUSmN4D8EkIG3mJV48jx1VdbHKSZtlPxHLHIWMIWJCzsTr9ihVMCYkE
+         2lik9ffXQLWbQScNgwirCm14fb44rEBRQ3ooXYBG/wRsPyH+IP15/fZN47AF7kPrITU1
+         Pbg2s7PL8WxYNogXtD7f77UsfyN7/YrJOqUIlfe0yxQb1wtMXibAB7su9uSpKZ3/PoIU
+         q20w==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :mime-version:content-disposition;
+        bh=yoiGVjBHZN2xJAtcYYTqPfPA8yxvgKQ0VkBgA3ZSX20=;
+        b=L9A3RyHTzHV+FMUGbXt87CW6BV9dZ7kcW4N2Y6v6EGeuaGYohH7qt5jGFHF3qL2+rk
+         lv3ZY/3cCaCgBq1G1QevpO40orf+7Ci4hLvL0YLC8MqI4QWzTemvMJsq3jb8aZ9lBMIs
+         HMXrqAuEhqatukjO/o5gykvb6oFhJF56HCwe3dIZgud75BaYNSKZKRvg/1X30S9EjBg3
+         +Y+qElbC26lKKpzvTnlG8VI4Gg+W1aMNeaa6gB/ybsddLGIss+jtoKWgI+Pey/P6b1bV
+         Hc0mwChymAeWPdIBlYD5cphbFMr9uPl4ceoQCw7l6+du+lI1M2/x5jFUV0taGLBTaHR2
+         FadA==
+X-Gm-Message-State: AOAM532NYpPD+ClV9sorQ9xbOrDBd+RgPqTbGjWmHYTxFYWTzBlmr8Ae
+	f3Y9g5K1oa/cMkDMkzESuHr/EpL1yy4=
+X-Google-Smtp-Source: ABdhPJwy5PDLB0wyelzZ7tpYgzeQzFLInozFHtZ4lQRvqE0cFrzbeHeXlgo/tK2Bzr/WRZea468KCA==
+X-Received: by 2002:a05:651c:323:: with SMTP id b3mr26998720ljp.316.1639363097753;
+        Sun, 12 Dec 2021 18:38:17 -0800 (PST)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id z2sm1235075lfd.301.2021.12.12.18.38.16
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Sun, 12 Dec 2021 18:38:17 -0800 (PST)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Mon, 13 Dec 2021 04:38:16 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: bazel-zig-cc v0.4.0-rc1
+Message-ID: <20211213023816.obgjrpaxt445lzpn@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Status: O
+Content-Length: 2091
+Lines: 63
+
+Hi folks,
+
+I released v0.4.0-rc1; notable changes from v0.3.4:
+
+- upgrade to zig 0.9.0-dev.1950+a76910b69. Now compilation on Darwin
+  will fail if `-framework` was specified, but wasn't able to be
+  linked[1]. This happens on darwin/arm64, which I had to disable CI
+  for. A patch that passes `zig cc --sysroot=/path/to/sdk` is sought
+  for, if you care about darwin/arm64 (or darwin in general).
+- remove default `-O3`[2]. This now re-enables UBSAN by default, which
+  is an important default in upstream[3].
+
+v0.4.0 will be released when zig 0.9.0 is released, which is scheduled
+for Dec 20.
+
+About undefined behavior (removal of `-O3`)
+-------------------------------------------
+
+The second change broke my use of brotli, which relies on undefined
+behaior[4]. This is my ugly way to mitigate it:
+
+Project's WORKSPACE
+```
+BROTLI_COMMIT = "4ec67035c0d97c270c1c73038cc66fc5fcdfc120"
+
+http_archive(
+    name = "brotli",
+    sha256 = "9f57c32e5903768a03900366d8a055d49c01ecbbded046dce47eae24115b58b8",
+    strip_prefix = "brotli-%s" % BROTLI_COMMIT,
+    urls = ["https://github.com/google/brotli/archive/%s.zip" % BROTLI_COMMIT],
+    patch_args = ["-p1"],
+    patches = [
+        "//patches:brotli-disable-undefined-behavior.patch",
+    ],
+)
+```
+
+And the patch:
+```
+diff --git a/BUILD b/BUILD
+index 07a6793..2b4d1c1 100644
+--- a/BUILD
++++ b/BUILD
+@@ -43,7 +43,7 @@ config_setting(
+ 
+ create_msvc_config()
+ 
+-STRICT_C_OPTIONS = select({
++STRICT_C_OPTIONS = ["-DBROTLI_BUILD_PORTABLE"] + select({
+     ":msvc": [],
+     "//conditions:default": [
+         "--pedantic-errors",
+```
+
+If anyone has a better idea how to append a COPT to a downstream Bazel
+project, I would be happy to learn from you.
+
+Motiejus
+
+[1]: https://github.com/ziglang/zig/pull/10312/
+[2]: https://git.sr.ht/~motiejus/bazel-zig-cc/commit/985e26b474fb7594bb385ce9382def7c95373ca9
+[3]: https://github.com/ziglang/zig/issues/4830#issuecomment-605491606
+[4]: https://github.com/google/brotli/blob/ce222e317e36aa362e83fc50c7a6226d238e03fd/CMakeLists.txt#L104-L108
+
+From MAILER-DAEMON Wed Mar  8 11:59:03 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lj1-f172.google.com (mail-lj1-f172.google.com [209.85.208.172])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 8F7BE11EFCB
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 15 Dec 2021 13:13:09 +0000 (UTC)
+Received: by mail-lj1-f172.google.com with SMTP id z8so33239469ljz.9
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 15 Dec 2021 05:13:09 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:mime-version
+         :content-disposition;
+        bh=Nd/WltjseH/65+GIHu93VIGVBFJcCg0jRhztUcKW+SU=;
+        b=YifS23k0ae73nB9jZrmpDfVWyVtYzoJdrWXc+5MNan5dueiYI+Pmjnkg9jxIEOwcnL
+         +VQHmcJ/Y9M6AdNgdKZwndRPHH0Czcw5mAcY0TeM47/bsU3T430BePLSIS5/O6p6JX/2
+         Hwxm8E9j6Z7zWCGPQZaZp+rFNsF2Zu9O26JiTRJQUhLsUysQG6FZknoPtpfX3BeZ+yoM
+         v2LcX8luagONzI+/x3P45oLzYKCDigtt18ZB3KRPNEshaf5dmN8RStVg1IDrw1FjUtRT
+         oL9zGkok8U8knDDek8p7lhB3MRboeGt594Ne5yQY/fbAJ2/X+Z1+xj7B4K6RRPlnHRXO
+         OAUQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :mime-version:content-disposition;
+        bh=Nd/WltjseH/65+GIHu93VIGVBFJcCg0jRhztUcKW+SU=;
+        b=pf8ogSdB1vOvUEquKYzJlAQtWpqT33q/Bg6qFpxtPUo1WjfP9wQr2AaOrjf5vw6aop
+         xEwyTnjTlepxIE+vzRGJia9BFnl1521dGEJQEs3U1+oUsuBbVRakm8nHmW/nxOXuMJAY
+         5ZO5wINNUWWAXNCoqAt9IL+AwhgnPu2ywTUtB7U+lSp04UuiykNScGtuZJ2RUx5P+0aj
+         Fe0POq1r5B4A7Jd7CqsD1ScZryljzSpljtqAUoDyofvfGG9IThOIGh2/7CWvFFgJW8Ad
+         ZSHXjUYfzwt/y3MJLaJplBF5rsFzROStOsSGLx30sltzXSmCrrJYG1LtXuAIm5rgj1SJ
+         6rrw==
+X-Gm-Message-State: AOAM533R97q6G/KfXwqKpV2oIKXGZVFqUK4F6MiTLkJRDOtDFFszGnUt
+	aYBdph3HB+26HO13BPLB93gvtQqpLtc=
+X-Google-Smtp-Source: ABdhPJx3uV4VjLPjCmWnmHQG63N7zAf+Y2l6UqhNBFLQzu4Z0QoQypdM5i/S04/3RQt/gC2gd7mUZw==
+X-Received: by 2002:a2e:7305:: with SMTP id o5mr10152834ljc.180.1639573987957;
+        Wed, 15 Dec 2021 05:13:07 -0800 (PST)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id o24sm316972lfr.117.2021.12.15.05.13.07
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Wed, 15 Dec 2021 05:13:07 -0800 (PST)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Wed, 15 Dec 2021 15:13:06 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: bazel-zig-cc v0.4.0-rc2
+Message-ID: <20211215131306.toz7czanzdhhukbe@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Status: O
+Content-Length: 1430
+Lines: 42
+
+Hi folks,
+
+I released v0.4.0-rc2, this time only upgrading zig to
+0.9.0-dev.1968+ff93486d0 (from 1950). Two notable changes with regards
+to `zig cc`:
+
+- [darwin] zig cc will now fail hard if `-framework` is specified, but
+  not found. It used to produce a strange-looking, likely-unworkable
+  binary.
+- glibc stubs are fixed[2]. I have been waiting for this for a long
+  time. More on this in HN[3].
+
+These resolve the last known high-severity issues. Thanks zig team! As I
+am not expecting any final-day fixes in zig itself, there likely won't
+be an rc3. A few weeks after 0.9.0 is released, I am planning to remove
+the dev versions from my mirror[4].
+
+Tip of the day
+--------------
+
+This is helpful in `.bazelrc`:
+
+    build --compilation_mode=opt
+
+This makes non-tests to be compiled with -O2. Tests will be compiled
+without optimizations, making compilation faster, and retaining
+UBSAN[5].
+
+Open questions
+--------------
+
+The question from last week[6] still holds: how to adjust CFLAGS for an
+external Bazel project?
+
+Motiejus
+
+[1]: https://github.com/ziglang/zig/pull/10312
+[2]: https://github.com/ziglang/zig/pull/10330
+[3]: https://news.ycombinator.com/item?id=29538264
+[4]: https://dl.jakstys.lt/zig/
+[5]: https://github.com/ziglang/zig/issues/4830#issuecomment-605491606
+[6]: https://lists.sr.ht/~motiejus/bazel-zig-cc/%3C20211213023816.obgjrpaxt445lzpn%40mtpad.i.jakstys.lt%3E
+
+From MAILER-DAEMON Wed Mar  8 11:59:03 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lj1-f177.google.com (mail-lj1-f177.google.com [209.85.208.177])
+	by mail-b.sr.ht (Postfix) with ESMTPS id E229D11EF12
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 27 Dec 2021 08:41:55 +0000 (UTC)
+Received: by mail-lj1-f177.google.com with SMTP id i11so12257671ljm.13
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 27 Dec 2021 00:41:55 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:mime-version
+         :content-disposition;
+        bh=wbwsWNmX9ACiddCLR8HrD69hw93GH+pGJxzcr23R6rM=;
+        b=dJQmTKPHoBlHHAkyWNFHks9q1bXMAkrYrZl5scATSk3Njq3uDtNg6ZePXJE2E52O8j
+         5t3SLmKPiCE4cljIPqMwljlWHrKZZJ3kc4a6cnGGGdXhOV53CHBYg/ox7Ck8f06/v6Ja
+         Rnw3hk5ExzZdfNIpieCztf5pAczKs+EJ83cxoJOR0KvGdof0gWsOop2M59eFpIEDuBzn
+         wlgxkVdd3zwmO2lOS7QUwosUkIbOyZkqY7JooI6WvL6GNcxeZdzGZrGy79F2oy1Y9cNc
+         pxAU1lr/REJg05oAR2T4pnRE5CKu2IEcxQhrj93Ev6xMxsvoNBl+1lPBGRoQjN0mH53i
+         bD1w==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :mime-version:content-disposition;
+        bh=wbwsWNmX9ACiddCLR8HrD69hw93GH+pGJxzcr23R6rM=;
+        b=0a0GA3vwn7I9H5bZ+7j9JKANjBci6Cy6bVy2w2CwnWwTaa7DFuQtq3WPn1ew623EN3
+         0MOuhwhGNKATpe2xicuCNX0bGAYcdELucvNqCRgtJmCCemuvpNhft+iqNFqbikUU104R
+         MXZJ4umCMwL7q9qFSHFZ2ss7yzsOpPipUsEx8vUfzbWDK+t/C0k8TbqPYu9J5GxTM0Ij
+         pykyVmYm1dZgTnZ2/MnnTupfSVB0lyT1IVCaKlcShPKNoZBMVVoGlSPC9OcwrxvFmCyO
+         /1VVlw3/SSvaDsubVmRRLygqLzc2g+u4u4qvhgFm6jIwycYgUMQmftvWCpg+byXQi1w2
+         +YIw==
+X-Gm-Message-State: AOAM53232Y6heOR1VRU9KAEewm/STKfMJjfFhmrKpvp33SRSRIjhReRT
+	MzLK1b9lTWFqiutkuzy6t/tEP8Xd2Nw=
+X-Google-Smtp-Source: ABdhPJx6ysrzoYMTFmAldsjWAd2AmWOnspuGaPYDfO1NywR7rTlaoEe1V3yyloNzmWWczgMgR9EN1A==
+X-Received: by 2002:a05:651c:12c3:: with SMTP id 3mr13364719lje.311.1640594514193;
+        Mon, 27 Dec 2021 00:41:54 -0800 (PST)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id z17sm1581748lfu.128.2021.12.27.00.41.53
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Mon, 27 Dec 2021 00:41:53 -0800 (PST)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Mon, 27 Dec 2021 10:41:52 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: upcoming bazel-zig-cc 0.4.0
+Message-ID: <20211227084152.mjkx33nbxhnls5qz@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Status: O
+Content-Length: 693
+Lines: 20
+
+Hi folks,
+
+I cannot yet release bazel-zig-cc 0.4.0, because there is a regression
+in `zig c++`; you may follow along here[1].
+
+I am happy bazel-zig-cc CI caught this[2]; this regression was quite
+easy to trigger.
+
+I accidentally pushed 0.4.0 a few days ago, but promptly deleted the
+tag. If you managed to catch 0.4.0 (it was there for <1 hour), please
+remove the tag. My mistake, I will try harder not to do this again.
+
+Note that this affects only glibc targets; I am successfully using zig
+0.9.0 with a musl target (0.4.0-rc2 with a custom zig version).
+
+Regards,
+Motiejus
+
+[1]: https://github.com/ziglang/zig/issues/10386
+[2]: https://builds.sr.ht/~motiejus/job/654617
+
+From MAILER-DAEMON Wed Mar  8 11:59:03 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-wr1-f54.google.com (mail-wr1-f54.google.com [209.85.221.54])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 3EB8D11EFDB
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue,  4 Jan 2022 17:16:46 +0000 (UTC)
+Received: by mail-wr1-f54.google.com with SMTP id q16so77569936wrg.7
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 04 Jan 2022 09:16:46 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=mime-version:from:date:message-id:subject:to;
+        bh=KTpeB6mEXbEVO9a1XtNR3GFzrxOFWa+ZXF8Ntx3rgQE=;
+        b=Xqqvwjx/OFAQCXqZrQRRfr4f/6Hy6ogWOP8o9/6CBrtsLEFipeCcyCM4UlWOpa/9Fy
+         VKSnc4F2ZzQVZVUES7wSf7KFum76ug5kMU5PwBuFX9A8bEf9lcHrpCxXN3x9H+9TPvC6
+         7sKeEX/UHtzvz+DW+rRwhFs8avs4emaJytc1g/5xrdZHYzRQBJjc0JOQk4YmenkQWYh5
+         CoCPoKtD+0AHORd7s4bAjdxHcSuNco/9YOtrNcpbpJoZWpBuF89vpOhiNnXkjHZ+Ib5r
+         fpS0I0H/WuM6OPAtWk/9buSDH8eMqeQvdFfM8NQOQpfnuznjacKtcOmDxitr3qGpYlP0
+         o1rQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:from:date:message-id:subject:to;
+        bh=KTpeB6mEXbEVO9a1XtNR3GFzrxOFWa+ZXF8Ntx3rgQE=;
+        b=EoaQhWc7ZeEt+nZ4OO9aWJ8EBVIwUx77DkAP8gfTjY4TOTQdw3NvqB8IXfMOaKncLL
+         jHzl5jeG2xBsKuMluZ5T39g+CHXiauQpeE6xAwO1tMdspk8LLhNtqNXiE03o/MKLi2DX
+         n0Z2CNfyj5kIXSn4+xGuGjoxxj3skjGSu8Qo81FdEzmQYeSCXsRGuiPehleMRtjyo4Y6
+         wppYadALhSCdQYpYtBK260baG1d8NlhO0I8qT3EGA9svs6Pq+2Jmn64poWYcLrwXdehI
+         hgKWt1gq9HEetyBTozHsntK3+rM5I/9rWaqoisQ2RXCHjLk7ABmXRT+GnG/TPOklhyH2
+         bvOA==
+X-Gm-Message-State: AOAM533nQTAoOK3lrkUd5a9qUOIOlNZqE9sijsCribhFatAX7FRj5Yk4
+	AAxFSmbbSf9wffS6dz99DqKatIhgqm/6eHoqtxtPf1bPXSk=
+X-Google-Smtp-Source: ABdhPJz5SDvu+LXfelCJO5FWEZ1/pCy7suiHJOP2dd4cF85wjaqUTXVLRsNB38Gvt9oPDvc//YU8gletRsD/roItGgQ=
+X-Received: by 2002:adf:fc0d:: with SMTP id i13mr42706077wrr.296.1641316604314;
+ Tue, 04 Jan 2022 09:16:44 -0800 (PST)
+MIME-Version: 1.0
+From: Joe Schafer <joesmoe10@gmail.com>
+Date: Tue, 4 Jan 2022 09:16:33 -0800
+Message-ID: <CAOGO9CoqMcAp=_9KVB3g9o5Jp45OtcAP7TT_Cn_Gom-YfQ9pew@mail.gmail.com>
+Subject: uname -m on M1 MacBook returns arm64
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 1664
+Lines: 38
+
+Hello,
+
+I'm a big fan of this project. It's *lot* easier than trying to figure
+out other Bazel CC toolchains.
+
+One of my teammates ran into a curious error on an M1 Macbook using
+the latest bazel-zig-cc.
+
+    cc/toolchain/defs.bzl", line 219, column 70, in _zig_repository_impl
+    zig_include_root  =
+repository_ctx.attr.host_platform_include_root[host_platform]
+    Error: key "macos-arm64" not found in dictionary
+
+I traced this to toolchain/defs.bzl [1] which uses `uname -m` to get
+the architecture. It looks like bazel-zig-cc only supports aarch64 but
+M1 Macs return arm64.
+
+What's really spooky is that bazel-zig-cc worked on my M1 mac but it
+didn't work for two other devs on my team also on M1 macs; they got
+the above error.
+
+I was able to work around the problem with the following steps:
+https://gist.github.com/jschaf/c9be10d806020087680310e49f6e2072.
+
+- Uploaded all zig SDKs to my own hosting. I had to use my own hosting
+to create macos-arm64 which is really just a copy of maco-aarch64 but
+I had to change the folder name to match the archive name.
+
+- Added "macos-arm64" to host_platform_include_root, similar to "macos-aarch64".
+
+I'm by no means a Bazel toolchain expert, but I would have thought
+there's a better way to get the host platform architecture than by
+shelling out to uname. Appears that there's not [2] but that answer is
+from 2017. Maybe platforms provide a way out [3]?
+
+[1]: https://git.sr.ht/~motiejus/bazel-zig-cc/tree/main/item/toolchain/defs.bzl#L210
+[2]: https://stackoverflow.com/a/45029999/30900
+[3]: https://github.com/bazelbuild/rules_go/blob/master/go/private/go_toolchain.bzl#L95
+
+From MAILER-DAEMON Wed Mar  8 11:59:03 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-ed1-f41.google.com (mail-ed1-f41.google.com [209.85.208.41])
+	by mail-b.sr.ht (Postfix) with ESMTPS id E27F211EEAC
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue,  4 Jan 2022 19:01:44 +0000 (UTC)
+Received: by mail-ed1-f41.google.com with SMTP id j21so152096346edt.9
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 04 Jan 2022 11:01:44 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:cc:subject:message-id:references:mime-version
+         :content-disposition:in-reply-to;
+        bh=sqozoOSn/Xg8xLEoqSt6hEPuCR5lAjjcsfSFhFhcG28=;
+        b=a5i7J7P+5dbR5hl9nrzn0rGAkpdY0vv+Cc/GvjD76am5EYdD6fAfwSTe7zkNzUa057
+         9BHEl6yT3TJB64QY7y46wtmX2arRDct0A1vVBi3rkNeU9qNm7HAc9SyjMMWH3qnKYjPj
+         /2hKFGMdZl8nPSQQLbe5jNHWWjy4pHjTufC3T0bnslJYRb/ZF/St8ceebXJdsd2QK39r
+         lOsuZBdKccvOU4hCU16mI+TNlXSCru8VJoagGVFrct1KumgBPaMw9TPacKtGAhJGtO2S
+         K1v6VICmXAKJQdpUpAjJGDA8SWMTbK66r8ePnQCfmTIw5ulTzWnZsstAhlbJZ4iIXaKy
+         0UKA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:cc:subject:message-id
+         :references:mime-version:content-disposition:in-reply-to;
+        bh=sqozoOSn/Xg8xLEoqSt6hEPuCR5lAjjcsfSFhFhcG28=;
+        b=Sh6rOJJbCS73hQaXWJ24BSAdUhnVxIcU9hHGN5WQIPR4n4jP+sEJjaN4kVurdXFwhP
+         XlpdrGSkqKLwjhYUI66FDhQBMIh2kylKLftNE8C0u027dJ/iGtRnGbdUQXOAf6Q8E8+b
+         +lMJoI55Jvl0g+ytjpGDyXUYgnZj7jxuWtZTchTRiB1f+GbBpPxIQtexfo9FbnWfM0gk
+         6tUJlR9VFLallMaiIDyJmgdDKhgN6xpd2Z8dUvK3GApXvgUjimuOHgiU/0omX5giImRB
+         3+XhMfBShAVDj3hFL+gWid4JB0YMZyr7TqRB0JJyCTZ8k9xxMnzKslN0fAqoaQW/rfxX
+         lKMg==
+X-Gm-Message-State: AOAM531XYd7AS2cJLP7y2V3qLSjker6j1R0GeTmQmEqRsP+VLbmd6h09
+	1xv4u9Wi6FL3PkC+fRkk1PE=
+X-Google-Smtp-Source: ABdhPJxmWYo6/XUgdzhYjIyhKSbIam61biE8MnttlBA315Az3EYiIUwHczhxeqqmFvn3kXL69nQs5A==
+X-Received: by 2002:a05:6402:1702:: with SMTP id y2mr49857910edu.372.1641322903749;
+        Tue, 04 Jan 2022 11:01:43 -0800 (PST)
+Received: from localhost (c54-242.i04-14.onvol.net. [84.255.54.242])
+        by smtp.gmail.com with ESMTPSA id nd36sm11599581ejc.196.2022.01.04.11.01.42
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Tue, 04 Jan 2022 11:01:43 -0800 (PST)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Tue, 4 Jan 2022 20:01:42 +0100
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: Joe Schafer <joesmoe10@gmail.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: Re: uname -m on M1 MacBook returns arm64
+Message-ID: <20220104190142.gwu27ru3iprhkyr2@mtpad.i.jakstys.lt>
+References: <CAOGO9CoqMcAp=_9KVB3g9o5Jp45OtcAP7TT_Cn_Gom-YfQ9pew@mail.gmail.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+In-Reply-To: <CAOGO9CoqMcAp=_9KVB3g9o5Jp45OtcAP7TT_Cn_Gom-YfQ9pew@mail.gmail.com>
+Status: O
+Content-Length: 2531
+Lines: 58
+
+On Tue, Jan 04, 2022 at 09:16:33AM -0800, Joe Schafer wrote:
+> Hello,
+> 
+> I'm a big fan of this project. It's *lot* easier than trying to figure
+> out other Bazel CC toolchains.
+> 
+> One of my teammates ran into a curious error on an M1 Macbook using
+> the latest bazel-zig-cc.
+> 
+>     cc/toolchain/defs.bzl", line 219, column 70, in _zig_repository_impl
+>     zig_include_root  =
+> repository_ctx.attr.host_platform_include_root[host_platform]
+>     Error: key "macos-arm64" not found in dictionary
+> 
+> I traced this to toolchain/defs.bzl [1] which uses `uname -m` to get
+> the architecture. It looks like bazel-zig-cc only supports aarch64 but
+> M1 Macs return arm64.
+>
+> What's really spooky is that bazel-zig-cc worked on my M1 mac but it
+> didn't work for two other devs on my team also on M1 macs; they got
+> the above error.
+
+Hi, Joe,
+
+that's interesting indeed. I don't have an M1 mac, nor know anyone
+with M1 mac, to test this "more closely".
+
+> I was able to work around the problem with the following steps:
+> https://gist.github.com/jschaf/c9be10d806020087680310e49f6e2072.
+> 
+> - Uploaded all zig SDKs to my own hosting. I had to use my own hosting
+> to create macos-arm64 which is really just a copy of maco-aarch64 but
+> I had to change the folder name to match the archive name.
+> 
+> - Added "macos-arm64" to host_platform_include_root, similar to "macos-aarch64".
+> 
+> I'm by no means a Bazel toolchain expert, but I would have thought
+> there's a better way to get the host platform architecture than by
+> shelling out to uname. Appears that there's not [2] but that answer is
+> from 2017. Maybe platforms provide a way out [3]?
+
+Re [3]: looks like `declare_toolchains` is an external function, and it
+accepts `host` as a parameter, which should be set by the caller? If so,
+I am not following how that would help.
+
+If you can dig in for more information why `uname -m` returns arm64 vs
+aarch64 (OSX minor version? something else?). If there is no other way
+out, I would be OK to for an internal workaround to map darwin/arm64 to
+darwin/aarch64 during download, provided it's the only problem 
+
+Is downloading the toolchain the only problem? Once you add that
+workaround, does it keep working as one would expect?
+
+Motiejus
+
+> [1]: https://git.sr.ht/~motiejus/bazel-zig-cc/tree/main/item/toolchain/defs.bzl#L210
+> [2]: https://stackoverflow.com/a/45029999/30900
+> [3]: https://github.com/bazelbuild/rules_go/blob/master/go/private/go_toolchain.bzl#L95
+
+From MAILER-DAEMON Wed Mar  8 11:59:03 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-wr1-f47.google.com (mail-wr1-f47.google.com [209.85.221.47])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 51C2B11F170
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu,  6 Jan 2022 22:43:41 +0000 (UTC)
+Received: by mail-wr1-f47.google.com with SMTP id a5so3645821wrh.5
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 06 Jan 2022 14:43:41 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=mime-version:references:in-reply-to:from:date:message-id:subject:to
+         :cc:content-transfer-encoding;
+        bh=WVJwDaPOhVhlyrEU+IRdCCE5Bs5cs9UYUZN+DWlC13U=;
+        b=Z/YdhgFssOWay1GX6DwjpELzE/O5CmnFXAOJZ+pn2YLEu07Qs9sIEatIYuFpIWdSGz
+         3ys7HemMNLgN40g+u90oqSWvUIBDpaxaeuzkXAyzJz/u5dnF2H+EFJdKa4b2RoldgMR2
+         vX/4tDQIRRuhEfjp4xdZ4sIEhjdpvpXGkI5UFaxymHpynCWdKJCF5yY5e7YcJU54tUkQ
+         B+n9XOftt91ax28/+6M2tsQSvr/lZQHWDc6MWOuTfpmcuHdme0or7AjCV1d4Szmi1lCK
+         2OxbGJm9YGHDbbEwYJnk0x+tpppdnKJ3fRryThv+wh2eIsqV3pjANZRW7lN6dl2GnY5+
+         xcSw==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:references:in-reply-to:from:date
+         :message-id:subject:to:cc:content-transfer-encoding;
+        bh=WVJwDaPOhVhlyrEU+IRdCCE5Bs5cs9UYUZN+DWlC13U=;
+        b=nHdFi9MD25Cmnt+QIo5ORWYAUAwJkPxPhA7B5pAWgHocWB4t7WqwMhBBwOW2Ak2NJn
+         mcGhdWj/ZTE2/v0CEOo25uOng9gFD/dAxcRSnxNmgSYGGlJOUCTebMA+e8ke9UzpY6Mu
+         Jebqf1DK8Z7Z5kbQInEtTVN2d3GPFrWbv09WRDBKwZgITEpm5cJwGMRiicQ7cT3X3w5n
+         1yjZCN0MMkld5x67RL8MhTt67uFMOsg2Fjuyeb+GSfMuSifmEFebd3sssa4bWP9KNDWQ
+         PcuyVLGDarSS3tAKPnpLBbCDX8mcwvZE5jxigcq+aDyv7AeneNSs2qlUYP7G2ZVVIVHf
+         v6dQ==
+X-Gm-Message-State: AOAM531xruJG1qetqb3s6+BOTwLPHXsX/dT/uuM4/WasEwcAw9Os6Sxu
+	j4REnms9oZpJjZToGhu1eb29LLGb/DMsOjF10q8=
+X-Google-Smtp-Source: ABdhPJxRSSzGKj43T3pehcBp+IYkqmzlgASVkMQHNoO58R9ZKtMCcLdOodTRXRfoEgA0ot8Jo67L0SZFfh1RBrbXXCU=
+X-Received: by 2002:a5d:64c6:: with SMTP id f6mr50835474wri.711.1641509019852;
+ Thu, 06 Jan 2022 14:43:39 -0800 (PST)
+MIME-Version: 1.0
+References: <CAOGO9CoqMcAp=_9KVB3g9o5Jp45OtcAP7TT_Cn_Gom-YfQ9pew@mail.gmail.com>
+ <20220104190142.gwu27ru3iprhkyr2@mtpad.i.jakstys.lt>
+In-Reply-To: <20220104190142.gwu27ru3iprhkyr2@mtpad.i.jakstys.lt>
+From: Joe Schafer <joesmoe10@gmail.com>
+Date: Thu, 6 Jan 2022 14:43:28 -0800
+Message-ID: <CAOGO9Cr=foMi5dX8m_ygVxeX_YVMRU1D=Ex7mTxL9ew_VBpYQA@mail.gmail.com>
+Subject: Re: uname -m on M1 MacBook returns arm64
+To: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 3682
+Lines: 91
+
+> If you can dig in for more information why `uname -m` returns arm64 vs
+aarch64 (OSX minor version? something else?)
+
+I think I figured it out. It depends on whether the Bazel binary is an amd6=
+4
+or arm64 binary. I installed the amd64 version Bazel first on my team befor=
+e
+arm64 was available. macOS runs the amd64 binary and propagates the
+architecture down the call chain, including the subshell to uname. I can
+confirm by running uname under x86_64 emulation with:
+
+    arch -x86_64 uname -m
+    x86_64
+
+So I think this package will not work for an M1 mac running an arm64 versio=
+n
+of Bazel. I think an internal translation from arm64 to aarch64 is likely t=
+he
+easiest approach.
+
+> Is downloading the toolchain the only problem? Once you add that
+workaround, does it keep working as one would expect?
+
+Yep, as long as both the host_platform_sha256 and
+host_platform_include_root dictionaries account for arm64.
+
+On Tue, Jan 4, 2022 at 11:01 AM Motiejus Jak=C5=A1tys <motiejus@jakstys.lt>=
+ wrote:
+>
+> On Tue, Jan 04, 2022 at 09:16:33AM -0800, Joe Schafer wrote:
+> > Hello,
+> >
+> > I'm a big fan of this project. It's *lot* easier than trying to figure
+> > out other Bazel CC toolchains.
+> >
+> > One of my teammates ran into a curious error on an M1 Macbook using
+> > the latest bazel-zig-cc.
+> >
+> >     cc/toolchain/defs.bzl", line 219, column 70, in _zig_repository_imp=
+l
+> >     zig_include_root  =3D
+> > repository_ctx.attr.host_platform_include_root[host_platform]
+> >     Error: key "macos-arm64" not found in dictionary
+> >
+> > I traced this to toolchain/defs.bzl [1] which uses `uname -m` to get
+> > the architecture. It looks like bazel-zig-cc only supports aarch64 but
+> > M1 Macs return arm64.
+> >
+> > What's really spooky is that bazel-zig-cc worked on my M1 mac but it
+> > didn't work for two other devs on my team also on M1 macs; they got
+> > the above error.
+>
+> Hi, Joe,
+>
+> that's interesting indeed. I don't have an M1 mac, nor know anyone
+> with M1 mac, to test this "more closely".
+>
+> > I was able to work around the problem with the following steps:
+> > https://gist.github.com/jschaf/c9be10d806020087680310e49f6e2072.
+> >
+> > - Uploaded all zig SDKs to my own hosting. I had to use my own hosting
+> > to create macos-arm64 which is really just a copy of maco-aarch64 but
+> > I had to change the folder name to match the archive name.
+> >
+> > - Added "macos-arm64" to host_platform_include_root, similar to "macos-=
+aarch64".
+> >
+> > I'm by no means a Bazel toolchain expert, but I would have thought
+> > there's a better way to get the host platform architecture than by
+> > shelling out to uname. Appears that there's not [2] but that answer is
+> > from 2017. Maybe platforms provide a way out [3]?
+>
+> Re [3]: looks like `declare_toolchains` is an external function, and it
+> accepts `host` as a parameter, which should be set by the caller? If so,
+> I am not following how that would help.
+>
+> If you can dig in for more information why `uname -m` returns arm64 vs
+> aarch64 (OSX minor version? something else?). If there is no other way
+> out, I would be OK to for an internal workaround to map darwin/arm64 to
+> darwin/aarch64 during download, provided it's the only problem
+>
+> Is downloading the toolchain the only problem? Once you add that
+> workaround, does it keep working as one would expect?
+>
+> Motiejus
+>
+> > [1]: https://git.sr.ht/~motiejus/bazel-zig-cc/tree/main/item/toolchain/=
+defs.bzl#L210
+> > [2]: https://stackoverflow.com/a/45029999/30900
+> > [3]: https://github.com/bazelbuild/rules_go/blob/master/go/private/go_t=
+oolchain.bzl#L95
+
+From MAILER-DAEMON Wed Mar  8 11:59:03 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-ed1-f48.google.com (mail-ed1-f48.google.com [209.85.208.48])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 5DC9611EF4B
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri,  7 Jan 2022 19:10:47 +0000 (UTC)
+Received: by mail-ed1-f48.google.com with SMTP id a18so24731800edj.7
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 07 Jan 2022 11:10:47 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:cc:subject:message-id:references:mime-version
+         :content-disposition:in-reply-to;
+        bh=mta6/kgE1u4vhkm5wKRTH7vrhBWpwE4m037Yrcq+h8k=;
+        b=cwU6fvE8zumy7+kfivo84iJf9gJnFO3+SS8nGqTNtHk63A/mVHWUMjG/8Myof0S1iB
+         Evq8JKMfHWTlFNHAXQAqisYTJgQcDF/FhutaE0KYfGaoS0jZrASHQVLBzmSqAEL7CMsA
+         n7arDFnhywBPsYlQYcZJdS6DQQMwk5lOU7NDl3/vMmhCLzztb5pnDMVIHDYIeNuM6JiH
+         AnGlVvROwU2JHYu/oTZMngfhRr3qe7rAh5UVQDQAPStYvPYUPg3DVJfzlqUjlEq9dNTb
+         KoOiftL/jkiqgO6Ef9tfl86STF1jl7ovMTrUdfaM92oh2Lrg4mPrd6j9y9I1llGAEBOr
+         +oIQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:cc:subject:message-id
+         :references:mime-version:content-disposition:in-reply-to;
+        bh=mta6/kgE1u4vhkm5wKRTH7vrhBWpwE4m037Yrcq+h8k=;
+        b=ahwosd6ENKxO3uOYiH1wRIn1v2+tXREtNQzPlkjcsS+a6BJXRgQr8fm+O2nvBbd9ji
+         a8g1wRrjgeY1W1wuVs+bUKrTxE0u22v5wUxrsJpxT0axtg6v13Q5jXaUyg7tisCWdu0k
+         B5zvX0LAzL3xkcll3CJ0lpr8B/KR+XZXGFXf5pjN4DYcnf+Wonk71z8h+WfJi6+g1cRP
+         xfKATpGqBEbvjNHwfN8PFw+kX1PYqHUmWcTcrr2J2iUlg+Qwb/rrdrUD2Tv3z9QRwa3h
+         w/O8Nxk1xTTf6ClJZ5S94Eb1D2Q2WQAkKNvyjg0/8sv/vWXELsfRed5FFju/KJGy6UHQ
+         CpNw==
+X-Gm-Message-State: AOAM532KdgUfIklM7pNasbPCLx4Uxn6SCjPEQaXH0Xg9ng5RfMU3QrtV
+	1qD54g4GQcqyGWGiGcrrFc8=
+X-Google-Smtp-Source: ABdhPJzfI4GCxLf8Gg1gskwaSfK0xpn5sH/6JMdgodDJX7fdSEAxLasmU6+TAV5+tlW9A8nUGdygPQ==
+X-Received: by 2002:a17:907:9808:: with SMTP id ji8mr51547186ejc.665.1641582646132;
+        Fri, 07 Jan 2022 11:10:46 -0800 (PST)
+Received: from localhost (c54-242.i04-14.onvol.net. [84.255.54.242])
+        by smtp.gmail.com with ESMTPSA id j9sm23919ejg.64.2022.01.07.11.10.44
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Fri, 07 Jan 2022 11:10:45 -0800 (PST)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Fri, 7 Jan 2022 20:10:43 +0100
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: Joe Schafer <joesmoe10@gmail.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: Re: uname -m on M1 MacBook returns arm64
+Message-ID: <20220107191043.5tl2jcliuh4ehp74@mtpad.i.jakstys.lt>
+References: <CAOGO9CoqMcAp=_9KVB3g9o5Jp45OtcAP7TT_Cn_Gom-YfQ9pew@mail.gmail.com>
+ <20220104190142.gwu27ru3iprhkyr2@mtpad.i.jakstys.lt>
+ <CAOGO9Cr=foMi5dX8m_ygVxeX_YVMRU1D=Ex7mTxL9ew_VBpYQA@mail.gmail.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+In-Reply-To: <CAOGO9Cr=foMi5dX8m_ygVxeX_YVMRU1D=Ex7mTxL9ew_VBpYQA@mail.gmail.com>
+Status: O
+Content-Length: 1629
+Lines: 41
+
+On Thu, Jan 06, 2022 at 02:43:28PM -0800, Joe Schafer wrote:
+> > If you can dig in for more information why `uname -m` returns arm64 vs
+> aarch64 (OSX minor version? something else?)
+> 
+> I think I figured it out. It depends on whether the Bazel binary is an amd64
+> or arm64 binary. I installed the amd64 version Bazel first on my team before
+> arm64 was available. macOS runs the amd64 binary and propagates the
+> architecture down the call chain, including the subshell to uname. I can
+> confirm by running uname under x86_64 emulation with:
+> 
+>     arch -x86_64 uname -m
+>     x86_64
+> 
+> So I think this package will not work for an M1 mac running an arm64 version
+> of Bazel. I think an internal translation from arm64 to aarch64 is likely the
+> easiest approach.
+> 
+> > Is downloading the toolchain the only problem? Once you add that
+> workaround, does it keep working as one would expect?
+> 
+> Yep, as long as both the host_platform_sha256 and
+> host_platform_include_root dictionaries account for arm64.
+
+Hi Joe, thanks for clarifying!
+
+In that case, I will accept a patch that rewrites the architecture for
+OSX from arm64 to aarch64. Please don't extend the dict though, as it
+will be duplicate information and thus harder to maintain. Something
+along the lines:
+
+arch = `uname -m`
+# two sentence explanation (an extract from your email would suffice)
+if macos and arch == "arm64"
+    arch = "aarch64"
+
+... keep going with the `arch` variable.
+
+See https://sr.ht/~motiejus/bazel-zig-cc/#questions-amp-contributions
+for how to send the patch. Thanks for your report!
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:03 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lf1-f54.google.com (mail-lf1-f54.google.com [209.85.167.54])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 9857111EF33
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 17 Jan 2022 15:11:32 +0000 (UTC)
+Received: by mail-lf1-f54.google.com with SMTP id x7so58771527lfu.8
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 17 Jan 2022 07:11:32 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:mime-version
+         :content-disposition;
+        bh=LwNHKhyXvDWWILJKIlSXcX0ihphVZMlQHLLR1EMYlXU=;
+        b=qEWnJSQXmLoa7O7rrgOAvcO9WFQ2BvtWmA+ZCjxhXSlZOq66HeIAJPBP43FcfahZHj
+         pbqsSQjVKTIChLryf2wGpOZWTULsaez6ZMzKsE08t3uLr8g/MkeeiQbPT5Wfged8BBjg
+         1B/WJHerfObEcrxVft3aNArknPktFeXZiDJeySh3y3v2DJsp7yVJndpVfIq3YN0LLXXr
+         wzSQMLABLurB4GnuTkk3E0BiInNFMCkAjLvwNfLEBLYBSgXcJ+1dpu9H16OQJGUsTb9G
+         JJ6qOqclLXbTu7Wi//nFlxJEFXE7ZqI9H98nki+o1RA3nsyZtzwHXoCGXqTalXMHfId6
+         Kdgg==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :mime-version:content-disposition;
+        bh=LwNHKhyXvDWWILJKIlSXcX0ihphVZMlQHLLR1EMYlXU=;
+        b=2YSu1BSyV/wzreFDcWI0y0RlG627clg0N4Ow0DVUajWxO+8kP2Jgmqnl4R2Bc4n0nS
+         gMRpQ/9mdpUv07Tea7VjmKvdg9OlflrmCP/W1MLKW/Dw56ynt7GEFR8X8EIwsL/lX/RU
+         71DyAp3Hbs10zM7Qti4C36uy9czFVC2DFKAtAO62y/UsFvntnRtKXmGq4f66VNTjhsVZ
+         rAixSKwc3Chp+YM5qIBPtdFry4rYu+/f0JR+mMhmHnrRA2fzPOU3WwLVBGvnCllHW9Xq
+         yGdH8Ij7MuD26ZpIfypZCd34GHGPW/gzUgITt6Pt2Dxfd6+Dx8TxIPFSNscpKRFgaCZj
+         0Skw==
+X-Gm-Message-State: AOAM5332i04xrhpV3v4y8o7ezH1et4Cse/k14KT/IknPaUoLFoApOX7c
+	tQwofHgBoNfuU9P0tbNgVSzxvjB4CwM=
+X-Google-Smtp-Source: ABdhPJzlsEGEQrpYJ8pZKope/CpBPy7mLUnLz2qSCClcr1R1PxGlIMy/Z9NGRoAtS9/FVRoNJHLa6Q==
+X-Received: by 2002:a05:6512:a94:: with SMTP id m20mr14846375lfu.546.1642432291016;
+        Mon, 17 Jan 2022 07:11:31 -0800 (PST)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id u14sm532440lfc.292.2022.01.17.07.11.30
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Mon, 17 Jan 2022 07:11:30 -0800 (PST)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Mon, 17 Jan 2022 17:11:29 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: bazel-zig-cc v0.4.0
+Message-ID: <20220117151129.kdvzdw3w2dnuaxrj@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Status: O
+Content-Length: 491
+Lines: 14
+
+Hi all,
+
+I just released bazel-zig-cc v0.4.0. It is the first release after zig
+0.9.0 came out. I didn't cut a release with 0.9.0 due to[1]. Many thanks
+Xavier for addressing that one!
+
+This version has no known upstream issues, and, as usual, a few ones[2]
+I will be accepting patches to, or will get to myself at some point.
+
+Happy hacking,
+Motiejus
+
+[1]: https://github.com/ziglang/zig/issues/10386
+[2]: https://git.sr.ht/~motiejus/bazel-zig-cc#known-issues-in-bazel-zig-cc
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lj1-f177.google.com (mail-lj1-f177.google.com [209.85.208.177])
+	by mail-b.sr.ht (Postfix) with ESMTPS id ABA1911EEB5
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 26 Jan 2022 05:44:02 +0000 (UTC)
+Received: by mail-lj1-f177.google.com with SMTP id c15so14139217ljf.11
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 25 Jan 2022 21:44:02 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:mime-version
+         :content-disposition;
+        bh=ZPIE+T8JZChmC3IzGFrcmvVvO2ND70BBO5FF9GExK5Q=;
+        b=HTwHTDZX/I7CSkd0ZpQuKHqBc5aAjlYedJVaOjGL6wCgeX4F5Zwsq8HQtStMYNq1mG
+         OFHCaVkzvGAOyLNfArV0sXlrwHAUT1846q/jGURV1HJA7EGz4iMz0jMu/416FIiD55Td
+         SWlVLhn2gb2/FRBGE00k2uAYfFSaW2iQ/XkJW7cQ+0oIVvcGfoaxA1Vk45kneGri0Vkg
+         XZIa9J6D54SMxSIl2wsuWybMnWEgbL2jWUmvcZGpSrP1+kINzaYiPxXD8lyt5Doir4oy
+         ppc3QF+6AMLOIy4pPRKdsdw7xb8iC6pZBiFyolxV5ebccWcr7Vj5NhtC8853QXF/Q7n7
+         1FTw==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :mime-version:content-disposition;
+        bh=ZPIE+T8JZChmC3IzGFrcmvVvO2ND70BBO5FF9GExK5Q=;
+        b=ebv8j2lQilm9IeIqajKQamk9SlFu0Erv0015fMchG4uPf+v3FIGDWbWwK52Mbprpjv
+         6Qcdj9y8uiD4qyG/HkZAjczQV7O+vwn+Q+nQB9jrSd/2D/1b02bOIXhVahFqCvZLYV8o
+         9PBrFVxpQ/UKjO+Jxmd8rxxpihhOxqdC6f8eT3MdjHRVt16oZUWxosvU/eWXBbDyvnLr
+         cML31Xm+HK5ZiPAi7raNpKYEpb0t/bAY+wm+R2mipl0CM9sW+I3yzXZGpVMsytqbaLOs
+         32znAYlz06L9ryeqo3tONEP6dxGoeRtAnADHhr1XK7b9ArsOIRxjTAXLpaPXpnjLt54J
+         r1bA==
+X-Gm-Message-State: AOAM530GrI6qZZJctG4jJt/0OZ7XNlMN4GT4RfjHMZcRSB8ljHV31/Ns
+	WgSHFIZyjzgIUPwISqIAzBPSzJtpC+w=
+X-Google-Smtp-Source: ABdhPJxus+2x3ziq6MGKHqA4hJMsMQAFXfVHMhG8j4pNQ2iT970HgmsFoP+8MjiP6ZeAHPsO0POZyA==
+X-Received: by 2002:a2e:6e0e:: with SMTP id j14mr4657369ljc.510.1643175838877;
+        Tue, 25 Jan 2022 21:43:58 -0800 (PST)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id q12sm1419957ljh.16.2022.01.25.21.43.57
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Tue, 25 Jan 2022 21:43:58 -0800 (PST)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Wed, 26 Jan 2022 07:43:57 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: bazel-zig-cc v0.4.1 and envoy PoC
+Message-ID: <20220126054357.h5jxh7jtg75k3g57@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Status: O
+Content-Length: 612
+Lines: 22
+
+Hi all,
+
+I cut bazel-zig-cc v0.4.1, which upgrades zig to
+0.10.0-dev.399+366c76744. Notably, it implements the following linker
+args:
+
+* --whole-archive, -whole-archive
+* --no-whole-archive, -no-whole-archive
+* -s, --strip-all
+* -S, --strip-debug
+
+... which were surfaced by Envoy trying out bazel-zig-cc[1].
+
+I also renewed my gpg key (just updated the expiry date, keys are
+unchanged), which you can find in today [2]. For some inexplicable
+reason I keep signing my releases.
+
+Regards,
+Motiejus
+
+[1]: https://github.com/envoyproxy/envoy/issues/19535
+[2]: https://jakstys.lt/mtpad/gpg.txt
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-pj1-f44.google.com (mail-pj1-f44.google.com [209.85.216.44])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 3C7CC11EFBD
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 27 Jan 2022 09:15:33 +0000 (UTC)
+Received: by mail-pj1-f44.google.com with SMTP id b1-20020a17090a990100b001b14bd47532so2351913pjp.0
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 27 Jan 2022 01:15:33 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:mime-version
+         :content-disposition;
+        bh=l2IL1hDG/wSYO+PblgmPSfkqj7PPv5mJfn293Xgw73s=;
+        b=GgAXrKlG1tG2EbkFA/s7+RvEyH0tbRU06xQHi4/grJr5t34fiCntHOtuOGEM9/Ry8V
+         FZio35kw0jk5pr4bujR5di/jGk4UBBg+z/pGti9Pj69dk2Ea24alcNokiuzkbfHJ0PYC
+         9TYcgC/A08g3CyWJJ0A7HwKagKXKjnC7k7XaWkywSn/FDoCwfhHZzsSnu0B3ZxNFEC+R
+         hjqnERKrAU/urSTBamqChs9Q4zdn1cWPl7qnHMW/7o6z048YVGJP48azpBwhPFxQqWui
+         TOri7Fxg3/6BrNsa0MMOr4tcgzlHVPtlbArKBj3f4ftd3tQVN0qga1ZLK+MxQAm3LSrX
+         76EA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :mime-version:content-disposition;
+        bh=l2IL1hDG/wSYO+PblgmPSfkqj7PPv5mJfn293Xgw73s=;
+        b=7XviGnEKKaxoby6FvKmwDoejO/LGWTy4Z4FR4GZbuAAXW6tihvwnDbUy2YfYjDgGzE
+         3WE5kBPnibuTJklRKvnwoEmqHvTfIWb45rmoxK7niJ6+VNbsxwAvai7Y/jyNTq96cKCo
+         d/Gfc8RQeqG8O/p4jT8pYSnk7UGfRwvBirSfxWkcgGn06hEZGZOrsAk6FY2yRQpRCdav
+         0lOs91QBS/k2hG5SBt4kERGN5xPhshWbCB8jSPT+xpQxV4yWR3l8Q4IOuGrMZRk5xi68
+         QAtjXozIKl6SikjDF0V5/QOyqfNhxTAIUbP/TrA7cnZM+n3qGzGWASewO+Pv8kY0sxov
+         emmQ==
+X-Gm-Message-State: AOAM531u9gQGl0U6kPxkXMkmxs6zxWCAblpRS977LnnylyyVQwSByswN
+	6OncviD3c0m1pTAzONn7y/whSWkygZ8=
+X-Google-Smtp-Source: ABdhPJwylL0/y/L7pD9UsX5ejQIsUCE84DECwz3l+joFVSHQGXR3t35Btz/+0h4nVB/tBBoPWDiNqw==
+X-Received: by 2002:a17:902:c403:: with SMTP id k3mr1966059plk.117.1643274930940;
+        Thu, 27 Jan 2022 01:15:30 -0800 (PST)
+Received: from localhost (88-119-96-125.static.zebra.lt. [88.119.96.125])
+        by smtp.gmail.com with ESMTPSA id ip4sm2056750pjb.8.2022.01.27.01.15.29
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Thu, 27 Jan 2022 01:15:30 -0800 (PST)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Thu, 27 Jan 2022 11:15:27 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: bazel-zig-cc v0.4.2
+Message-ID: <20220127091527.oe53s3gm75354rdm@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Status: O
+Content-Length: 564
+Lines: 17
+
+Hi all,
+
+I cut bazel-zig-cc v0.4.2, which upgrades zig to
+0.10.0-dev.430+35423b005. Notable changes:
+- fix linux kernel's aarch64 include paths, use stable kernel for
+  headers[1].
+- implement --hash-style linker parameter[2].
+
+I am working on aarch64 at my dayjob, which resulted in (1). The latter
+was surfaced in envoy's ongoing investigation into zig-cc and
+bazel-zig-cc[3].
+
+Motiejus
+
+[1]: https://github.com/ziglang/zig/pull/10699
+[2]: https://github.com/ziglang/zig/commit/40c9ce2caf8f
+[3]: https://github.com/envoyproxy/envoy/issues/19535
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lf1-f41.google.com (mail-lf1-f41.google.com [209.85.167.41])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 7F1CF11EEDD
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed,  2 Feb 2022 13:32:17 +0000 (UTC)
+Received: by mail-lf1-f41.google.com with SMTP id u14so40638261lfo.11
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 02 Feb 2022 05:32:17 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:mime-version
+         :content-disposition;
+        bh=CaNfsprl7AZ0nZjlw9C6IbI2Leuo8/M+n+R0iuzS+cY=;
+        b=L+7CoNGpEND6STivveZtxm5V2vE3pCeLaBKHvJvsFUh/x8n3BIVoiA/AG5o27MG0xF
+         4X1ikzp9eYLAFRK3ISIaZ5aYwbBwhU+noXuWqK/JRPmbLsj1rbPMefVWSfBRKud/aVhW
+         sKBrU0KwOstAnh9kajQEBR1oUhn9GN7rUok1WEl9zximfVVL+3dMbOP9Ry0oNauYRQQw
+         wJjL3/zlMlqaRSzhOMDMQNdXK0XXj5BdhIq6LYHG1lqTYc8Sm6ulBVY/Mc91nk2f7VMT
+         4REW+8p5rXDtATKuezmsM3ooxBxa6PR69aMn635w8M6YQQOyV0f/aNdW5Nc9xExoEOdM
+         nQNQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :mime-version:content-disposition;
+        bh=CaNfsprl7AZ0nZjlw9C6IbI2Leuo8/M+n+R0iuzS+cY=;
+        b=c3+2Uvi12fzwT/Rdf21yrUu9zQry0vHZp1+IUOk3uFtE3SrceACYFbKqLuORdpfAno
+         3Noa/4kRkCLchOI0B8+mzMwzk2uTpxBqT+X2DPcz0c0t34p/yd0EkVjDZUr/iKHeVzh9
+         UULn/HOYm1dYyJhauFiMBmIuzuVkUx3Wt29XMBufKuoJgKWA0271BbYqC42XCf5yCk5a
+         OeLvnTPdRh6yGurvPcB30bpmQtUX8PWBDCACiq4qBU7Lf8mbbTbHmONyjRWw2g6+C1Gr
+         yekWw8zjayekGtAEwyFn1Ve0WN4hQYXkR2yF7+HhcSu2UmTIKbSXhUyKjTuLxbgsdjeG
+         owUg==
+X-Gm-Message-State: AOAM530ewLoLRvtGBos0lqYEAwwXrUfGvqfLBiIlO/6HSSC26FgXyiRn
+	XeVc1bRmFHku4DlppyKu9rZIQ6i+qFQ=
+X-Google-Smtp-Source: ABdhPJwEoIgMEhpBLz+ai9v9eSwdLa6kW5PAcKQK+5jQByExX2Rh1+OBULJPudgaVVKKSEwwEeb7Yg==
+X-Received: by 2002:a05:6512:ac6:: with SMTP id n6mr22945258lfu.322.1643808734872;
+        Wed, 02 Feb 2022 05:32:14 -0800 (PST)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id u12sm3672275lfm.308.2022.02.02.05.32.14
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Wed, 02 Feb 2022 05:32:14 -0800 (PST)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Wed, 2 Feb 2022 15:32:13 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: bazel-zig-cc v0.4.3
+Message-ID: <20220202133213.g6c66zwont7qyrr4@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Status: O
+Content-Length: 627
+Lines: 17
+
+Hi all,
+
+I released v0.4.3. It only zig, which fixes[1] `--hash-style` and
+`--whole-archive`. The README was also updated following some users'
+questions[2]. "The starlark" remains the same.
+
+At some point I will not be releasing new versions of bazel-zig-cc when
+*only* zig is updated; at that point, you will need to download zig
+provide it to bazel-zig-cc. Something akin to [3].
+
+Motiejus
+
+[1]:
+https://github.com/envoyproxy/envoy/issues/19535#issuecomment-1024533163
+[2]:
+https://github.com/envoyproxy/envoy/issues/19535#issuecomment-1026111822
+[3]: https://github.com/grailbio/bazel-toolchain#quickstart
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lj1-f182.google.com (mail-lj1-f182.google.com [209.85.208.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 6C8BC11EFDA
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri,  4 Feb 2022 11:56:02 +0000 (UTC)
+Received: by mail-lj1-f182.google.com with SMTP id c7so8094148ljr.13
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 04 Feb 2022 03:56:02 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:mime-version
+         :content-disposition;
+        bh=FKPxTpAiSiY0k9tKJOGQ14KTAR6pM4E7CD61F5+ZIZg=;
+        b=Q71lKWPQHHD7J7ZIiQyw9CPA/wvS6GzZN3HjrOD58SK/g6CFpfHwBFeDGLyI7QlD2x
+         LaHTPfJ8QGMtubI9dhFzTxBLJGUPqk7JTKDWHWe8Hwu5UY2ngDc6GnoDmf2t+98vhwiT
+         iZQdCzUYq3k5Od7kSi7J3MEIuuIvUNa2nDvRKCgbeCGZGenFzJ06aH64Ht6GfX2PbAaK
+         xTPWCY8/G83aRCiCC/diLatM4RCUTDkI254mcJ55/xJJ/DvmM2cmrxvRRBldly/jZmeF
+         gh2ZVz84Hik8v29pmbHh7fV4XHXLpMyCARe249KGIFmdDb5WFF8rKtubb7X0Jl/Uv5ML
+         Bnng==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :mime-version:content-disposition;
+        bh=FKPxTpAiSiY0k9tKJOGQ14KTAR6pM4E7CD61F5+ZIZg=;
+        b=q3seF01i5nl0FcHfaPDeGtBzJUeuUhZdYawh3fvAOimJmUKLkjTZZZmiyHfkn9hbvr
+         UXcHcXizu0+QLPwb+z2gIOeO5zQdjOSV6+2SnNvrNWwFxpN2t5teCqsUJtTr2G9n5pXl
+         YdNRtCZUSQjOvOsGhH0Ncv4H8wHBnchGzT8HT+K39tsSrjsPwVVFNmzQdcLYGc9O48ae
+         3yLJ1FB41qiFX8M/PRc32aeIDxRYhTCoD4i5AoGJ6CkvtZtQtcbg7n+d9SRy9d0FyGXL
+         f4hdYavfhxiCLljcS0VmJskiJ58aFbPkRvKcJP9N2tafMSaS85x7MbSPVWFjn1N11hW6
+         elsw==
+X-Gm-Message-State: AOAM533rCo1xV4yuik3hvvB17GySt46j8+KS4cEhKTHoJeQ3kgaV7vjH
+	9FzcGJK4wJetxV5cFR4BPKwpb9Azuzo=
+X-Google-Smtp-Source: ABdhPJz+wWN6uIoFx23yDrPATpG+aJ1LdP/b1iN2zD70pcef7VbGScFaG0UPhS8LtIkUtd4JBKfoGw==
+X-Received: by 2002:a2e:b8c7:: with SMTP id s7mr1606227ljp.118.1643975759407;
+        Fri, 04 Feb 2022 03:55:59 -0800 (PST)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id bu32sm280744lfb.287.2022.02.04.03.55.58
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Fri, 04 Feb 2022 03:55:58 -0800 (PST)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Fri, 4 Feb 2022 13:55:57 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: bazel test under qemu-aarch64: help needed
+Message-ID: <20220204115557.dhs7gvnyk3bapyja@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Status: O
+Content-Length: 1092
+Lines: 35
+
+Hi folks,
+
+I spent a good day trying to figure this out, I need help enabling tests
+for aarch64.
+
+Goal: run `bazel test //test/...` for 2 architectures: amd64 and arm64.
+Arm64 would be executed under qemu-aarch64.
+
+This works on my laptop (amd64/buster):
+
+    git clone https://git.sr.ht/~motiejus/bazel-zig-cc -b qemu
+    cd bazel-zig-cc; direnv allow .
+    bazel test --run_under=qemu-aarch64 \
+        --platforms @zig_sdk//:linux_arm64_platform \
+        --extra_toolchains @zig_sdk//:linux_arm64_musl_toolchain \
+        //test/go:go_test
+
+Fails[1] on builds.sr.ht, which is also buster/amd64.
+
+    2022/02/04 09:21:03 fork/exec /home/<...>/go_test: exec format error
+
+However, when executed directly via qemu-aarch64 on the given CI
+machine, it works:
+
+build@build:~/bazel-zig-cc$ qemu-aarch64 /<...>/go_test
+PASS
+build@build:~/bazel-zig-cc$ 
+
+strace, investigating the bazel's sandboxing (I suspected this may be
+caused by linux-sandbox-pid1.cc) didn't reveal anything. Any pointers?
+
+Thanks,
+Motiejus
+
+[1]: https://builds.sr.ht/~motiejus/job/687819
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lf1-f54.google.com (mail-lf1-f54.google.com [209.85.167.54])
+	by mail-b.sr.ht (Postfix) with ESMTPS id DFEC611F2DA
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat,  5 Feb 2022 04:55:32 +0000 (UTC)
+Received: by mail-lf1-f54.google.com with SMTP id u6so16394869lfm.10
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 04 Feb 2022 20:55:32 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:references:mime-version
+         :content-disposition:content-transfer-encoding:in-reply-to;
+        bh=XKOR1hOp9WbzmRujEKM5M3zyyBvcZgTOpIPrU4XXc20=;
+        b=KwIUKAX2O9OUNMyVWbwGDD75T/hCnF8WJgURSnnJ7LcHZiHyPh3LUzdxrovVHj70GS
+         ZgMP25hwmgDJlexldlQ5goH7XRn/EwV+viynlbq/8W3X4Zi8r2FpH0Waa4ds/g0uLJri
+         Xhchxy8fX8h6JKX8faOOwrTmsYrQ20oOAqxfrFfa0Fsfdy5f9JRviCmRdqcb4gyvHw5P
+         3JvIvyaGmL95RlR4mL5iQfKXB5pewagGtOKSf4zuqUgcyyKfP7HIHA7bOPXweyJsFJ6F
+         KsfSuztCsYO0jA5PAGv5VZqS3L8nZUdDWgNRsyxSA85zaLH98zDrn1w7uveQ9Oycp7/D
+         QdYQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :references:mime-version:content-disposition
+         :content-transfer-encoding:in-reply-to;
+        bh=XKOR1hOp9WbzmRujEKM5M3zyyBvcZgTOpIPrU4XXc20=;
+        b=pDyTgKvM5oVBXYVcmDAHVYBF6u69uAleBhZXMtxTABp6jGMbdX0oFv5SD5Z+AQTyuq
+         Qoz2/iX0A1erkQ3JTejCG5zjYIOYqbh7MvgOtAM+sgzS9xk3ASfbTCYtf3lemN4ZjBN0
+         R9nt+huX7vqqIDmFhBVf6UaQ3nFHu7c5HiBSIhEGE7Ck6KTQQYAXCFM2QCo68Ez3AeHF
+         uFaHgYZBQSvY5Dpr1/8nHd9yzKPVdipni3gErD600QTHwRZ1KTW0evKmhBcmwuPoiOVz
+         cKUOZzOKZM1fLL2S84Q0kSNyoqRDv9kfAP6Xg8jdkacdnNVzYdi7R/v8nKH8pUjiXX7y
+         lXnQ==
+X-Gm-Message-State: AOAM530784Z7OOYq/FydPztz1MiT4dtQ4Hr+v++1DfRT3rqwoYRlw/3V
+	RWN1qZX3Aunatwrf1e6RtRU6UnxfiRI=
+X-Google-Smtp-Source: ABdhPJxJ0QD5Cq/QWw3sHoVTecWwIu9kamdfu4rahFH5eT2GWNJIdzr+y76ReriZ2P0sWLeLjCDvoQ==
+X-Received: by 2002:a05:6512:4014:: with SMTP id br20mr1577156lfb.217.1644036931198;
+        Fri, 04 Feb 2022 20:55:31 -0800 (PST)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id z27sm577500lfg.31.2022.02.04.20.55.30
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Fri, 04 Feb 2022 20:55:30 -0800 (PST)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Sat, 5 Feb 2022 06:55:29 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: Re: bazel test under qemu-aarch64: help needed
+Message-ID: <20220205045529.c4quz7koyncgfqiz@mtpad.i.jakstys.lt>
+References: <20220204115557.dhs7gvnyk3bapyja@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Content-Transfer-Encoding: 8bit
+In-Reply-To: <20220204115557.dhs7gvnyk3bapyja@mtpad.i.jakstys.lt>
+Status: O
+Content-Length: 696
+Lines: 21
+
+On Fri, Feb 04, 2022 at 01:55:57PM +0200, Motiejus Jakštys wrote:
+> Hi folks,
+> 
+> I spent a good day trying to figure this out, I need help enabling tests
+> for aarch64.
+
+Hi all,
+
+Piotr Sikora replied out-of-band[1]. Two things needed to be changed:
+
+1. Install binfmt-support. That registers qemu handlers to binfmt.
+2. use qemu-aarch64-static instead of the shared version.
+
+... and now we run all unit tests on both amd64 and arm64, and the test
+runner[2] is less ugly.
+
+Motiejus
+
+[1]:
+https://github.com/PiotrSikora/bazel-zig-cc/commit/10101bf7f11ff404e66f582bbb64a3a875f8e45f#commitcomment-66048081
+[2]: https://git.sr.ht/~motiejus/bazel-zig-cc/tree/main/item/ci/test
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lf1-f48.google.com (mail-lf1-f48.google.com [209.85.167.48])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 4707611F2DA
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat,  5 Feb 2022 05:06:31 +0000 (UTC)
+Received: by mail-lf1-f48.google.com with SMTP id x23so16612445lfc.0
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 04 Feb 2022 21:06:31 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:mime-version
+         :content-disposition;
+        bh=YqUW7x3rsx9mzzxrNShByRFQQHaM25RXdnjFURhRiTc=;
+        b=aUMZbJhDNBCB6wVPI8VBaPiGorrlY2MGcHpyX5chxJEWcdl0gWmAFL5V55Vcor0E4i
+         VhdChdEOXTHAxFrvDOIABVrpnZp/XrToQa1dqphOLjelmVAbyu6XI0XNgy3uXJ94kHec
+         APDqE0WpflKzbmggrrU+85yjh/jmEW6XuLJ054dkkf8K6grBNlRi5KBQyfqfwAwuJLT6
+         FciVpP5r8QQ7hBCtdEUw36s/flZNMRAxvdoBnLUUNjAndU73JZwy5WyCZ6YepAIiFwpl
+         3m3oYcX1A7AOPI/OntxO9KYqR39DGEkfbURn8nmAYccrvY3Iw1X8yC3aTU1t7F7HP8U8
+         Hlnw==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :mime-version:content-disposition;
+        bh=YqUW7x3rsx9mzzxrNShByRFQQHaM25RXdnjFURhRiTc=;
+        b=eobDiXZbHrULR7IVzjffjOMSIRbBOjGpoBNcmRjZOxXm1LKQ+75fa/gO3+fKG6WaZs
+         jIk77c+LTLCETXGTNwQ5mb/9n7dpCOv5M0qydN6cw2yUe49i+ooJ6CHg1ZFVMeHD+QA2
+         6+TnYvY2N1qsicSfaoPvHW249jbWHjvro5KKuMh+QBgwibXmo0LvICQCjA0U8dJ7adBZ
+         7QHOJiBPxc2kmN0jk8SUL5oi3+2lawi58Enas2XwGwk+gpwtUUsp6F6BZ/5JuuvuDs3G
+         YSSyCmt5a3CJmvZ2dCm6e8gAJF0fk1/Us4fZ1GWjp54QhQfi45xXgv+87tuqAK0jFn0X
+         EGAA==
+X-Gm-Message-State: AOAM530HYBE3U1cQ8IVpBmUBM25gs3Cl/xw++l9knhpUQUCYWIUIpy3Z
+	pUMy1q0uu3uLFLCkwRdyd7Y6BsnaXg8=
+X-Google-Smtp-Source: ABdhPJzfulESjC6wntPstFC25e8xaYDPKQen6k5HrvMwq6aQsB65WuJBlVzadqsNnwNGQNv6hu9BvA==
+X-Received: by 2002:ac2:43ae:: with SMTP id t14mr1493698lfl.599.1644037590060;
+        Fri, 04 Feb 2022 21:06:30 -0800 (PST)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id be20sm524965ljb.105.2022.02.04.21.06.29
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Fri, 04 Feb 2022 21:06:29 -0800 (PST)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Sat, 5 Feb 2022 07:06:28 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: bazel-zig-cc v0.4.4 and upcoming zig 0.9.1
+Message-ID: <20220205050628.3m6ewpkxnvqngcqw@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Status: O
+Content-Length: 999
+Lines: 22
+
+Hi all,
+
+bazel-zig-cc v0.4.4 is out. Major changes:
+
+- register "bazel platforms" @zig_sdk//:<os>_<arch>_platform. Example
+  `--platform @zig_sdk//:linux_amd64_platform`. Note that this is in the
+  wrong place[1] and is likely to be changed.
+- Tests are now executed[2] with `bazel test //test/...` on amd64
+  (natively) and arm64 (via qemu-aarch64-static). You are enocouraged to
+  add your own tests if you would like me to catch issues for you before
+  bumping zig-cc.
+- I did NOT upgrade zig, it's the same as in v0.4.3.
+
+Zig's maintainer Andrew asked me to test the 0.9.x release branch before
+he does a zig 0.9.1 release. So if you care for zig not breaking
+something before the release, but that doesn't really fit into zig's
+test suite, a test in test/ may be a good place.
+
+Motiejus
+
+[1]: https://git.sr.ht/~motiejus/bazel-zig-cc/tree/v0.4.4/item/README.md#toolchain-and-platform-target-locations
+[2]: https://git.sr.ht/~motiejus/bazel-zig-cc/tree/v0.4.4/item/ci/test
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 2D5CC11F033;
+	Thu, 10 Feb 2022 23:32:58 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Thu, 10 Feb 2022 23:32:57 +0000
+Subject: [PATCH bazel-zig-cc 0/3] Support ARM64 Mac
+MIME-Version: 1.0
+Message-ID: <164453597791.17553.15415322179801626658-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <accounts@kmicklas.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: kmicklas@uber.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+Status: O
+Content-Length: 405
+Lines: 13
+
+With this I'm able to build a simple `cc_library` target on an M1.
+
+Ken Micklas (3):
+  Fix darwin arm64 case in .envrc for loading bazel
+  Interpret arm64 output from uname as aarch64 on mac OS
+  Fix and adjust darwin libc header paths depending on CPU
+
+ .envrc             |  2 +-
+ toolchain/defs.bzl | 21 +++++++++++++--------
+ 2 files changed, 14 insertions(+), 9 deletions(-)
+
+-- 
+2.32.0
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 5AB6311F0C1;
+	Thu, 10 Feb 2022 23:32:58 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Thu, 10 Feb 2022 18:20:56 -0500
+Subject: 
+ [PATCH bazel-zig-cc 1/3] Fix darwin arm64 case in .envrc for loading bazel
+Message-ID: <164453597791.17553.15415322179801626658-1@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <accounts@kmicklas.com>
+In-Reply-To: <164453597791.17553.15415322179801626658-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: kmicklas@uber.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 783
+Lines: 26
+
+From: Ken Micklas <kmicklas@uber.com>
+
+---
+ .envrc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/.envrc b/.envrc
+index 802d197..2b1d835 100644
+--- a/.envrc
++++ b/.envrc
+@@ -17,7 +17,7 @@ case "$(uname | tr A-Z a-z)-$(uname -m)" in
+         bzl=3D$(direnv fetchurl "${_u}linux-arm64" sha256-wd5oYN1PjV4uwnAJe9=
+RtaiEblxoLizhVl4S9BR6pUKE=3D);;
+     darwin-x86_64)
+         bzl=3D$(direnv fetchurl "${_u}darwin-amd64" sha256-5IW7+EUy0CpgsOsjx=
+wJhC1QI3zoZkIek8rXgmVu/LVo=3D);;
+-    darwin-aarch64)
++    darwin-arm64)
+         bzl=3D$(direnv fetchurl "${_u}darwin-arm64" sha256-wi1IYBRm2dOwQ8zXQ=
+FHy9CMPm59FCfCXAXyXMDqojRM=3D);;
+     *)
+         >&2 echo "unsupported architecture tuple $(uname | tr A-Z a-z)-$(una=
+me -m)"
+--=20
+2.32.0
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 7571711F0C9;
+	Thu, 10 Feb 2022 23:32:58 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Thu, 10 Feb 2022 18:22:37 -0500
+Subject: [PATCH bazel-zig-cc 2/3] Interpret arm64 output from uname as aarch64
+ on mac OS
+Message-ID: <164453597791.17553.15415322179801626658-2@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <accounts@kmicklas.com>
+In-Reply-To: <164453597791.17553.15415322179801626658-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: kmicklas@uber.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 1126
+Lines: 34
+
+From: Ken Micklas <kmicklas@uber.com>
+
+---
+ toolchain/defs.bzl | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 693e2da..2b572d3 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -222,12 +222,15 @@ def _zig_repository_impl(repository_ctx):
+     res =3D repository_ctx.execute(["uname", "-m"])
+     if res.return_code !=3D 0:
+         fail("failed to run uname -m")
+-    uname =3D res.stdout.strip()
++    arch =3D res.stdout.strip()
+=20
++    os =3D "linux"
+     if repository_ctx.os.name.lower().startswith("mac os"):
+-        host_platform =3D "macos-{}".format(uname)
+-    else:
+-        host_platform =3D "linux-{}".format(uname)
++        os =3D "macos"
++        if arch =3D=3D "arm64":
++            # uname -m reports arm64 on an M1 Mac.
++            arch =3D "aarch64"
++    host_platform =3D "{}-{}".format(os, arch)
+=20
+     zig_include_root =3D repository_ctx.attr.host_platform_include_root[host=
+_platform]
+     zig_sha256 =3D repository_ctx.attr.host_platform_sha256[host_platform]
+--=20
+2.32.0
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 93FE611F189;
+	Thu, 10 Feb 2022 23:32:58 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Thu, 10 Feb 2022 18:24:21 -0500
+Subject: [PATCH bazel-zig-cc 3/3] Fix and adjust darwin libc header paths
+ depending on CPU
+Message-ID: <164453597791.17553.15415322179801626658-3@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <accounts@kmicklas.com>
+In-Reply-To: <164453597791.17553.15415322179801626658-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: kmicklas@uber.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+MIME-Version: 1.0
+Status: O
+Content-Length: 1125
+Lines: 34
+
+From: Ken Micklas <kmicklas@uber.com>
+
+---
+ toolchain/defs.bzl | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 2b572d3..8ed93c7 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -54,15 +54,17 @@ _GLIBCS = [
+ ]
+ 
+ def _target_darwin(gocpu, zigcpu):
++    min_os = "10"
++    if zigcpu == "aarch64":
++        min_os = "11"
+     return struct(
+         gotarget = "darwin_{}".format(gocpu),
+         zigtarget = "{}-macos-gnu".format(zigcpu),
+         includes = [
+             "libunwind/include",
+-            # FIXME: add macos.10, macos.11 and macos.12 targets,
+-            # and adjust the includes
+-            "libc/include/{}-macos.10-gnu".format(zigcpu),
+-            "libc/include/{}-macos-any".format(zigcpu),
++            # TODO: Define a toolchain for each minimum OS version
++            "libc/include/{}-macos.{}-gnu".format(zigcpu, min_os),
++            "libc/include/any-macos.{}-any".format(min_os),
+             "libc/include/any-macos-any",
+         ],
+         linkopts = [],
+-- 
+2.32.0
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=iFZPni2s8+PUNzy+zRMfM/84OlUZYNc44+op1j+85vU=;
+ c=simple/simple; d=sr.ht; h=Date:From:In-Reply-To:Subject:To:Cc;
+ q=dns/txt; s=srht; t=1644536758; v=1;
+ b=nwchpQbJskdTrW86U+nIYMXtY5qtrAAQ1PmhQMEU2DRVR6LyoUWQ0m/XoKSOakS2QYNAtKFG
+ eH7jqHuViZjuINpv4NscE+l+u238PRAf5qTMiusugMOetvvlzw6n25oPckO9bs5/2kidDkRiuVF
+ ZbDyp/L4+98ACknuwLr9+kOd1QZjU34L6S81GkOKE23jKHNnLT+wAmyDq2KS91EQUk4rGPuCTuK
+ 0NnT9gJrEx3ytD5iyb7eyjtcupQBHTqbEDUpPpW7pc0QsvgTOobiv1rK7K6dwcSGBT1Kx6pml3V
+ eMidvLC1gkLkL0Tx+2371PVoanmuBKJ+Jy/uN43X1NFlA==
+Received: from localhost (unknown [173.195.146.249])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id 6539E11F033;
+	Thu, 10 Feb 2022 23:45:58 +0000 (UTC)
+MIME-Version: 1.0
+Date: Thu, 10 Feb 2022 23:45:58 +0000
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CHSRML2SAOY5.1NQDDWU9LNOYA@cirno>
+In-Reply-To: <164453597791.17553.15415322179801626658-3@git.sr.ht>
+Subject: [bazel-zig-cc/patches/.build.yml] build success
+To: "~kmicklas" <accounts@kmicklas.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 304
+Lines: 9
+
+bazel-zig-cc/patches/.build.yml: SUCCESS in 12m57s
+
+[Support ARM64 Mac][0] from [~kmicklas][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/29276
+[1]: mailto:accounts@kmicklas.com
+
+=E2=9C=93 #693103 SUCCESS bazel-zig-cc/patches/.build.yml https://builds.sr=
+.ht/~motiejus/job/693103
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lj1-f171.google.com (mail-lj1-f171.google.com [209.85.208.171])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 1A0A511F006
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 11 Feb 2022 04:34:02 +0000 (UTC)
+Received: by mail-lj1-f171.google.com with SMTP id z20so10896707ljo.6
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 10 Feb 2022 20:34:02 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:cc:subject:message-id:references:mime-version
+         :content-disposition:in-reply-to;
+        bh=uNKHiAfOE1XXriWNUtxZO2RyASkqd7Sf7RgJXzrnxZw=;
+        b=bG/yg7+8EDr7XPFG5C4Pi9CaXTtY36Ndidvr6aaLEQxdc9Vk7OXjhkIsS2e3AhkmqO
+         QMAT8Yluz5r1VpQ+/5UWk0DfRWbEI9Q7KMPS1NkkgFmbzNljLdfs8HuV1JsbjAqbDixn
+         beA4+J1vxNy5nj0eeP70+TaPC5G+W7Rrzr7dPDa/ZY4ey3Itx3kHDZA7b5BTTVYeSNrB
+         bNcvS+x5mpTYFaacqYSuS7pZfiF1JhC9LjOeE5mQjpVztRWPAeJJKh0tdx0/2q3zf/Kb
+         iecc2tcaMmUerc78LmogJ4QPBlUEapaew8FQe1k12N7UNQ0blQP3SLVRf1eelSQUyF/v
+         jUXg==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:cc:subject:message-id
+         :references:mime-version:content-disposition:in-reply-to;
+        bh=uNKHiAfOE1XXriWNUtxZO2RyASkqd7Sf7RgJXzrnxZw=;
+        b=3kpFIibEGFkECokJqdQej4nn8+cg4yeLhxFMgU4/IxcQaxTcpkeBGU7zh3jl6KQJTa
+         WOn9lYlWNzZXGJtjAajDqELCqMFiTAJLPU16OE43QKNVzhhr5aLpIUoTp6b1AFtRYTTZ
+         VmXLnMBsP+0AE1GaksMzm6f6wjlsUWz++hY0NcX5qKdPUogbXFQu5KzWUJDejB4sROeo
+         l7pPb8MvLRg7sTjhRfzMffL96sIqtjXAK6o9wHAyExWH5RjQhOTXnJk8BJ2iOezNVsmw
+         mnybyeSrIoHnl8PEovLDriZFgWJpgpmqTd0Vj82UH/50LZK+PbKEVjaGBMf7/1B8Lw6Y
+         w+wA==
+X-Gm-Message-State: AOAM533jR9y8KlycSsOOu2CgJ8L5yL5a869ALofm8kSQ6tSwqAa+YvAO
+	VTpASzqriQCJEvn/7j0F+1I=
+X-Google-Smtp-Source: ABdhPJybI1W3A3/4xVRPIq7fWV8haq5HpYKCBiFGcgS9/uhSDBKHjInW6LLK6a75vfURGLbrb1KjUw==
+X-Received: by 2002:a2e:b047:: with SMTP id d7mr7118977ljl.359.1644554038457;
+        Thu, 10 Feb 2022 20:33:58 -0800 (PST)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id l1sm2988565lfh.151.2022.02.10.20.33.57
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Thu, 10 Feb 2022 20:33:57 -0800 (PST)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Fri, 11 Feb 2022 06:33:56 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~kmicklas <accounts@kmicklas.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht, kmicklas@uber.com,
+	joesmoe10@gmail.com
+Subject: Re: [PATCH bazel-zig-cc 0/3] Support ARM64 Mac
+Message-ID: <20220211043356.xgchjv34q246kxa3@mtpad.i.jakstys.lt>
+References: <164453597791.17553.15415322179801626658-0@git.sr.ht>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+In-Reply-To: <164453597791.17553.15415322179801626658-0@git.sr.ht>
+Status: O
+Content-Length: 463
+Lines: 13
+
+On Thu, Feb 10, 2022 at 11:32:57PM +0000, ~kmicklas wrote:
+> With this I'm able to build a simple `cc_library` target on an M1.
+> 
+> Ken Micklas (3):
+>   Fix darwin arm64 case in .envrc for loading bazel
+>   Interpret arm64 output from uname as aarch64 on mac OS
+>   Fix and adjust darwin libc header paths depending on CPU
+
+Thank you. Applied all 3 patches and tagged v0.4.5.
+
+cc Joe, who had problems with M1 before. These are now fixed.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 5024911EF37;
+	Thu, 17 Mar 2022 20:04:30 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Thu, 17 Mar 2022 20:04:29 +0000
+Subject: [PATCH bazel-zig-cc 0/3] Download improvments
+MIME-Version: 1.0
+Message-ID: <164754746999.13783.11303815672892555536-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <git@kmicklas.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: kmicklas@uber.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+Status: O
+Content-Length: 347
+Lines: 12
+
+This adds support for netrc and multiple download mirrors.
+
+Ken Micklas (3):
+  Pull default SHA256s into constant and don't update
+  Support multiple URL formats
+  Support netrc for Zig SDK download
+
+ toolchain/defs.bzl | 66 +++++++++++++++++++++++++++++++++++-----------
+ 1 file changed, 50 insertions(+), 16 deletions(-)
+
+-- 
+2.34.1
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 7FAB111EF43;
+	Thu, 17 Mar 2022 20:04:30 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Thu, 17 Mar 2022 15:11:17 -0400
+Subject: 
+ [PATCH bazel-zig-cc 1/3] Pull default SHA256s into constant and don't update
+Message-ID: <164754746999.13783.11303815672892555536-1@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <git@kmicklas.com>
+In-Reply-To: <164754746999.13783.11303815672892555536-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: kmicklas@uber.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 2340
+Lines: 66
+
+From: Ken Micklas <kmicklas@uber.com>
+
+Starlark's default argument semantics are pretty weird and likely not
+what you would expect:
+https://github.com/bazelbuild/starlark/blob/master/spec.md#functions
+
+Additionally, this is just easier to read.
+---
+ toolchain/defs.bzl | 19 +++++++++----------
+ 1 file changed, 9 insertions(+), 10 deletions(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 8ed93c7..f942c5b 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -158,29 +158,28 @@ _URL_FORMAT_JAKSTYS =3D "https://dl.jakstys.lt/zig/zig-=
+{host_platform}-{version}.t
+=20
+ _VERSION =3D "0.10.0-dev.513+029844210"
+=20
++_HOST_PLATFORM_SHA256 =3D {
++    "linux-aarch64": "fc0b929948d57d1b15aaac33db0cd136a1f79830926c9285fd3f5b=
+6445f1ef95",
++    "linux-x86_64": "c6f323b02b0bcf7b18143983bf2525640dd541f39af661e963823c9=
+a61a09b28",
++    "macos-aarch64": "0ccd8dad1264474ca824d45c3021b7e549b67792fa1a66cb9d4d70=
+40775319bb",
++    "macos-x86_64": "3c939bebe8648c277ee66d1c600e68576e382d0309dc29eb4c32aba=
+96b83f6f0",
++}
++
+ def register_toolchains(
+         register =3D [],
+         version =3D _VERSION,
+         url_format =3D _URL_FORMAT_JAKSTYS,
+-        host_platform_sha256 =3D {}):
++        host_platform_sha256 =3D _HOST_PLATFORM_SHA256):
+     """
+         Download zig toolchain and register some.
+         @param register registers the given toolchains to the system using
+         native.register_toolchains(). See README for possible choices.
+     """
+-    sha256s =3D {
+-        "linux-aarch64": "fc0b929948d57d1b15aaac33db0cd136a1f79830926c9285fd=
+3f5b6445f1ef95",
+-        "linux-x86_64": "c6f323b02b0bcf7b18143983bf2525640dd541f39af661e9638=
+23c9a61a09b28",
+-        "macos-aarch64": "0ccd8dad1264474ca824d45c3021b7e549b67792fa1a66cb9d=
+4d7040775319bb",
+-        "macos-x86_64": "3c939bebe8648c277ee66d1c600e68576e382d0309dc29eb4c3=
+2aba96b83f6f0",
+-    }
+-    sha256s.update(host_platform_sha256)
+-
+     zig_repository(
+         name =3D "zig_sdk",
+         version =3D version,
+         url_format =3D url_format,
+-        host_platform_sha256 =3D sha256s,
++        host_platform_sha256 =3D host_platform_sha256,
+         host_platform_include_root =3D {
+             "linux-aarch64": "lib/",
+             "linux-x86_64": "lib/",
+--=20
+2.34.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id AFC4C11EF44;
+	Thu, 17 Mar 2022 20:04:30 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Thu, 17 Mar 2022 15:39:41 -0400
+Subject: [PATCH bazel-zig-cc 2/3] Support multiple URL formats
+Message-ID: <164754746999.13783.11303815672892555536-2@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <git@kmicklas.com>
+In-Reply-To: <164754746999.13783.11303815672892555536-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: kmicklas@uber.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 2412
+Lines: 67
+
+From: Ken Micklas <kmicklas@uber.com>
+
+---
+ toolchain/defs.bzl | 20 +++++++++++++++-----
+ 1 file changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index f942c5b..f883cc2 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -168,7 +168,8 @@ _HOST_PLATFORM_SHA256 =3D {
+ def register_toolchains(
+         register =3D [],
+         version =3D _VERSION,
+-        url_format =3D _URL_FORMAT_JAKSTYS,
++        url_format =3D [_URL_FORMAT_JAKSTYS],
++        url_formats =3D [],
+         host_platform_sha256 =3D _HOST_PLATFORM_SHA256):
+     """
+         Download zig toolchain and register some.
+@@ -178,7 +179,8 @@ def register_toolchains(
+     zig_repository(
+         name =3D "zig_sdk",
+         version =3D version,
+-        url_format =3D url_format,
++        url_format =3D url_format if type(url_format) =3D=3D type("") else N=
+one,
++        url_formats =3D url_format if type(url_format) =3D=3D type([""]) els=
+e None,
+         host_platform_sha256 =3D host_platform_sha256,
+         host_platform_include_root =3D {
+             "linux-aarch64": "lib/",
+@@ -239,10 +241,17 @@ def _zig_repository_impl(repository_ctx):
+         "version": repository_ctx.attr.version,
+         "host_platform": host_platform,
+     }
+-    zig_url =3D repository_ctx.attr.url_format.format(**format_vars)
++
++    url_format =3D repository_ctx.attr.url_format
++    url_formats =3D repository_ctx.attr.url_formats
++
++    if len(url_formats) =3D=3D 0:
++        url_formats =3D [url_format]
++    elif url_format !=3D "":
++        fail("Only one of url_format and url_formats should be specified.")
+=20
+     repository_ctx.download_and_extract(
+-        url =3D zig_url,
++        url =3D [uf.format(**format_vars) for uf in url_formats],
+         stripPrefix =3D "zig-{host_platform}-{version}/".format(**format_var=
+s),
+         sha256 =3D zig_sha256,
+     )
+@@ -279,7 +288,8 @@ zig_repository =3D repository_rule(
+     attrs =3D {
+         "version": attr.string(),
+         "host_platform_sha256": attr.string_dict(),
+-        "url_format": attr.string(),
++        "url_format": attr.string(doc =3D "Deprecated in favor of url_format=
+s"),
++        "url_formats": attr.string_list(),
+         "host_platform_include_root": attr.string_dict(),
+     },
+     implementation =3D _zig_repository_impl,
+--=20
+2.34.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id D52B611EF52;
+	Thu, 17 Mar 2022 20:04:30 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Thu, 17 Mar 2022 15:47:45 -0400
+Subject: [PATCH bazel-zig-cc 3/3] Support netrc for Zig SDK download
+Message-ID: <164754746999.13783.11303815672892555536-3@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <git@kmicklas.com>
+In-Reply-To: <164754746999.13783.11303815672892555536-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: kmicklas@uber.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 2268
+Lines: 64
+
+From: Ken Micklas <kmicklas@uber.com>
+
+---
+ toolchain/defs.bzl | 29 +++++++++++++++++++++++++++--
+ 1 file changed, 27 insertions(+), 2 deletions(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index f883cc2..0ea7a26 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -1,5 +1,5 @@
+ load("@bazel_skylib//lib:shell.bzl", "shell")
+-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
++load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_netrc", "use_net=
+rc")
+ load(":zig_toolchain.bzl", "zig_cc_toolchain_config")
+=20
+ DEFAULT_TOOL_PATHS =3D {
+@@ -250,8 +250,11 @@ def _zig_repository_impl(repository_ctx):
+     elif url_format !=3D "":
+         fail("Only one of url_format and url_formats should be specified.")
+=20
++    urls =3D [uf.format(**format_vars) for uf in url_formats]
++
+     repository_ctx.download_and_extract(
+-        url =3D [uf.format(**format_vars) for uf in url_formats],
++        auth =3D use_netrc(read_user_netrc(repository_ctx), urls, {}),
++        url =3D urls,
+         stripPrefix =3D "zig-{host_platform}-{version}/".format(**format_var=
+s),
+         sha256 =3D zig_sha256,
+     )
+@@ -407,3 +410,25 @@ def zig_build_macro(absolute_path, zig_include_root):
+                     name =3D "{os}_{gocpu}_platform".format(os =3D os, gocpu=
+ =3D gocpu),
+                     constraint_values =3D constraint_values,
+                 )
++
++# Copied from https://github.com/bazelbuild/bazel/blob/master/tools/build_de=
+fs/repo/utils.bzl
++# TODO: Upgrade to Bazel 5.1 and import this instead.
++def read_user_netrc(ctx):
++    """Read user's default netrc file.
++    Args:
++      ctx: The repository context of the repository rule calling this utilit=
+y function.
++    Returns:
++      dict mapping a machine names to a dict with the information provided a=
+bout them.
++    """
++    if ctx.os.name.startswith("windows"):
++        home_dir =3D ctx.os.environ.get("USERPROFILE", "")
++    else:
++        home_dir =3D ctx.os.environ.get("HOME", "")
++
++    if not home_dir:
++        return {}
++
++    netrcfile =3D "{}/.netrc".format(home_dir)
++    if not ctx.path(netrcfile).exists:
++        return {}
++    return read_netrc(ctx, netrcfile)
+--=20
+2.34.1
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=7E5ugq03gQepqZijHDKqWwmyoSoljjtR17dVHMYjfto=;
+ c=simple/simple; d=sr.ht; h=Date:In-Reply-To:Subject:To:Cc:From;
+ q=dns/txt; s=srht; t=1647548274; v=1;
+ b=aTuLBd3oZ//M2LwIw2Rup9HB16zQiEx5QkEq/L8E/T+y7EX72a7E5EVzqniFdJ+YN0l6Lb+y
+ 3l5fvv4E43+2OwzTCAvnIHZU0FLLjYNzCG8FuyAssCABK3+Tj+jjplVZm/StyQjbIPiEuj6/XFa
+ jBx2L1zac0NHkjCHyQ6tcGY8pjFksQGdHoZ9DcLuUEVlXsf7xL+DUK31RzMlZFFcLPaR/wyYaf8
+ GUpjAWdoIp+54H0vUQgt+cjtTxzv7ILPkF1E7xUuvtpdE7pzpOLygodgIKZB2ImLMa3w/CZ11rf
+ L0mNJgGnomwUBTrALMJZnjlwSlB3v0bYP3n2tNVTOA9hQ==
+Received: from localhost (unknown [173.195.146.249])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id F25FC11EF37;
+	Thu, 17 Mar 2022 20:17:53 +0000 (UTC)
+MIME-Version: 1.0
+Date: Thu, 17 Mar 2022 20:17:53 +0000
+Message-ID: <CIMF4C956NY6.XAHMHMOADXNQ@cirno>
+In-Reply-To: <164754746999.13783.11303815672892555536-3@git.sr.ht>
+Subject: [bazel-zig-cc/patches/.build.yml] build success
+To: "~kmicklas" <git@kmicklas.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+From: "builds.sr.ht" <builds@sr.ht>
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 302
+Lines: 9
+
+bazel-zig-cc/patches/.build.yml: SUCCESS in 13m21s
+
+[Download improvments][0] from [~kmicklas][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/30313
+[1]: mailto:git@kmicklas.com
+
+=E2=9C=93 #717171 SUCCESS bazel-zig-cc/patches/.build.yml https://builds.sr=
+.ht/~motiejus/job/717171
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lj1-f171.google.com (mail-lj1-f171.google.com [209.85.208.171])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 8FFDB11EFC0
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 18 Mar 2022 05:58:51 +0000 (UTC)
+Received: by mail-lj1-f171.google.com with SMTP id 25so10006112ljv.10
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 17 Mar 2022 22:58:51 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:mime-version
+         :content-disposition;
+        bh=O5wygcx8YHlm9775MqZTv4VJEnvHYlC1UwlOjkrGTrU=;
+        b=f92Rz2hfsT15yHex1cxQWB0PaPyKA48jRdlarTnZj2BiC/jJ9ZHRBQzbZw9bTgHaU9
+         X/8+7wTlBzGgsrot4pN+2q1TAxL0lcYR3EpBUihhIPWNRYRx2odjeBm3khgRKs4tGfy5
+         mZvIuoncaj5su8mw6G9rP4MF0l0BSFoF4YX9zrkMYblOxO8Pst8VpyqN83qv/wTkCYER
+         EKD/qD3bTuD/V7qyZ37D5NudbabbwggRdazfuXcFMu7UKMY6I+JOWumd7ptA6GXiPPrh
+         E1Tkk1cQN9CY4UAF+Ie4I3ghZ1qCMq0R6BbsO01g0tKOAOuarPmQSyN7TJAOXq8wDRaE
+         E6zg==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :mime-version:content-disposition;
+        bh=O5wygcx8YHlm9775MqZTv4VJEnvHYlC1UwlOjkrGTrU=;
+        b=x+4EEFsiiz57BGZprGzyJZLYG5Ci2gvxI1xHGgyfL6PAA3t+1lS1MAK6jLbwgHf6IG
+         ZLZ9BvaD7zR8QtFWGjoKKlVtSagMvjiGHT9k67hNMDcy3ZEX76UFBxFQTXbv0DkIYrYu
+         r+YXtKAQhmxgCsX2Jxia0xPLHQtZJR2w6E/devmhpb8v4m1QEcVqjvkzSTbmQEY11S0b
+         pxJAx9/7ZJPjUd9R7BGr50050Yzmxln8hk3ERFb6dBbvP49lqW2yZxrpioKr6ciGYTP7
+         0Bd33Y7VEMRgEin0ImL3kGDyD2sTjEFL9lkLcnGXkCxm5VIPpQIvFfHYW0jHDf5Nq5zt
+         FNmg==
+X-Gm-Message-State: AOAM5310aa6U0D3DwRUXBG0km88Duds7a04XE9uMa5/NHpkVlM7i4M7Y
+	hNtj0uOOIetpr+7wBBHVgOYvEf4a08Kg7A==
+X-Google-Smtp-Source: ABdhPJyQwYb1aPDuUAsW4HWDz5avo2+R7rK/HjA9tOlhOyQodRvS76ToI2lMUcBnpSgb1Jy4zkwl/A==
+X-Received: by 2002:a05:651c:512:b0:249:71cf:37ee with SMTP id o18-20020a05651c051200b0024971cf37eemr339884ljp.484.1647583128947;
+        Thu, 17 Mar 2022 22:58:48 -0700 (PDT)
+Received: from localhost ([87.54.21.186])
+        by smtp.gmail.com with ESMTPSA id j14-20020a056512108e00b004481ee0cee1sm690552lfg.67.2022.03.17.22.58.48
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Thu, 17 Mar 2022 22:58:48 -0700 (PDT)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Fri, 18 Mar 2022 06:58:47 +0100
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: bazel-zig-cc v0.5.0
+Message-ID: <20220318055847.p3qo75w55piucvix@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Status: O
+Content-Length: 909
+Lines: 23
+
+Hi all,
+
+thanks to Ken Micklas contributions, bazel-zig-cc can now do the
+following:
+
+- support netrc authentication. You can use internal mirrors for zig
+  bundle now (assuming they support netrc, of course).
+- provide multiple download urls for the zig toolchain via
+  `url_formats`. This option is now documented, among with `version` and
+  `sha256`.
+- while at it, upgraded zig to 0.10.0-dev.1393+291f5055f. I will be
+  cleaning up pre-0.10.0 from dl.jakstys.lt, consider yourself warned.
+
+Since `sha256`, `urls` and `version` are part of the "official" API, I
+will not be upgrading zig in bazel-zig-cc (or, rather, will upgrade much
+more rarely); please do so in your application.
+
+Reminder: dl.jakstys.lt is a small machine in my home closet. No UPS, no
+monitoring whatsoever. So, if you are depending on this for work, you
+may want to use your mirror.
+
+Happy compiling,
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id B878611EF57;
+	Fri, 25 Mar 2022 15:53:45 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Fri, 25 Mar 2022 15:53:45 +0000
+Subject: 
+ [PATCH bazel-zig-cc 0/4] Upgrade to Bazel 5.1.0 and associated cleanups
+MIME-Version: 1.0
+Message-ID: <164822362548.25319.8453123527885867890-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <git@kmicklas.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: kmicklas@uber.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+Status: O
+Content-Length: 430
+Lines: 15
+
+Also pins the Go SDK version.
+
+Ken Micklas (4):
+  Upgrade to Bazel 5.1.0
+  Remove repo fetch-time uname dependency, use new os.arch instead
+  Use upstream read_user_netrc from Bazel 5.1
+  Pin Go SDK to 1.18 for reproducibility
+
+ .bazelversion      |  2 +-
+ WORKSPACE          |  2 +-
+ toolchain/defs.bzl | 41 ++++++++---------------------------------
+ 3 files changed, 10 insertions(+), 35 deletions(-)
+
+-- 
+2.34.1
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id D86DC11F01F;
+	Fri, 25 Mar 2022 15:53:45 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Fri, 25 Mar 2022 11:45:39 -0400
+Subject: [PATCH bazel-zig-cc 1/4] Upgrade to Bazel 5.1.0
+Message-ID: <164822362548.25319.8453123527885867890-1@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <git@kmicklas.com>
+In-Reply-To: <164822362548.25319.8453123527885867890-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: kmicklas@uber.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+MIME-Version: 1.0
+Status: O
+Content-Length: 280
+Lines: 16
+
+From: Ken Micklas <kmicklas@uber.com>
+
+---
+ .bazelversion | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/.bazelversion b/.bazelversion
+index af8c8ec..831446c 100644
+--- a/.bazelversion
++++ b/.bazelversion
+@@ -1 +1 @@
+-4.2.2
++5.1.0
+-- 
+2.34.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id F2C8E11F0F2;
+	Fri, 25 Mar 2022 15:53:45 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Fri, 25 Mar 2022 11:46:11 -0400
+Subject: [PATCH bazel-zig-cc 2/4] Remove repo fetch-time uname dependency, use
+ new os.arch instead
+Message-ID: <164822362548.25319.8453123527885867890-2@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <git@kmicklas.com>
+In-Reply-To: <164822362548.25319.8453123527885867890-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: kmicklas@uber.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 1105
+Lines: 38
+
+From: Ken Micklas <kmicklas@uber.com>
+
+---
+ toolchain/defs.bzl | 15 ++++++---------
+ 1 file changed, 6 insertions(+), 9 deletions(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 810db50..840976d 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -221,17 +221,14 @@ _ZIG_TOOLS =3D [
+ ]
+=20
+ def _zig_repository_impl(repository_ctx):
+-    res =3D repository_ctx.execute(["uname", "-m"])
+-    if res.return_code !=3D 0:
+-        fail("failed to run uname -m")
+-    arch =3D res.stdout.strip()
++    arch =3D repository_ctx.os.arch
++    if arch =3D=3D "amd64":
++        arch =3D "x86_64"
+=20
+-    os =3D "linux"
+-    if repository_ctx.os.name.lower().startswith("mac os"):
++    os =3D repository_ctx.os.name.lower()
++    if os.startswith("mac os"):
+         os =3D "macos"
+-        if arch =3D=3D "arm64":
+-            # uname -m reports arm64 on an M1 Mac.
+-            arch =3D "aarch64"
++
+     host_platform =3D "{}-{}".format(os, arch)
+=20
+     zig_include_root =3D repository_ctx.attr.host_platform_include_root[host=
+_platform]
+--=20
+2.34.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 3AA1D11F178;
+	Fri, 25 Mar 2022 15:53:46 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Fri, 25 Mar 2022 11:46:59 -0400
+Subject: [PATCH bazel-zig-cc 3/4] Use upstream read_user_netrc from Bazel 5.1
+Message-ID: <164822362548.25319.8453123527885867890-3@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <git@kmicklas.com>
+In-Reply-To: <164822362548.25319.8453123527885867890-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: kmicklas@uber.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 2267
+Lines: 64
+
+From: Ken Micklas <kmicklas@uber.com>
+
+---
+ toolchain/defs.bzl | 26 ++------------------------
+ 1 file changed, 2 insertions(+), 24 deletions(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 840976d..112a64a 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -1,6 +1,6 @@
+ load("@bazel_skylib//lib:shell.bzl", "shell")
+ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_netrc", "use_net=
+rc")
++load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_user_netrc", "us=
+e_netrc")
+ load(":zig_toolchain.bzl", "zig_cc_toolchain_config")
+=20
+ DEFAULT_TOOL_PATHS =3D {
+@@ -240,7 +240,7 @@ def _zig_repository_impl(repository_ctx):
+=20
+     urls =3D [uf.format(**format_vars) for uf in repository_ctx.attr.url_for=
+mats]
+     repository_ctx.download_and_extract(
+-        auth =3D use_netrc(_read_user_netrc(repository_ctx), urls, {}),
++        auth =3D use_netrc(read_user_netrc(repository_ctx), urls, {}),
+         url =3D urls,
+         stripPrefix =3D "zig-{host_platform}-{version}/".format(**format_var=
+s),
+         sha256 =3D zig_sha256,
+@@ -396,25 +396,3 @@ def zig_build_macro(absolute_path, zig_include_root):
+                     name =3D "{os}_{gocpu}_platform".format(os =3D os, gocpu=
+ =3D gocpu),
+                     constraint_values =3D constraint_values,
+                 )
+-
+-# Copied from https://github.com/bazelbuild/bazel/blob/master/tools/build_de=
+fs/repo/utils.bzl
+-# TODO: Upgrade to Bazel 5.1 and import this instead.
+-def _read_user_netrc(ctx):
+-    """Read user's default netrc file.
+-    Args:
+-      ctx: The repository context of the repository rule calling this utilit=
+y function.
+-    Returns:
+-      dict mapping a machine names to a dict with the information provided a=
+bout them.
+-    """
+-    if ctx.os.name.startswith("windows"):
+-        home_dir =3D ctx.os.environ.get("USERPROFILE", "")
+-    else:
+-        home_dir =3D ctx.os.environ.get("HOME", "")
+-
+-    if not home_dir:
+-        return {}
+-
+-    netrcfile =3D "{}/.netrc".format(home_dir)
+-    if not ctx.path(netrcfile).exists:
+-        return {}
+-    return read_netrc(ctx, netrcfile)
+--=20
+2.34.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 5A3F711EF57;
+	Fri, 25 Mar 2022 15:53:46 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Fri, 25 Mar 2022 11:47:10 -0400
+Subject: [PATCH bazel-zig-cc 4/4] Pin Go SDK to 1.18 for reproducibility
+Message-ID: <164822362548.25319.8453123527885867890-4@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <git@kmicklas.com>
+In-Reply-To: <164822362548.25319.8453123527885867890-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: kmicklas@uber.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+MIME-Version: 1.0
+Status: O
+Content-Length: 479
+Lines: 21
+
+From: Ken Micklas <kmicklas@uber.com>
+
+---
+ WORKSPACE | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/WORKSPACE b/WORKSPACE
+index eeb098a..0aff5db 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -28,7 +28,7 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+ go_rules_dependencies()
+ 
+ # use latest stable.
+-go_download_sdk(name = "go_sdk")
++go_download_sdk(name = "go_sdk", version = "1.18")
+ 
+ go_register_toolchains()
+ 
+-- 
+2.34.1
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=vl6q2l7OOKEBhNt4qtJAxHIft46gdMwjqZrsBx08HLM=;
+ c=simple/simple; d=sr.ht; h=Date:In-Reply-To:Subject:To:Cc:From;
+ q=dns/txt; s=srht; t=1648224469; v=1;
+ b=grlGdG4ZDS5JH4IcFhaf7h4A5MUCfTSq78jO+bUR4LXCdjgOxQD4LUiHPJVGHkqAWEItA8rp
+ kagxXYt7EYuF2U3R2Ub0ygW/2G3JiwFDAlpUdA0E5d0Zm3KCMaiI8OpLwZO0C0TdJ4SdgL28K83
+ IuxKzxJwp/hl31zQROAhFlPI0Lln10Bo9qC1tcCqDB5qjSwBPeFl3yTD8lvlwScp0VzNvoVVKKt
+ qFn0sfWwWkE/12x4SzFcm+HzJFvMaVIiPfxJFhvyj1z7ATuNMo18n4jFOCb0LRECw02rPIrbgvs
+ sxbGBnopieamHloWulztJlETdQrYe/J8vsc+eIYwic5Gg==
+Received: from localhost (unknown [173.195.146.244])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id 89B2D11F01F;
+	Fri, 25 Mar 2022 16:07:49 +0000 (UTC)
+MIME-Version: 1.0
+Date: Fri, 25 Mar 2022 16:07:49 +0000
+Message-ID: <CIT2T87A4BL6.2OSWJY7N2ORZ8@cirno2>
+In-Reply-To: <164822362548.25319.8453123527885867890-4@git.sr.ht>
+Subject: [bazel-zig-cc/patches/.build.yml] build failed
+To: "~kmicklas" <git@kmicklas.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+From: "builds.sr.ht" <builds@sr.ht>
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 325
+Lines: 9
+
+bazel-zig-cc/patches/.build.yml: FAILED in 14m1s
+
+[Upgrade to Bazel 5.1.0 and associated cleanups][0] from [~kmicklas][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/30549
+[1]: mailto:git@kmicklas.com
+
+=E2=9C=97 #722785 FAILED bazel-zig-cc/patches/.build.yml https://builds.sr.=
+ht/~motiejus/job/722785
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lf1-f42.google.com (mail-lf1-f42.google.com [209.85.167.42])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 2AE3F11EEFB
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat, 26 Mar 2022 14:06:40 +0000 (UTC)
+Received: by mail-lf1-f42.google.com with SMTP id bu29so17829100lfb.0
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat, 26 Mar 2022 07:06:40 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:cc:subject:message-id:references:mime-version
+         :content-disposition:in-reply-to;
+        bh=Pjp+gqfwJjtlGbhG+5IobsfAGPuvy8DjKMfMfW3ADko=;
+        b=RI7sHW8r7FyGW0vbk3qyqAq3MuUjawc9/2p29i3aZxM87nfsYuD62WXN5evfRFez2t
+         NfhZhLLpXh7WEHvD5DJYsMJQ5/w9q+JPs+M/Px9OJkRzh9LNQWIyKHax8oNw3k+yqOEv
+         A2KF2vD8d64ryhYW0eyeCKPNCrHNiz+xs3cxGr139Uds3+yVhFohqkuXtzSaciXbyv+d
+         Iv1qc5/ag2fsCHjUmaPakLmGqrH0qkxo5fCD8YNcV1K0ihH6u37dZL4vxPTgx4IZUnY1
+         tXHuTXZOmlFafkK7rKSQSubju4TSvh0gIkpL2k07/qEkZs826Ic2LfZ6CQ+Wp1FFPK4D
+         3wGA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:cc:subject:message-id
+         :references:mime-version:content-disposition:in-reply-to;
+        bh=Pjp+gqfwJjtlGbhG+5IobsfAGPuvy8DjKMfMfW3ADko=;
+        b=C4Yr3Sd0roSvg87qIpO7coq1CuXnajM/v7T1MqnSSjxl2M4lYT2GiSTEXTUreffZ7D
+         Wrnr9o+wXrwDfm6FIg6DTuOHXJBz47j9aF5kp8DlGxSq692B62mhW4Cfs9sMslk38KxF
+         xIpThBrG+JoSkdrGw0uds9uutUP+/yJja/JTs9DEY/HfalnTu9IylQxAOTdOa8u8ON6y
+         VpyIEe1fXB14IsUwpyWfVNm6IzYf/ioDtW/DLs8AiDf/Z8qcyZO+UDaslRXn9Hx/8zHL
+         u3i/gaqj77fkMfkjuISHsPz/bkjYZNCoaOKY5G3LnO2poyvmSs04hffjtdPEFKQQV4nZ
+         UA3w==
+X-Gm-Message-State: AOAM533hURPTlwQiQpKPHi6X0Pec8XKTXELjIFbPijs7YX/qsA2lhh96
+	mudeKBHrIAjCtXojtDPGne4=
+X-Google-Smtp-Source: ABdhPJz8vo3yFz/ewrYm/4U/ieOtYJRdVogRkE0lVcRSKpjbVUEhyKlhBOQiTFQsXTSs8ANMmkPCxw==
+X-Received: by 2002:a05:6512:224e:b0:44a:7bae:527f with SMTP id i14-20020a056512224e00b0044a7bae527fmr3850225lfu.322.1648303597462;
+        Sat, 26 Mar 2022 07:06:37 -0700 (PDT)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id q17-20020a2e8751000000b00244beaacef1sm1043982ljj.18.2022.03.26.07.06.36
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Sat, 26 Mar 2022 07:06:36 -0700 (PDT)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Sat, 26 Mar 2022 16:06:35 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~kmicklas <git@kmicklas.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht, kmicklas@uber.com
+Subject: Re: [PATCH bazel-zig-cc 4/4] Pin Go SDK to 1.18 for reproducibility
+Message-ID: <20220326140635.yhzoo74n2gudaihk@mtpad.i.jakstys.lt>
+References: <164822362548.25319.8453123527885867890-0@git.sr.ht>
+ <164822362548.25319.8453123527885867890-4@git.sr.ht>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+In-Reply-To: <164822362548.25319.8453123527885867890-4@git.sr.ht>
+Status: O
+Content-Length: 729
+Lines: 23
+
+On Fri, Mar 25, 2022 at 11:47:10AM -0400, ~kmicklas wrote:
+> From: Ken Micklas <kmicklas@uber.com>
+> 
+> ---
+>  WORKSPACE | 2 +-
+>  1 file changed, 1 insertion(+), 1 deletion(-)
+> 
+> diff --git a/WORKSPACE b/WORKSPACE
+> index eeb098a..0aff5db 100644
+> --- a/WORKSPACE
+> +++ b/WORKSPACE
+> @@ -28,7 +28,7 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+>  go_rules_dependencies()
+>  
+>  # use latest stable.
+> -go_download_sdk(name = "go_sdk")
+> +go_download_sdk(name = "go_sdk", version = "1.18")
+
+I was on the edge about this myself, since that would require us to
+upgrade it with every go version, even patch ones. But I guess you're
+right, leaving it like this for reproducibility.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lj1-f174.google.com (mail-lj1-f174.google.com [209.85.208.174])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 942C011EEFB
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat, 26 Mar 2022 14:07:22 +0000 (UTC)
+Received: by mail-lj1-f174.google.com with SMTP id g24so13600550lja.7
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat, 26 Mar 2022 07:07:22 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:cc:subject:message-id:references:mime-version
+         :content-disposition:in-reply-to;
+        bh=skzF2rzi5tynBle2oTMXjUWcWv4l0MA2+RTOPpkNpPM=;
+        b=GZ5rcUtXhyF0l2l1SEFkrIH4P9N+zQTGl+HTbUxhaDXriIWpkKIBg+yyl2L4pHnfe9
+         tEGxxjFItRJr2362cUOhjeepUZQccgruWISJdojLDpP/MKVnJF9Dbcz37lvgwzlZDhGT
+         v3H8UVUadD1VcSBm5Wil0svCKqtmgZ49WJ6JAlY07LJqAN5O/JMZKXLG6aBvr4bP0OqI
+         +lQRPdyCrpFPU8hSAhzVFW3TpSWqv/vpQhUeiIckZaaaig+iONeOHggcWUsouNhVVPlE
+         eXGXLilT79UYbJUlMjMoppfy8NIHlVfnf4QLP462YF1aEjWp79hKUZhPjOc9zCAXhuPl
+         2uug==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:cc:subject:message-id
+         :references:mime-version:content-disposition:in-reply-to;
+        bh=skzF2rzi5tynBle2oTMXjUWcWv4l0MA2+RTOPpkNpPM=;
+        b=cQGHnNmkyoRITbX37Kh4Xk+F1Hrwgas32m+irYiGC0GnHc9ETWxeTBIK6I0SctgYYL
+         CqvJmahfPtgchqLFb2XS+MVK+M5p/55PSL1n7NIyaILIe4yF6Bfc086uGtFvdgy5LeWx
+         s1zJyJoakElOu+tInarcVCS0tnXa83DKoyqir64TuK1iz0Yp/Hh/f5pB1a85DD31zeS4
+         MXHOwY8RVNAWcRCNnQpujtC7/VEVh1xy87FSeDeCMs+PJn5KKlOn27bc1iy6/HuwZ7vr
+         NogutdjHUOx5MoQt4Jtu32/zv1XEOhmcyS0I5CCEM9FhN3sggvj7DNUwFM0kdj6mP1c8
+         ZOeQ==
+X-Gm-Message-State: AOAM530ltYKvJutOC++bK2hnktHvvRWxnaa5Ql87dRHhMFOLflj9+qkz
+	1aN/+FXRivw/AYqj/BRkEXXjHqv+br0=
+X-Google-Smtp-Source: ABdhPJymq04BSTzfJpVHdZ+laiZbzglDSEIbJnE2fdBBOkR9NviuD4mebDzB5lu2c+1zY8w4/rSv9g==
+X-Received: by 2002:a2e:a58c:0:b0:249:b1ce:ba97 with SMTP id m12-20020a2ea58c000000b00249b1ceba97mr9423600ljp.78.1648303638993;
+        Sat, 26 Mar 2022 07:07:18 -0700 (PDT)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id d6-20020a193846000000b0044a589efadbsm1075763lfj.2.2022.03.26.07.07.18
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Sat, 26 Mar 2022 07:07:18 -0700 (PDT)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Sat, 26 Mar 2022 16:07:17 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~kmicklas <git@kmicklas.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht, kmicklas@uber.com
+Subject: Re: [PATCH bazel-zig-cc 0/4] Upgrade to Bazel 5.1.0 and associated
+ cleanups
+Message-ID: <20220326140717.oep2mxniosjzzetg@mtpad.i.jakstys.lt>
+References: <164822362548.25319.8453123527885867890-0@git.sr.ht>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+In-Reply-To: <164822362548.25319.8453123527885867890-0@git.sr.ht>
+Status: O
+Content-Length: 396
+Lines: 12
+
+On Fri, Mar 25, 2022 at 03:53:45PM +0000, ~kmicklas wrote:
+> Also pins the Go SDK version.
+> 
+> Ken Micklas (4):
+>   Upgrade to Bazel 5.1.0
+>   Remove repo fetch-time uname dependency, use new os.arch instead
+>   Use upstream read_user_netrc from Bazel 5.1
+>   Pin Go SDK to 1.18 for reproducibility
+
+Thanks, applied all of them (+buildifier). Do you want me to cut v0.5.1?
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 150F811EF0D
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu,  7 Apr 2022 09:37:53 +0000 (UTC)
+From: ~laurynasl <laurynasl@git.sr.ht>
+Date: Thu, 07 Apr 2022 09:37:52 +0000
+Subject: [PATCH bazel-zig-cc 0/4] Move platforms and toolchains
+MIME-Version: 1.0
+Message-ID: <164932427279.26543.1789507091630612744-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~laurynasl <laurynasl@uber.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+Status: O
+Content-Length: 1282
+Lines: 31
+
+Move platform and toochains definitions into their own "namespaces".
+
+laurynasl (4):
+  move platforms under @zig_cc//platform:
+  Move declare_platforms() to platform/
+  Move toolchainss under @zig_sdk//platform:
+  Move toolchain definitions to toolchains/
+
+ .bazelrc                            |   8 +-
+ README.md                           |  27 +--
+ ci/test                             |   4 +-
+ toolchain/BUILD.sdk.bazel           |   5 +-
+ toolchain/defs.bzl                  | 244 +++-------------------------
+ toolchain/platform/BUILD            |   3 +
+ toolchain/platform/defs.bzl         |  17 ++
+ toolchain/private/BUILD             |   0
+ toolchain/private/defs.bzl          | 124 ++++++++++++++
+ toolchain/toolchain/BUILD           |   0
+ toolchain/toolchain/BUILD.sdk.bazel |  10 ++
+ toolchain/toolchain/defs.bzl        |  87 ++++++++++
+ 12 files changed, 277 insertions(+), 252 deletions(-)
+ create mode 100644 toolchain/platform/BUILD
+ create mode 100644 toolchain/platform/defs.bzl
+ create mode 100644 toolchain/private/BUILD
+ create mode 100644 toolchain/private/defs.bzl
+ create mode 100644 toolchain/toolchain/BUILD
+ create mode 100644 toolchain/toolchain/BUILD.sdk.bazel
+ create mode 100644 toolchain/toolchain/defs.bzl
+
+-- 
+2.34.1
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 30F8411EF31
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu,  7 Apr 2022 09:37:53 +0000 (UTC)
+From: ~laurynasl <laurynasl@git.sr.ht>
+Date: Wed, 06 Apr 2022 19:16:53 +0000
+Subject: [PATCH bazel-zig-cc 1/4] move platforms under @zig_cc//platform:
+Message-ID: <164932427279.26543.1789507091630612744-1@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~laurynasl <laurynasl@uber.com>
+In-Reply-To: <164932427279.26543.1789507091630612744-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 4658
+Lines: 126
+
+From: laurynasl <laurynasl@uber.com>
+
+---
+ README.md                |  9 +++------
+ ci/test                  |  2 +-
+ toolchain/defs.bzl       | 10 ++++++++--
+ toolchain/platform/BUILD |  3 +++
+ 4 files changed, 15 insertions(+), 9 deletions(-)
+ create mode 100644 toolchain/platform/BUILD
+
+diff --git a/README.md b/README.md
+index 1c8e011..d855c78 100644
+--- a/README.md
++++ b/README.md
+@@ -114,9 +114,6 @@ The path to Bazel toolchains is `@zig_sdk//:<toolchain>_t=
+oolchain`. It should
+ be moved to `@zig_sdk//toolchain:<toolchain>` or similar; so the user-facing
+ targets are in their own namespace.
+=20
+-Likewise, platforms are `@zig_sdk//:<platform>_platform`, and should be moved
+-to `@zig_sdk//:platform:<platform>`.
+-
+ ## OSX: sysroot
+=20
+ For non-trivial programs (and for all darwin/arm64 cgo programs) MacOS SDK m=
+ay
+@@ -164,7 +161,7 @@ may apply to aarch64, but the author didn't find a need t=
+o test it (yet).
+ ## build & run linux cgo + glibc
+=20
+ ```
+-$ bazel build --platforms @zig_sdk//:linux_amd64_platform //test/go:go
++$ bazel build --platforms @zig_sdk//platform:linux_amd64 //test/go:go
+ $ file bazel-out/k8-opt-ST-d17813c235ce/bin/test/go/go_/go
+ bazel-out/k8-opt-ST-d17813c235ce/bin/test/go/go_/go: ELF 64-bit LSB executab=
+le, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux=
+-x86-64.so.2, for GNU/Linux 2.0.0, Go BuildID=3Dredacted, with debug_info, no=
+t stripped
+ $ bazel-out/k8-opt-ST-d17813c235ce/bin/test/go/go_/go
+@@ -176,7 +173,7 @@ hello, world
+ ```
+ $ bazel test \
+     --config=3Dqemu-aarch64 \
+-    --platforms @zig_sdk//:linux_arm64_platform \
++    --platforms @zig_sdk//platform:linux_arm64 \
+     --extra_toolchains @zig_sdk//:linux_arm64_musl_toolchain //test/...
+ ...
+ INFO: Build completed successfully, 10 total actions
+@@ -186,7 +183,7 @@ INFO: Build completed successfully, 10 total actions
+ ## macos cgo
+=20
+ ```
+-$ bazel build --platforms @zig_sdk//:darwin_amd64_platform //test/go:go
++$ bazel build --platforms @zig_sdk//platform:darwin_amd64 //test/go:go
+ ...
+ $ file bazel-out/k8-opt-ST-d17813c235ce/bin/test/go/go_/go
+ bazel-out/k8-opt-ST-d17813c235ce/bin/test/go/go_/go: Mach-O 64-bit x86_64 ex=
+ecutable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
+diff --git a/ci/test b/ci/test
+index e9a8e9a..5b9a4d7 100755
+--- a/ci/test
++++ b/ci/test
+@@ -18,7 +18,7 @@ while read -r action platform toolchain config; do
+     fi
+=20
+     args+=3D(\
+-        --platforms "@zig_sdk//:${platform}_platform" \
++        --platforms "@zig_sdk//platform:${platform}" \
+         --extra_toolchains "@zig_sdk//:${toolchain}_toolchain" \
+         //test/... \
+     )
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 112a64a..eb005fe 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -264,6 +264,11 @@ def _zig_repository_impl(repository_ctx):
+         content =3D _fcntl_h,
+     )
+=20
++    repository_ctx.symlink(
++        Label("//toolchain/platform:BUILD"),
++        "platform/BUILD",
++    )
++
+     repository_ctx.template(
+         "BUILD.bazel",
+         Label("//toolchain:BUILD.sdk.bazel"),
+@@ -380,6 +385,7 @@ def zig_build_macro(absolute_path, zig_include_root):
+             toolchain_type =3D "@bazel_tools//tools/cpp:toolchain_type",
+         )
+=20
++def declare_platforms():
+     # create @zig_sdk//{os}_{arch}_platform entries with zig and go conventi=
+ons
+     for zigcpu, gocpu in (("x86_64", "amd64"), ("aarch64", "arm64")):
+         for bzlos, oss in {"linux": ["linux"], "macos": ["macos", "darwin"]}=
+.items():
+@@ -389,10 +395,10 @@ def zig_build_macro(absolute_path, zig_include_root):
+                     "@platforms//cpu:{}".format(zigcpu),
+                 ]
+                 native.platform(
+-                    name =3D "{os}_{zigcpu}_platform".format(os =3D os, zigc=
+pu =3D zigcpu),
++                    name =3D "{os}_{zigcpu}".format(os =3D os, zigcpu =3D zi=
+gcpu),
+                     constraint_values =3D constraint_values,
+                 )
+                 native.platform(
+-                    name =3D "{os}_{gocpu}_platform".format(os =3D os, gocpu=
+ =3D gocpu),
++                    name =3D "{os}_{gocpu}".format(os =3D os, gocpu =3D gocp=
+u),
+                     constraint_values =3D constraint_values,
+                 )
+diff --git a/toolchain/platform/BUILD b/toolchain/platform/BUILD
+new file mode 100644
+index 0000000..b02436b
+--- /dev/null
++++ b/toolchain/platform/BUILD
+@@ -0,0 +1,3 @@
++load("@bazel-zig-cc//toolchain:defs.bzl", "declare_platforms")
++
++declare_platforms()
+--=20
+2.34.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 4D67411EF0D
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu,  7 Apr 2022 09:37:53 +0000 (UTC)
+From: ~laurynasl <laurynasl@git.sr.ht>
+Date: Wed, 06 Apr 2022 19:19:44 +0000
+Subject: [PATCH bazel-zig-cc 2/4] Move declare_platforms() to platform/
+Message-ID: <164932427279.26543.1789507091630612744-2@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~laurynasl <laurynasl@uber.com>
+In-Reply-To: <164932427279.26543.1789507091630612744-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 2927
+Lines: 77
+
+From: laurynasl <laurynasl@uber.com>
+
+---
+ toolchain/defs.bzl          | 17 -----------------
+ toolchain/platform/BUILD    |  2 +-
+ toolchain/platform/defs.bzl | 17 +++++++++++++++++
+ 3 files changed, 18 insertions(+), 18 deletions(-)
+ create mode 100644 toolchain/platform/defs.bzl
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index eb005fe..3f6b4bd 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -385,20 +385,3 @@ def zig_build_macro(absolute_path, zig_include_root):
+             toolchain_type =3D "@bazel_tools//tools/cpp:toolchain_type",
+         )
+=20
+-def declare_platforms():
+-    # create @zig_sdk//{os}_{arch}_platform entries with zig and go conventi=
+ons
+-    for zigcpu, gocpu in (("x86_64", "amd64"), ("aarch64", "arm64")):
+-        for bzlos, oss in {"linux": ["linux"], "macos": ["macos", "darwin"]}=
+.items():
+-            for os in oss:
+-                constraint_values =3D [
+-                    "@platforms//os:{}".format(bzlos),
+-                    "@platforms//cpu:{}".format(zigcpu),
+-                ]
+-                native.platform(
+-                    name =3D "{os}_{zigcpu}".format(os =3D os, zigcpu =3D zi=
+gcpu),
+-                    constraint_values =3D constraint_values,
+-                )
+-                native.platform(
+-                    name =3D "{os}_{gocpu}".format(os =3D os, gocpu =3D gocp=
+u),
+-                    constraint_values =3D constraint_values,
+-                )
+diff --git a/toolchain/platform/BUILD b/toolchain/platform/BUILD
+index b02436b..ce0ffc7 100644
+--- a/toolchain/platform/BUILD
++++ b/toolchain/platform/BUILD
+@@ -1,3 +1,3 @@
+-load("@bazel-zig-cc//toolchain:defs.bzl", "declare_platforms")
++load("@bazel-zig-cc//toolchain/platform:defs.bzl", "declare_platforms")
+=20
+ declare_platforms()
+diff --git a/toolchain/platform/defs.bzl b/toolchain/platform/defs.bzl
+new file mode 100644
+index 0000000..e094029
+--- /dev/null
++++ b/toolchain/platform/defs.bzl
+@@ -0,0 +1,17 @@
++def declare_platforms():
++    # create @zig_sdk//{os}_{arch}_platform entries with zig and go conventi=
+ons
++    for zigcpu, gocpu in (("x86_64", "amd64"), ("aarch64", "arm64")):
++        for bzlos, oss in {"linux": ["linux"], "macos": ["macos", "darwin"]}=
+.items():
++            for os in oss:
++                constraint_values =3D [
++                    "@platforms//os:{}".format(bzlos),
++                    "@platforms//cpu:{}".format(zigcpu),
++                ]
++                native.platform(
++                    name =3D "{os}_{zigcpu}".format(os =3D os, zigcpu =3D zi=
+gcpu),
++                    constraint_values =3D constraint_values,
++                )
++                native.platform(
++                    name =3D "{os}_{gocpu}".format(os =3D os, gocpu =3D gocp=
+u),
++                    constraint_values =3D constraint_values,
++                )
+--=20
+2.34.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 6C1EB11EF31
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu,  7 Apr 2022 09:37:53 +0000 (UTC)
+From: ~laurynasl <laurynasl@git.sr.ht>
+Date: Wed, 06 Apr 2022 19:46:15 +0000
+Subject: [PATCH bazel-zig-cc 3/4] Move toolchainss under @zig_sdk//platform:
+Message-ID: <164932427279.26543.1789507091630612744-3@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~laurynasl <laurynasl@uber.com>
+In-Reply-To: <164932427279.26543.1789507091630612744-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 10472
+Lines: 268
+
+From: laurynasl <laurynasl@uber.com>
+
+---
+ .bazelrc                            |  8 ++---
+ README.md                           | 18 ++++------
+ ci/test                             |  2 +-
+ toolchain/BUILD.sdk.bazel           |  5 ++-
+ toolchain/defs.bzl                  | 55 ++++++++++++++++++-----------
+ toolchain/toolchain/BUILD           |  0
+ toolchain/toolchain/BUILD.sdk.bazel | 10 ++++++
+ 7 files changed, 57 insertions(+), 41 deletions(-)
+ create mode 100644 toolchain/toolchain/BUILD
+ create mode 100644 toolchain/toolchain/BUILD.sdk.bazel
+
+diff --git a/.bazelrc b/.bazelrc
+index cba4a5e..fed6f0b 100644
+--- a/.bazelrc
++++ b/.bazelrc
+@@ -6,10 +6,10 @@ build --worker_sandboxing
+ build --compilation_mode=3Dopt
+=20
+ build --incompatible_enable_cc_toolchain_resolution
+-build --extra_toolchains @zig_sdk//:linux_amd64_gnu.2.19_toolchain
+-build --extra_toolchains @zig_sdk//:linux_arm64_gnu.2.28_toolchain
+-build --extra_toolchains @zig_sdk//:darwin_amd64_toolchain
+-build --extra_toolchains @zig_sdk//:darwin_arm64_toolchain
++build --extra_toolchains @zig_sdk//toolchain:linux_amd64_gnu.2.19
++build --extra_toolchains @zig_sdk//toolchain:linux_arm64_gnu.2.28
++build --extra_toolchains @zig_sdk//toolchain:darwin_amd64
++build --extra_toolchains @zig_sdk//toolchain:darwin_arm64
+=20
+ test:qemu-aarch64 --test_env=3DQEMU_LD_PREFIX=3D/usr/aarch64-linux-gnu/
+ test:qemu-aarch64 --run_under=3Dqemu-aarch64-static
+diff --git a/README.md b/README.md
+index d855c78..1a20d5f 100644
+--- a/README.md
++++ b/README.md
+@@ -41,10 +41,10 @@ And this to `.bazelrc`:
+=20
+ ```
+ build --incompatible_enable_cc_toolchain_resolution
+-build --extra_toolchains @zig_sdk//:linux_amd64_gnu.2.19_toolchain
+-build --extra_toolchains @zig_sdk//:linux_arm64_gnu.2.28_toolchain
+-build --extra_toolchains @zig_sdk//:darwin_amd64_toolchain
+-build --extra_toolchains @zig_sdk//:darwin_arm64_toolchain
++build --extra_toolchains @zig_sdk//toolchain:linux_amd64_gnu.2.19
++build --extra_toolchains @zig_sdk//toolchain:linux_arm64_gnu.2.28
++build --extra_toolchains @zig_sdk//toolchain:darwin_amd64
++build --extra_toolchains @zig_sdk//toolchain:darwin_arm64
+ ```
+=20
+ The snippets above will download the zig toolchain and register it for the
+@@ -80,7 +80,7 @@ different one is registered using `--extra_toolchains <tool=
+chain>` in
+ tests) on linux/amd64/musl, you may specify:
+=20
+ ```
+---extra_toolchains @zig_sdk//:linux_amd64_musl_toolchain
++--extra_toolchains @zig_sdk//toolchain:linux_amd64_musl
+ ```
+=20
+ ## UBSAN and "SIGILL: Illegal Instruction"
+@@ -108,12 +108,6 @@ how to contribute.
+ Currently zig cache is in `$HOME`, so `bazel clean --expunge` does not clear
+ the zig cache. Zig's cache should be stored somewhere in the project's path.
+=20
+-## Toolchain and platform target locations
+-
+-The path to Bazel toolchains is `@zig_sdk//:<toolchain>_toolchain`. It should
+-be moved to `@zig_sdk//toolchain:<toolchain>` or similar; so the user-facing
+-targets are in their own namespace.
+-
+ ## OSX: sysroot
+=20
+ For non-trivial programs (and for all darwin/arm64 cgo programs) MacOS SDK m=
+ay
+@@ -174,7 +168,7 @@ hello, world
+ $ bazel test \
+     --config=3Dqemu-aarch64 \
+     --platforms @zig_sdk//platform:linux_arm64 \
+-    --extra_toolchains @zig_sdk//:linux_arm64_musl_toolchain //test/...
++    --extra_toolchains @zig_sdk//toolchain:linux_arm64_musl //test/...
+ ...
+ INFO: Build completed successfully, 10 total actions
+ //test/go:go_test                                                        PAS=
+SED in 0.2s
+diff --git a/ci/test b/ci/test
+index 5b9a4d7..35d0c07 100755
+--- a/ci/test
++++ b/ci/test
+@@ -19,7 +19,7 @@ while read -r action platform toolchain config; do
+=20
+     args+=3D(\
+         --platforms "@zig_sdk//platform:${platform}" \
+-        --extra_toolchains "@zig_sdk//:${toolchain}_toolchain" \
++        --extra_toolchains "@zig_sdk//toolchain:${toolchain}" \
+         //test/... \
+     )
+=20
+diff --git a/toolchain/BUILD.sdk.bazel b/toolchain/BUILD.sdk.bazel
+index 8b5db49..cf5dc4a 100644
+--- a/toolchain/BUILD.sdk.bazel
++++ b/toolchain/BUILD.sdk.bazel
+@@ -1,11 +1,10 @@
+-load("@bazel-zig-cc//toolchain:defs.bzl", "zig_build_macro")
++load("@bazel-zig-cc//toolchain:defs.bzl", "declare_files")
+=20
+ package(
+     default_visibility =3D ["//visibility:public"],
+ )
+=20
+-zig_build_macro(
+-    absolute_path =3D {absolute_path},
++declare_files(
+     zig_include_root =3D {zig_include_root},
+ )
+=20
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 3f6b4bd..61e099f 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -189,7 +189,7 @@ def register_toolchains(
+         },
+     )
+=20
+-    toolchains =3D ["@zig_sdk//:%s_toolchain" % t for t in register]
++    toolchains =3D ["@zig_sdk//:toolchain:%s" % t for t in register]
+     native.register_toolchains(*toolchains)
+=20
+ ZIG_TOOL_PATH =3D "tools/{zig_tool}"
+@@ -268,11 +268,19 @@ def _zig_repository_impl(repository_ctx):
+         Label("//toolchain/platform:BUILD"),
+         "platform/BUILD",
+     )
+-
+     repository_ctx.template(
+-        "BUILD.bazel",
++        "BUILD",
+         Label("//toolchain:BUILD.sdk.bazel"),
+         executable =3D False,
++        substitutions =3D {
++            "{zig_include_root}": shell.quote(zig_include_root),
++        },
++    )
++
++    repository_ctx.template(
++        "toolchain/BUILD",
++        Label("//toolchain/toolchain:BUILD.sdk.bazel"),
++        executable =3D False,
+         substitutions =3D {
+             "{absolute_path}": shell.quote(str(repository_ctx.path(""))),
+             "{zig_include_root}": shell.quote(zig_include_root),
+@@ -302,13 +310,21 @@ def filegroup(name, **kwargs):
+     native.filegroup(name =3D name, **kwargs)
+     return ":" + name
+=20
+-def zig_build_macro(absolute_path, zig_include_root):
++def declare_files(zig_include_root):
+     filegroup(name =3D "empty")
+     native.exports_files(["zig"], visibility =3D ["//visibility:public"])
+     filegroup(name =3D "lib/std", srcs =3D native.glob(["lib/std/**"]))
+=20
+     lazy_filegroups =3D {}
+=20
++    for target_config in _target_structs():
++        for d in DEFAULT_INCLUDE_DIRECTORIES + target_config.includes:
++            d =3D zig_include_root + d
++            if d not in lazy_filegroups:
++                lazy_filegroups[d] =3D filegroup(name =3D d, srcs =3D native=
+.glob([d + "/**"]))
++
++
++def declare_toolchains(absolute_path, zig_include_root):
+     for target_config in _target_structs():
+         gotarget =3D target_config.gotarget
+         zigtarget =3D target_config.zigtarget
+@@ -316,8 +332,6 @@ def zig_build_macro(absolute_path, zig_include_root):
+         cxx_builtin_include_directories =3D []
+         for d in DEFAULT_INCLUDE_DIRECTORIES + target_config.includes:
+             d =3D zig_include_root + d
+-            if d not in lazy_filegroups:
+-                lazy_filegroups[d] =3D filegroup(name =3D d, srcs =3D native=
+.glob([d + "/**"]))
+             cxx_builtin_include_directories.append(absolute_path + "/" + d)
+         for d in getattr(target_config, "toplevel_include", []):
+             cxx_builtin_include_directories.append(absolute_path + "/" + d)
+@@ -338,7 +352,7 @@ def zig_build_macro(absolute_path, zig_include_root):
+             copts =3D copts + ["-include", absolute_path + "/" + incl]
+=20
+         zig_cc_toolchain_config(
+-            name =3D zigtarget + "_toolchain_cc_config",
++            name =3D zigtarget + "_cc_config",
+             target =3D zigtarget,
+             tool_paths =3D absolute_tool_paths,
+             cxx_builtin_include_directories =3D cxx_builtin_include_director=
+ies,
+@@ -353,35 +367,34 @@ def zig_build_macro(absolute_path, zig_include_root):
+         )
+=20
+         native.cc_toolchain(
+-            name =3D zigtarget + "_toolchain_cc",
++            name =3D zigtarget + "_cc",
+             toolchain_identifier =3D zigtarget + "-toolchain",
+-            toolchain_config =3D ":%s_toolchain_cc_config" % zigtarget,
+-            all_files =3D ":zig",
+-            ar_files =3D ":zig",
+-            compiler_files =3D ":zig",
+-            linker_files =3D ":zig",
+-            dwp_files =3D ":empty",
+-            objcopy_files =3D ":empty",
+-            strip_files =3D ":empty",
++            toolchain_config =3D ":%s_cc_config" % zigtarget,
++            all_files =3D "@zig_sdk//:zig",
++            ar_files =3D "@zig_sdk//:zig",
++            compiler_files =3D "@zig_sdk//:zig",
++            linker_files =3D "@zig_sdk//:zig",
++            dwp_files =3D "@zig_sdk//:empty",
++            objcopy_files =3D "@zig_sdk//:empty",
++            strip_files =3D "@zig_sdk//:empty",
+             supports_param_files =3D 0,
+         )
+=20
+         # register two kinds of toolchain targets: Go and Zig conventions.
+         # Go convention: amd64/arm64, linux/darwin
+         native.toolchain(
+-            name =3D gotarget + "_toolchain",
++            name =3D gotarget,
+             exec_compatible_with =3D None,
+             target_compatible_with =3D target_config.constraint_values,
+-            toolchain =3D ":%s_toolchain_cc" % zigtarget,
++            toolchain =3D ":%s_cc" % zigtarget,
+             toolchain_type =3D "@bazel_tools//tools/cpp:toolchain_type",
+         )
+=20
+         # Zig convention: x86_64/aarch64, linux/macos
+         native.toolchain(
+-            name =3D zigtarget + "_toolchain",
++            name =3D zigtarget,
+             exec_compatible_with =3D None,
+             target_compatible_with =3D target_config.constraint_values,
+-            toolchain =3D ":%s_toolchain_cc" % zigtarget,
++            toolchain =3D ":%s_cc" % zigtarget,
+             toolchain_type =3D "@bazel_tools//tools/cpp:toolchain_type",
+         )
+-
+diff --git a/toolchain/toolchain/BUILD b/toolchain/toolchain/BUILD
+new file mode 100644
+index 0000000..e69de29
+diff --git a/toolchain/toolchain/BUILD.sdk.bazel b/toolchain/toolchain/BUILD.=
+sdk.bazel
+new file mode 100644
+index 0000000..4b505dc
+--- /dev/null
++++ b/toolchain/toolchain/BUILD.sdk.bazel
+@@ -0,0 +1,10 @@
++load("@bazel-zig-cc//toolchain:defs.bzl", "declare_toolchains")
++
++package(
++    default_visibility =3D ["//visibility:public"],
++)
++
++declare_toolchains(
++    absolute_path =3D {absolute_path},
++    zig_include_root =3D {zig_include_root},
++)
+--=20
+2.34.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id A38FF11EF0D
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu,  7 Apr 2022 09:37:53 +0000 (UTC)
+From: ~laurynasl <laurynasl@git.sr.ht>
+Date: Wed, 06 Apr 2022 20:10:45 +0000
+Subject: [PATCH bazel-zig-cc 4/4] Move toolchain definitions to toolchains/
+Message-ID: <164932427279.26543.1789507091630612744-4@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~laurynasl <laurynasl@uber.com>
+In-Reply-To: <164932427279.26543.1789507091630612744-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 19852
+Lines: 532
+
+From: laurynasl <laurynasl@uber.com>
+
+---
+ toolchain/defs.bzl                  | 214 +---------------------------
+ toolchain/private/BUILD             |   0
+ toolchain/private/defs.bzl          | 124 ++++++++++++++++
+ toolchain/toolchain/BUILD.sdk.bazel |   2 +-
+ toolchain/toolchain/defs.bzl        |  87 +++++++++++
+ 5 files changed, 215 insertions(+), 212 deletions(-)
+ create mode 100644 toolchain/private/BUILD
+ create mode 100644 toolchain/private/defs.bzl
+ create mode 100644 toolchain/toolchain/defs.bzl
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 61e099f..084af86 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -1,23 +1,7 @@
+ load("@bazel_skylib//lib:shell.bzl", "shell")
+ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_user_netrc", "us=
+e_netrc")
+-load(":zig_toolchain.bzl", "zig_cc_toolchain_config")
+-
+-DEFAULT_TOOL_PATHS =3D {
+-    "ar": "ar",
+-    "gcc": "c++",  # https://github.com/bazelbuild/bazel/issues/4644
+-    "cpp": "/usr/bin/false",
+-    "gcov": "/usr/bin/false",
+-    "nm": "/usr/bin/false",
+-    "objdump": "/usr/bin/false",
+-    "strip": "/usr/bin/false",
+-}.items()
+-
+-DEFAULT_INCLUDE_DIRECTORIES =3D [
+-    "include",
+-    "libcxx/include",
+-    "libcxxabi/include",
+-]
++load("@bazel-zig-cc//toolchain/private:defs.bzl", "DEFAULT_INCLUDE_DIRECTORI=
+ES", "ZIG_TOOL_PATH", "target_structs")
+=20
+ _fcntl_map =3D """
+ GLIBC_2.2.5 {
+@@ -32,114 +16,6 @@ __asm__(".symver fcntl64, fcntl@GLIBC_2.2.5");
+ #endif
+ """
+=20
+-# Zig supports even older glibcs than defined below, but we have tested only
+-# down to 2.17.
+-# $ zig targets | jq -r '.glibc[]' | sort -V
+-_GLIBCS =3D [
+-    "2.17",
+-    "2.18",
+-    "2.19",
+-    "2.22",
+-    "2.23",
+-    "2.24",
+-    "2.25",
+-    "2.26",
+-    "2.27",
+-    "2.28",
+-    "2.29",
+-    "2.30",
+-    "2.31",
+-    "2.32",
+-    "2.33",
+-    "2.34",
+-]
+-
+-def _target_darwin(gocpu, zigcpu):
+-    min_os =3D "10"
+-    if zigcpu =3D=3D "aarch64":
+-        min_os =3D "11"
+-    return struct(
+-        gotarget =3D "darwin_{}".format(gocpu),
+-        zigtarget =3D "{}-macos-gnu".format(zigcpu),
+-        includes =3D [
+-            "libunwind/include",
+-            # TODO: Define a toolchain for each minimum OS version
+-            "libc/include/{}-macos.{}-gnu".format(zigcpu, min_os),
+-            "libc/include/any-macos.{}-any".format(min_os),
+-            "libc/include/any-macos-any",
+-        ],
+-        linkopts =3D [],
+-        copts =3D [],
+-        bazel_target_cpu =3D "darwin",
+-        constraint_values =3D [
+-            "@platforms//os:macos",
+-            "@platforms//cpu:{}".format(zigcpu),
+-        ],
+-        tool_paths =3D {"ld": "ld64.lld"},
+-    )
+-
+-def _target_linux_gnu(gocpu, zigcpu, glibc_version =3D ""):
+-    glibc_suffix =3D "gnu"
+-    if glibc_version !=3D "":
+-        glibc_suffix =3D "gnu.{}".format(glibc_version)
+-
+-    # https://github.com/ziglang/zig/issues/5882#issuecomment-888250676
+-    # fcntl_hack is only required for glibc 2.27 or less. We assume that
+-    # glibc_version =3D=3D "" (autodetect) is running a recent glibc version=
+, thus
+-    # adding this hack only when glibc is explicitly 2.27 or lower.
+-    fcntl_hack =3D False
+-    if glibc_version =3D=3D "":
+-        # zig doesn't reliably detect the glibc version, so
+-        # often falls back to 2.17; the hack should be included.
+-        # https://github.com/ziglang/zig/issues/6469
+-        fcntl_hack =3D True
+-    else:
+-        # hack is required for 2.27 or less.
+-        fcntl_hack =3D glibc_version < "2.28"
+-
+-    return struct(
+-        gotarget =3D "linux_{}_{}".format(gocpu, glibc_suffix),
+-        zigtarget =3D "{}-linux-{}".format(zigcpu, glibc_suffix),
+-        includes =3D [
+-            "libunwind/include",
+-            "libc/include/generic-glibc",
+-            "libc/include/any-linux-any",
+-            "libc/include/{}-linux-gnu".format(zigcpu),
+-            "libc/include/{}-linux-any".format(zigcpu),
+-        ] + (["libc/include/x86-linux-any"] if zigcpu =3D=3D "x86_64" else [=
+]),
+-        toplevel_include =3D ["glibc-hacks"] if fcntl_hack else [],
+-        compiler_extra_includes =3D ["glibc-hacks/glibchack-fcntl.h"] if fcn=
+tl_hack else [],
+-        linker_version_scripts =3D ["glibc-hacks/fcntl.map"] if fcntl_hack e=
+lse [],
+-        linkopts =3D ["-lc++", "-lc++abi"],
+-        copts =3D [],
+-        bazel_target_cpu =3D "k8",
+-        constraint_values =3D [
+-            "@platforms//os:linux",
+-            "@platforms//cpu:{}".format(zigcpu),
+-        ],
+-        tool_paths =3D {"ld": "ld.lld"},
+-    )
+-
+-def _target_linux_musl(gocpu, zigcpu):
+-    return struct(
+-        gotarget =3D "linux_{}_musl".format(gocpu),
+-        zigtarget =3D "{}-linux-musl".format(zigcpu),
+-        includes =3D [
+-            "libc/include/generic-musl",
+-            "libc/include/any-linux-any",
+-            "libc/include/{}-linux-musl".format(zigcpu),
+-            "libc/include/{}-linux-any".format(zigcpu),
+-        ] + (["libc/include/x86-linux-any"] if zigcpu =3D=3D "x86_64" else [=
+]),
+-        linkopts =3D ["-s", "-w"],
+-        copts =3D ["-D_LIBCPP_HAS_MUSL_LIBC", "-D_LIBCPP_HAS_THREAD_API_PTHR=
+EAD"],
+-        bazel_target_cpu =3D "k8",
+-        constraint_values =3D [
+-            "@platforms//os:linux",
+-            "@platforms//cpu:{}".format(zigcpu),
+-        ],
+-        tool_paths =3D {"ld": "ld.lld"},
+-    )
+-
+ # Official recommended version. Should use this when we have a usable releas=
+e.
+ URL_FORMAT_RELEASE =3D "https://ziglang.org/download/{version}/zig-{host_pla=
+tform}-{version}.tar.xz"
+=20
+@@ -192,7 +68,6 @@ def register_toolchains(
+     toolchains =3D ["@zig_sdk//:toolchain:%s" % t for t in register]
+     native.register_toolchains(*toolchains)
+=20
+-ZIG_TOOL_PATH =3D "tools/{zig_tool}"
+ ZIG_TOOL_WRAPPER =3D """#!/bin/bash
+ set -e
+=20
+@@ -297,14 +172,7 @@ zig_repository =3D repository_rule(
+     implementation =3D _zig_repository_impl,
+ )
+=20
+-def _target_structs():
+-    ret =3D []
+-    for zigcpu, gocpu in (("x86_64", "amd64"), ("aarch64", "arm64")):
+-        ret.append(_target_darwin(gocpu, zigcpu))
+-        ret.append(_target_linux_musl(gocpu, zigcpu))
+-        for glibc in [""] + _GLIBCS:
+-            ret.append(_target_linux_gnu(gocpu, zigcpu, glibc))
+-    return ret
++
+=20
+ def filegroup(name, **kwargs):
+     native.filegroup(name =3D name, **kwargs)
+@@ -317,84 +185,8 @@ def declare_files(zig_include_root):
+=20
+     lazy_filegroups =3D {}
+=20
+-    for target_config in _target_structs():
++    for target_config in target_structs():
+         for d in DEFAULT_INCLUDE_DIRECTORIES + target_config.includes:
+             d =3D zig_include_root + d
+             if d not in lazy_filegroups:
+                 lazy_filegroups[d] =3D filegroup(name =3D d, srcs =3D native=
+.glob([d + "/**"]))
+-
+-
+-def declare_toolchains(absolute_path, zig_include_root):
+-    for target_config in _target_structs():
+-        gotarget =3D target_config.gotarget
+-        zigtarget =3D target_config.zigtarget
+-
+-        cxx_builtin_include_directories =3D []
+-        for d in DEFAULT_INCLUDE_DIRECTORIES + target_config.includes:
+-            d =3D zig_include_root + d
+-            cxx_builtin_include_directories.append(absolute_path + "/" + d)
+-        for d in getattr(target_config, "toplevel_include", []):
+-            cxx_builtin_include_directories.append(absolute_path + "/" + d)
+-
+-        absolute_tool_paths =3D {}
+-        for name, path in target_config.tool_paths.items() + DEFAULT_TOOL_PA=
+THS:
+-            if path[0] =3D=3D "/":
+-                absolute_tool_paths[name] =3D path
+-                continue
+-            tool_path =3D ZIG_TOOL_PATH.format(zig_tool =3D path)
+-            absolute_tool_paths[name] =3D "%s/%s" % (absolute_path, tool_pat=
+h)
+-
+-        linkopts =3D target_config.linkopts
+-        copts =3D target_config.copts
+-        for s in getattr(target_config, "linker_version_scripts", []):
+-            linkopts =3D linkopts + ["-Wl,--version-script,%s/%s" % (absolut=
+e_path, s)]
+-        for incl in getattr(target_config, "compiler_extra_includes", []):
+-            copts =3D copts + ["-include", absolute_path + "/" + incl]
+-
+-        zig_cc_toolchain_config(
+-            name =3D zigtarget + "_cc_config",
+-            target =3D zigtarget,
+-            tool_paths =3D absolute_tool_paths,
+-            cxx_builtin_include_directories =3D cxx_builtin_include_director=
+ies,
+-            copts =3D copts,
+-            linkopts =3D linkopts,
+-            target_cpu =3D target_config.bazel_target_cpu,
+-            target_system_name =3D "unknown",
+-            target_libc =3D "unknown",
+-            compiler =3D "clang",
+-            abi_version =3D "unknown",
+-            abi_libc_version =3D "unknown",
+-        )
+-
+-        native.cc_toolchain(
+-            name =3D zigtarget + "_cc",
+-            toolchain_identifier =3D zigtarget + "-toolchain",
+-            toolchain_config =3D ":%s_cc_config" % zigtarget,
+-            all_files =3D "@zig_sdk//:zig",
+-            ar_files =3D "@zig_sdk//:zig",
+-            compiler_files =3D "@zig_sdk//:zig",
+-            linker_files =3D "@zig_sdk//:zig",
+-            dwp_files =3D "@zig_sdk//:empty",
+-            objcopy_files =3D "@zig_sdk//:empty",
+-            strip_files =3D "@zig_sdk//:empty",
+-            supports_param_files =3D 0,
+-        )
+-
+-        # register two kinds of toolchain targets: Go and Zig conventions.
+-        # Go convention: amd64/arm64, linux/darwin
+-        native.toolchain(
+-            name =3D gotarget,
+-            exec_compatible_with =3D None,
+-            target_compatible_with =3D target_config.constraint_values,
+-            toolchain =3D ":%s_cc" % zigtarget,
+-            toolchain_type =3D "@bazel_tools//tools/cpp:toolchain_type",
+-        )
+-
+-        # Zig convention: x86_64/aarch64, linux/macos
+-        native.toolchain(
+-            name =3D zigtarget,
+-            exec_compatible_with =3D None,
+-            target_compatible_with =3D target_config.constraint_values,
+-            toolchain =3D ":%s_cc" % zigtarget,
+-            toolchain_type =3D "@bazel_tools//tools/cpp:toolchain_type",
+-        )
+diff --git a/toolchain/private/BUILD b/toolchain/private/BUILD
+new file mode 100644
+index 0000000..e69de29
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+new file mode 100644
+index 0000000..8380071
+--- /dev/null
++++ b/toolchain/private/defs.bzl
+@@ -0,0 +1,124 @@
++DEFAULT_INCLUDE_DIRECTORIES =3D [
++    "include",
++    "libcxx/include",
++    "libcxxabi/include",
++]
++
++ZIG_TOOL_PATH =3D "tools/{zig_tool}"
++
++# Zig supports even older glibcs than defined below, but we have tested only
++# down to 2.17.
++# $ zig targets | jq -r '.glibc[]' | sort -V
++_GLIBCS =3D [
++    "2.17",
++    "2.18",
++    "2.19",
++    "2.22",
++    "2.23",
++    "2.24",
++    "2.25",
++    "2.26",
++    "2.27",
++    "2.28",
++    "2.29",
++    "2.30",
++    "2.31",
++    "2.32",
++    "2.33",
++    "2.34",
++]
++
++def target_structs():
++    ret =3D []
++    for zigcpu, gocpu in (("x86_64", "amd64"), ("aarch64", "arm64")):
++        ret.append(_target_darwin(gocpu, zigcpu))
++        ret.append(_target_linux_musl(gocpu, zigcpu))
++        for glibc in [""] + _GLIBCS:
++            ret.append(_target_linux_gnu(gocpu, zigcpu, glibc))
++    return ret
++
++def _target_darwin(gocpu, zigcpu):
++    min_os =3D "10"
++    if zigcpu =3D=3D "aarch64":
++        min_os =3D "11"
++    return struct(
++        gotarget =3D "darwin_{}".format(gocpu),
++        zigtarget =3D "{}-macos-gnu".format(zigcpu),
++        includes =3D [
++            "libunwind/include",
++            # TODO: Define a toolchain for each minimum OS version
++            "libc/include/{}-macos.{}-gnu".format(zigcpu, min_os),
++            "libc/include/any-macos.{}-any".format(min_os),
++            "libc/include/any-macos-any",
++        ],
++        linkopts =3D [],
++        copts =3D [],
++        bazel_target_cpu =3D "darwin",
++        constraint_values =3D [
++            "@platforms//os:macos",
++            "@platforms//cpu:{}".format(zigcpu),
++        ],
++        tool_paths =3D {"ld": "ld64.lld"},
++    )
++
++def _target_linux_gnu(gocpu, zigcpu, glibc_version =3D ""):
++    glibc_suffix =3D "gnu"
++    if glibc_version !=3D "":
++        glibc_suffix =3D "gnu.{}".format(glibc_version)
++
++    # https://github.com/ziglang/zig/issues/5882#issuecomment-888250676
++    # fcntl_hack is only required for glibc 2.27 or less. We assume that
++    # glibc_version =3D=3D "" (autodetect) is running a recent glibc version=
+, thus
++    # adding this hack only when glibc is explicitly 2.27 or lower.
++    fcntl_hack =3D False
++    if glibc_version =3D=3D "":
++        # zig doesn't reliably detect the glibc version, so
++        # often falls back to 2.17; the hack should be included.
++        # https://github.com/ziglang/zig/issues/6469
++        fcntl_hack =3D True
++    else:
++        # hack is required for 2.27 or less.
++        fcntl_hack =3D glibc_version < "2.28"
++
++    return struct(
++        gotarget =3D "linux_{}_{}".format(gocpu, glibc_suffix),
++        zigtarget =3D "{}-linux-{}".format(zigcpu, glibc_suffix),
++        includes =3D [
++            "libunwind/include",
++            "libc/include/generic-glibc",
++            "libc/include/any-linux-any",
++            "libc/include/{}-linux-gnu".format(zigcpu),
++            "libc/include/{}-linux-any".format(zigcpu),
++        ] + (["libc/include/x86-linux-any"] if zigcpu =3D=3D "x86_64" else [=
+]),
++        toplevel_include =3D ["glibc-hacks"] if fcntl_hack else [],
++        compiler_extra_includes =3D ["glibc-hacks/glibchack-fcntl.h"] if fcn=
+tl_hack else [],
++        linker_version_scripts =3D ["glibc-hacks/fcntl.map"] if fcntl_hack e=
+lse [],
++        linkopts =3D ["-lc++", "-lc++abi"],
++        copts =3D [],
++        bazel_target_cpu =3D "k8",
++        constraint_values =3D [
++            "@platforms//os:linux",
++            "@platforms//cpu:{}".format(zigcpu),
++        ],
++        tool_paths =3D {"ld": "ld.lld"},
++    )
++
++def _target_linux_musl(gocpu, zigcpu):
++    return struct(
++        gotarget =3D "linux_{}_musl".format(gocpu),
++        zigtarget =3D "{}-linux-musl".format(zigcpu),
++        includes =3D [
++            "libc/include/generic-musl",
++            "libc/include/any-linux-any",
++            "libc/include/{}-linux-musl".format(zigcpu),
++            "libc/include/{}-linux-any".format(zigcpu),
++        ] + (["libc/include/x86-linux-any"] if zigcpu =3D=3D "x86_64" else [=
+]),
++        linkopts =3D ["-s", "-w"],
++        copts =3D ["-D_LIBCPP_HAS_MUSL_LIBC", "-D_LIBCPP_HAS_THREAD_API_PTHR=
+EAD"],
++        bazel_target_cpu =3D "k8",
++        constraint_values =3D [
++            "@platforms//os:linux",
++            "@platforms//cpu:{}".format(zigcpu),
++        ],
++        tool_paths =3D {"ld": "ld.lld"},
++    )
+diff --git a/toolchain/toolchain/BUILD.sdk.bazel b/toolchain/toolchain/BUILD.=
+sdk.bazel
+index 4b505dc..7cbca73 100644
+--- a/toolchain/toolchain/BUILD.sdk.bazel
++++ b/toolchain/toolchain/BUILD.sdk.bazel
+@@ -1,4 +1,4 @@
+-load("@bazel-zig-cc//toolchain:defs.bzl", "declare_toolchains")
++load("@bazel-zig-cc//toolchain/toolchain:defs.bzl", "declare_toolchains")
+=20
+ package(
+     default_visibility =3D ["//visibility:public"],
+diff --git a/toolchain/toolchain/defs.bzl b/toolchain/toolchain/defs.bzl
+new file mode 100644
+index 0000000..1b0c087
+--- /dev/null
++++ b/toolchain/toolchain/defs.bzl
+@@ -0,0 +1,87 @@
++load("@bazel-zig-cc//toolchain:zig_toolchain.bzl", "zig_cc_toolchain_config")
++load("@bazel-zig-cc//toolchain/private:defs.bzl", "DEFAULT_INCLUDE_DIRECTORI=
+ES", "ZIG_TOOL_PATH", "target_structs")
++
++DEFAULT_TOOL_PATHS =3D {
++    "ar": "ar",
++    "gcc": "c++",  # https://github.com/bazelbuild/bazel/issues/4644
++    "cpp": "/usr/bin/false",
++    "gcov": "/usr/bin/false",
++    "nm": "/usr/bin/false",
++    "objdump": "/usr/bin/false",
++    "strip": "/usr/bin/false",
++}.items()
++
++def declare_toolchains(absolute_path, zig_include_root):
++    for target_config in target_structs():
++        gotarget =3D target_config.gotarget
++        zigtarget =3D target_config.zigtarget
++
++        cxx_builtin_include_directories =3D []
++        for d in DEFAULT_INCLUDE_DIRECTORIES + target_config.includes:
++            d =3D zig_include_root + d
++            cxx_builtin_include_directories.append(absolute_path + "/" + d)
++        for d in getattr(target_config, "toplevel_include", []):
++            cxx_builtin_include_directories.append(absolute_path + "/" + d)
++
++        absolute_tool_paths =3D {}
++        for name, path in target_config.tool_paths.items() + DEFAULT_TOOL_PA=
+THS:
++            if path[0] =3D=3D "/":
++                absolute_tool_paths[name] =3D path
++                continue
++            tool_path =3D ZIG_TOOL_PATH.format(zig_tool =3D path)
++            absolute_tool_paths[name] =3D "%s/%s" % (absolute_path, tool_pat=
+h)
++
++        linkopts =3D target_config.linkopts
++        copts =3D target_config.copts
++        for s in getattr(target_config, "linker_version_scripts", []):
++            linkopts =3D linkopts + ["-Wl,--version-script,%s/%s" % (absolut=
+e_path, s)]
++        for incl in getattr(target_config, "compiler_extra_includes", []):
++            copts =3D copts + ["-include", absolute_path + "/" + incl]
++
++        zig_cc_toolchain_config(
++            name =3D zigtarget + "_cc_config",
++            target =3D zigtarget,
++            tool_paths =3D absolute_tool_paths,
++            cxx_builtin_include_directories =3D cxx_builtin_include_director=
+ies,
++            copts =3D copts,
++            linkopts =3D linkopts,
++            target_cpu =3D target_config.bazel_target_cpu,
++            target_system_name =3D "unknown",
++            target_libc =3D "unknown",
++            compiler =3D "clang",
++            abi_version =3D "unknown",
++            abi_libc_version =3D "unknown",
++        )
++
++        native.cc_toolchain(
++            name =3D zigtarget + "_cc",
++            toolchain_identifier =3D zigtarget + "-toolchain",
++            toolchain_config =3D ":%s_cc_config" % zigtarget,
++            all_files =3D "@zig_sdk//:zig",
++            ar_files =3D "@zig_sdk//:zig",
++            compiler_files =3D "@zig_sdk//:zig",
++            linker_files =3D "@zig_sdk//:zig",
++            dwp_files =3D "@zig_sdk//:empty",
++            objcopy_files =3D "@zig_sdk//:empty",
++            strip_files =3D "@zig_sdk//:empty",
++            supports_param_files =3D 0,
++        )
++
++        # register two kinds of toolchain targets: Go and Zig conventions.
++        # Go convention: amd64/arm64, linux/darwin
++        native.toolchain(
++            name =3D gotarget,
++            exec_compatible_with =3D None,
++            target_compatible_with =3D target_config.constraint_values,
++            toolchain =3D ":%s_cc" % zigtarget,
++            toolchain_type =3D "@bazel_tools//tools/cpp:toolchain_type",
++        )
++
++        # Zig convention: x86_64/aarch64, linux/macos
++        native.toolchain(
++            name =3D zigtarget,
++            exec_compatible_with =3D None,
++            target_compatible_with =3D target_config.constraint_values,
++            toolchain =3D ":%s_cc" % zigtarget,
++            toolchain_type =3D "@bazel_tools//tools/cpp:toolchain_type",
++        )
+--=20
+2.34.1
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lf1-f51.google.com (mail-lf1-f51.google.com [209.85.167.51])
+	by mail-b.sr.ht (Postfix) with ESMTPS id D9FEC11EF31
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu,  7 Apr 2022 10:16:27 +0000 (UTC)
+Received: by mail-lf1-f51.google.com with SMTP id t25so8768526lfg.7
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 07 Apr 2022 03:16:27 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:mime-version
+         :content-disposition;
+        bh=5CcT+69xbBgEfxFL90+YhwoI1iopbKQyy7Oi4opMTIo=;
+        b=WNQLVGqkd80D1Sm/Bfg3bmp/ynq5+d2t4yMiCcaS5ijR8tzSBD2ewFCCYO6rmEt3rN
+         EgssWTJvHJ9cGVMB8k2ckF74+UvQUO4H/VKEqEkLiOy8xMpJAxtSFa21n4PjAOWchxQN
+         CZ1vVmgVM68w3mKfoz92ah96+cb+ZTr8BDjnEevZphe+JnTnNPBZvHsUBvAIolRv6Dwg
+         nSMlG6TvQvsWdPug+9oZxRGidUpgazXaDLT3g4LGcEz8AyC1GZJVTQoaZreRziWWeF88
+         zBQa9ATBItAAtHBA0zWKlO2x4+5qTJk9CmFKWJek018+i4hp2AGKaxY9GUIexq6QpQ5W
+         obGA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :mime-version:content-disposition;
+        bh=5CcT+69xbBgEfxFL90+YhwoI1iopbKQyy7Oi4opMTIo=;
+        b=YhFHoqEerjfIciMqFQcFW6XlcmM0SFvzFmVpIfvBBzhM/mGcqD9ABPjOgog1WbLH6x
+         sp/aMZdeWURMfxcEiGFzqJxxRYTO0QVH4sVFqDz1Yph7p6QRbVZkFnubcqxK8frv/gEw
+         LW1zj1gg7ELhhMOyZrXuPuzWhGgIIj3tF3PWyF8Q09GX7fUUe0itt/Mc6/Ohh9h/4yLo
+         54QUc+NEcBdEc3QYsEVGElbEjFubD6nCJHFHI4m9q4T9KuEdEnIEHaYlYW8f7nqz6Tuj
+         b9Yd9o9xo+tXEGedd7sX7QsTxP4m0mpK7kUHi5B14u9fYe1vSmTi5zEVTl5ihT7ARcKi
+         dDng==
+X-Gm-Message-State: AOAM532qmhQiEFzNxou2eb+eEvZXItLxJZCh4JqPJbRUeVx4UTFd1uHr
+	0X/kEjn6J/NE0+7UPzoqovuzemPp0rI=
+X-Google-Smtp-Source: ABdhPJzBikjzOYpY5FJD64W5d9x0JHb/4ZzQTYtpxW37qmpNx0PuZ7vUcGJcyNZEtHb/l4uDER4dAQ==
+X-Received: by 2002:a05:6512:2207:b0:45d:cd01:d3ca with SMTP id h7-20020a056512220700b0045dcd01d3camr9223234lfu.561.1649326586313;
+        Thu, 07 Apr 2022 03:16:26 -0700 (PDT)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id f15-20020a0565123b0f00b0044a29f8ec94sm2122687lfv.95.2022.04.07.03.16.25
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Thu, 07 Apr 2022 03:16:25 -0700 (PDT)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Thu, 7 Apr 2022 13:16:25 +0300
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: RW access to contributors; talk in zig meetup
+Message-ID: <20220407101625.aahrqx4fa4qme56i@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Status: O
+Content-Length: 955
+Lines: 23
+
+Hi all,
+
+As I've received significant contributions from Ken Micklas and Laurynas
+Lubys, I decided to grant them write access to bazel-zig-cc. Here is an
+email I've sent them privately with the rules:
+
+- When WIP, feel free to push your code to <your name>/<feature name>
+  branch. Remove the branch when done.
+- When ready for merging, push it to the `next` branch and ping me.
+- I will keep merging to `main`, tagging the releases keep emailing the
+  announcements.
+
+That way, `main` will still have the latest tagged release signed by me.
+
+I will also be talking about bazel-zig-cc in the upcoming Zig meetup
+this weekend[1]. I was also listed in Google FOSS peer award and
+"earned" $250 for bazel-zig-cc[2]. Thanks Google!
+
+Regards,
+Motiejus
+
+[1]: https://twitter.com/croloris/status/1511342711764303890
+[2]: https://opensource.googleblog.com/2022/03/Announcing-First-Group-of-Google-Open-Source-Peer-Bonus-Winners-in-2022.html
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lj1-f174.google.com (mail-lj1-f174.google.com [209.85.208.174])
+	by mail-b.sr.ht (Postfix) with ESMTPS id EC4CF11EF0D
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu,  7 Apr 2022 11:46:53 +0000 (UTC)
+Received: by mail-lj1-f174.google.com with SMTP id m12so7091213ljp.8
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 07 Apr 2022 04:46:53 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:mime-version
+         :content-disposition;
+        bh=n3IIP9b/dm6u4Ogk5WbyKAVibt9GhM62nPVV/n4RUwk=;
+        b=padVY/+QQ/vqOrkAO5EDkuy3Q71mz0nCyzYt7PzYZBn1TakTVltTOOOAt1dWqai4ZW
+         4UCaCWTTXp1QsTY1Jhy3jk1+VtNmwE5hCnog/oBLKyTZy9VG9oJCufZ98C0NhZH6QYWm
+         /kV//4KYHgLBYm4xMVXqrQZDWUFqDOSBbobqqvXhDyFYCoJ0I2hE2am34t3t6iRTXnPi
+         YBk3eHlG1YxdHJVAy9m/tPTdVoG7vJDMqvRWpdTO4bj/2y/mZsv+6EC+F++G4EaFqDU+
+         lkF0LqOOyXOjhPXH9mTDWDplqUGCOQpohocBkiklULHK9EOI6a2978e/xzVzXHXbrDUA
+         ISFA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :mime-version:content-disposition;
+        bh=n3IIP9b/dm6u4Ogk5WbyKAVibt9GhM62nPVV/n4RUwk=;
+        b=r6pUU4alpx0qxQLSeUrJJAZg3pPmByXNg4yS6TUtdO6XiMpFn+l/UbHfRI+j1kOze9
+         CjQBgMjN7cbD/qCDHmj5DcJ2stVmXB6w7JgplKWJKztHjZz7Xp7/dal13mWBJYY6bA0B
+         tvk8GqbCWxKg1hjKHBQjVbonY7olfqYmvPLjrltNLWdMdhP0iYZi1Jx0Efbwo0wZYlyG
+         u0GtCRmZo6mbncqqY0buGAZrbbZDyzmlYvoiiQgzDjVxJ2OArhC7JKzs4Oy4MrCVmcc2
+         n44RukxntoB1JICgxjTuP1tOVJwtqnWJozy8sMj/gIiAC4sxSUh0WpaGMnDSIMn6fPwk
+         5kCg==
+X-Gm-Message-State: AOAM532EiS0iNVxCL7f5RMo6C8NBMUh6+ZBmA8E2RCXRiKL5Of0tbCRK
+	Hio5r/zbebNRN9d5Qh9cHVSnLnIFtG0=
+X-Google-Smtp-Source: ABdhPJw8kmQ9cjm9v6O7vVVO/LcYYG2JfwlxfdYcNwo3ggshEQ11R2kprT9RNkXkRhfStSdk8IkNFw==
+X-Received: by 2002:a2e:b8cb:0:b0:24b:16a3:ed9d with SMTP id s11-20020a2eb8cb000000b0024b16a3ed9dmr8241447ljp.393.1649332012561;
+        Thu, 07 Apr 2022 04:46:52 -0700 (PDT)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id e23-20020a196917000000b00464f74b2245sm134248lfc.252.2022.04.07.04.46.51
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Thu, 07 Apr 2022 04:46:51 -0700 (PDT)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Thu, 7 Apr 2022 14:46:50 +0300
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: bazel-zig-cc v0.6.0
+Message-ID: <20220407114650.uvdymzjjrdpwy6ei@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Status: O
+Content-Length: 1775
+Lines: 52
+
+Hi all,
+
+this change is a breaking change to bazel-zig-cc. Main points (from changelog):
+
+### [laurynasl] Hide toolchain internals
+
+This is a long-standing issue where platforms, toolchains and private stuff was
+mixed together. Now platforms and toolchains are defined in their own
+namespaces:
+
+$ bazel query @zig_sdk//platform:*
+@zig_sdk//platform:BUILD
+@zig_sdk//platform:darwin_aarch64
+@zig_sdk//platform:darwin_amd64
+@zig_sdk//platform:darwin_arm64
+@zig_sdk//platform:darwin_x86_64
+@zig_sdk//platform:linux_aarch64
+@zig_sdk//platform:linux_amd64
+@zig_sdk//platform:linux_arm64
+@zig_sdk//platform:linux_x86_64
+@zig_sdk//platform:macos_aarch64
+@zig_sdk//platform:macos_amd64
+@zig_sdk//platform:macos_arm64
+@zig_sdk//platform:macos_x86_64
+
+$ bazel query @zig_sdk//toolchain:* | head -10
+Loading: 0 packages loaded
+@zig_sdk//toolchain:BUILD
+@zig_sdk//toolchain:aarch64-linux-gnu
+@zig_sdk//toolchain:aarch64-linux-gnu.2.17
+@zig_sdk//toolchain:aarch64-linux-gnu.2.18
+@zig_sdk//toolchain:aarch64-linux-gnu.2.19
+@zig_sdk//toolchain:aarch64-linux-gnu.2.22
+@zig_sdk//toolchain:aarch64-linux-gnu.2.23
+@zig_sdk//toolchain:aarch64-linux-gnu.2.24
+@zig_sdk//toolchain:aarch64-linux-gnu.2.25
+@zig_sdk//toolchain:aarch64-linux-gnu.2.26
+
+Thanks Laurynas!
+
+### [Ken Micklas] Upgrade to Bazel 5.1.0
+
+... we now require minimal bazel 5.1.0. And there are some other minor
+CI improvements, like specifying golang version for reproducibility.
+
+Laurynas is preparing a different way to specify musl and glibc
+platforms by selecting the platform, not the toolchain. This should
+happen soon. This was desirable from day 0, but I couldn't make it
+happen reliably at the time, so resorted to `--extra_toolchains`.
+Looking forward to it!
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lf1-f45.google.com (mail-lf1-f45.google.com [209.85.167.45])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 26EB511EF0D
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu,  7 Apr 2022 11:59:00 +0000 (UTC)
+Received: by mail-lf1-f45.google.com with SMTP id j9so1115535lfe.9
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 07 Apr 2022 04:59:00 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:references:mime-version
+         :content-disposition:content-transfer-encoding:in-reply-to;
+        bh=qPvE8Z3jxFbO8/hk/7iLyvO8AvuVK1BVd14aRCHEq9Q=;
+        b=oHQTT3iCEJtVOWQUpeJMxTuzSU8kBCJr+Rhre09sno6wm9JMS+4XMD5Mk89ZzsblLg
+         rvecwfi75VwCYUgp/Nj5yRnQI2K8KTeNkRUCB7GTd9oF7NuZsxC8+GxH9TxR8xqvODLw
+         yk03ZdPwvg/UvkNWgNLBOE2gYcuXN3fagTuWe/FjfEZMmjvt1SthbmZZFJYRjwoS2cIK
+         9btIhIMkl9TU6CjKwhLSqkO8oK/jfuH0A6bwa98Vq9vaoT9KTXGC+0rzmLVXa0QvpzgM
+         gSVt3JGjtNpasYkEvykRqNiL9IF+ybEuS3v8ooWJLBS7OvvbXkmlHa6upqlUIBZs0fDY
+         YI7Q==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :references:mime-version:content-disposition
+         :content-transfer-encoding:in-reply-to;
+        bh=qPvE8Z3jxFbO8/hk/7iLyvO8AvuVK1BVd14aRCHEq9Q=;
+        b=vLTlF5zQFcCkVWc3pTkrSl6laNqNX+7U4OFZjoQF5w+Q3R9baAMbTjeuN91+rgoAlY
+         I35XRrUryuCQQGPsCWfFmTriUcRraq2lg7wqedf9mCCQrd6DzQsYD9EFeDuftP0nYw4E
+         /B/eHXdWqFJJZ/LeFg1tsAqPywtvqkog69NFfwjlVCCHoswHLeoNzMmJbeIhvKIzHFZ9
+         JYhyLXbsYQ5mH8BhIXP3vVX9/dBaTml53KifDPhAK5+a+WBTpDp4FMq5Fo6uHRtCCvph
+         ftoxdhzDD5cCuI0333ObESfY8C9auh++SpJB8VoKE47mqGqxTTwbG5OAihnSootP455N
+         FOdg==
+X-Gm-Message-State: AOAM530+ADb6PNwhrVoZ2Pvix6HxW85gaJulXtWffYEtq0aRR5C1oF1j
+	sesRfuRME7Q/fPVchsNpjYzTrfAB10o=
+X-Google-Smtp-Source: ABdhPJyoV6RBbcMPkh4E6B56JGD/HqTSZPMCZFPKWkImrBLr2QckR6kmYKhjvASHRiZbtHuDLq17dw==
+X-Received: by 2002:a05:6512:2252:b0:44a:3038:cbc with SMTP id i18-20020a056512225200b0044a30380cbcmr9119693lfu.252.1649332738955;
+        Thu, 07 Apr 2022 04:58:58 -0700 (PDT)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id y5-20020a2e3205000000b0024b045e3b18sm1824027ljy.66.2022.04.07.04.58.58
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Thu, 07 Apr 2022 04:58:58 -0700 (PDT)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Thu, 7 Apr 2022 14:58:57 +0300
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: Re: RW access to contributors; talk in zig meetup
+Message-ID: <20220407115857.q2gikkc624j2eyp2@mtpad.i.jakstys.lt>
+References: <20220407101625.aahrqx4fa4qme56i@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Content-Transfer-Encoding: 8bit
+In-Reply-To: <20220407101625.aahrqx4fa4qme56i@mtpad.i.jakstys.lt>
+Status: O
+Content-Length: 1048
+Lines: 26
+
+Hi all,
+
+Slight rule correction:
+
+On Thu, Apr 07, 2022 at 01:16:25PM +0300, Motiejus Jakštys wrote:
+> - When ready for merging, push it to the `next` branch and ping me.
+
+Since I allow for force-pushes, we have 3 contributors, `next` doesn't
+make sense. So push to "your" branch (<your name>/<feature slug>) and
+I'll merge from there.
+
+So we should have only those branches in ~motiejus/bazel-zig-cc:
+- `main`: passes CI and is always the latest released tag.
+- for our sandbox work: `motiejus/<X>`, `laurynasl/<X>`,
+  `kmicklas/<X>`. You are the boss there.
+
+There seems to be a problem with sourcehut picking the patches from the
+mailing list, which I reported to `#sr.ht:libera.chat`:
+
+    UI-generated patchset
+    (https://lists.sr.ht/~motiejus/bazel-zig-cc/%3C164932427279.26543.1789507091630612744-0%40git.sr.ht%3E)
+    did not end up in https://lists.sr.ht/~motiejus/bazel-zig-cc/patches
+    and, consequently, did not trigger a CI run. Is this appropriate
+    place to report it? Happened ~1 hour ago.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 82D7C11EF2F
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri,  8 Apr 2022 13:03:53 +0000 (UTC)
+From: ~laurynasl <laurynasl@git.sr.ht>
+Date: Fri, 08 Apr 2022 13:03:53 +0000
+Subject: 
+ [PATCH bazel-zig-cc 0/1] Fix the register parameter in register toolchain
+MIME-Version: 1.0
+Message-ID: <164942303327.26005.14403108374611803240-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~laurynasl <laurynasl@uber.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+Status: O
+Content-Length: 232
+Lines: 11
+
+Looks like this slipped through the CI. We should think about how to
+catch cases like these.
+
+laurynasl (1):
+  Fix register toolchain
+
+ toolchain/defs.bzl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+-- 
+2.34.1
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 9D4EB11EF52
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri,  8 Apr 2022 13:03:53 +0000 (UTC)
+From: ~laurynasl <laurynasl@git.sr.ht>
+Date: Fri, 08 Apr 2022 12:55:52 +0000
+Subject: [PATCH bazel-zig-cc 1/1] Fix register toolchain
+Message-ID: <164942303327.26005.14403108374611803240-1@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~laurynasl <laurynasl@uber.com>
+In-Reply-To: <164942303327.26005.14403108374611803240-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+MIME-Version: 1.0
+Status: O
+Content-Length: 563
+Lines: 21
+
+From: laurynasl <laurynasl@uber.com>
+
+---
+ toolchain/defs.bzl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index ebcb65e..9e34e6b 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -65,7 +65,7 @@ def register_toolchains(
+         },
+     )
+ 
+-    toolchains = ["@zig_sdk//:toolchain:%s" % t for t in register]
++    toolchains = ["@zig_sdk//toolchain:%s" % t for t in register]
+     native.register_toolchains(*toolchains)
+ 
+ ZIG_TOOL_WRAPPER = """#!/bin/bash
+-- 
+2.34.1
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=YOJYgIRj5Efp6IEK+Upr03ayDJNyfjbPpxDgRvSeIe4=;
+ c=simple/simple; d=sr.ht; h=Date:From:In-Reply-To:Subject:To:Cc;
+ q=dns/txt; s=srht; t=1649423871; v=1;
+ b=SvfvUpxx4SspZsLgBcrQnFjUzHEuh8tlyXSVomm/BKNwgYNa9xKwsKxFpjdNZo03+CnJ6VN9
+ f0d61GSdt4hYH8fX3pedL4BU7m4UzzercYw4hNuqXsM4LaNcsr2WspELZf3rFy95EqEKBzgeLk6
+ c5eEENfDGxnu8MRQ20KsKzRVQpXc9ji6yRsLWnFgsYB0ILzZk3+4wUyQ8CA3VwyrUrWP9BZeT/Z
+ QLE4h+6VHGbbkH4ALEh2AWG+ziVMDK9/fcbd2lPxOkxJDSRG2NDnj2QNl3aJ6pemxHOsFSwUsnZ
+ 1/6RYkJAPt4IoVFggK7R0Q0NI3rd8kdntqu7kDjtm6MCg==
+Received: from localhost (unknown [173.195.146.244])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id 2D9DE11EF2F;
+	Fri,  8 Apr 2022 13:17:51 +0000 (UTC)
+MIME-Version: 1.0
+Date: Fri, 08 Apr 2022 13:17:51 +0000
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CJ4VYPONM9FI.3QD09NITLDE94@cirno2>
+In-Reply-To: <164942303327.26005.14403108374611803240-1@git.sr.ht>
+Subject: [bazel-zig-cc/patches/.build.yml] build success
+To: "~laurynasl" <laurynasl@uber.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 333
+Lines: 9
+
+bazel-zig-cc/patches/.build.yml: SUCCESS in 13m56s
+
+[Fix the register parameter in register toolchain][0] from [~laurynasl][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/30909
+[1]: mailto:laurynasl@uber.com
+
+=E2=9C=93 #732421 SUCCESS bazel-zig-cc/patches/.build.yml https://builds.sr=
+.ht/~motiejus/job/732421
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-ed1-f51.google.com (mail-ed1-f51.google.com [209.85.208.51])
+	by mail-b.sr.ht (Postfix) with ESMTPS id E328611EF8D
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri,  8 Apr 2022 21:15:40 +0000 (UTC)
+Received: by mail-ed1-f51.google.com with SMTP id g20so11420427edw.6
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 08 Apr 2022 14:15:40 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:cc:subject:message-id:references:mime-version
+         :content-disposition:in-reply-to;
+        bh=T6ualBv4fzgTEhmeVIagcPsiNBDA5mkwh+NR7uMFVLg=;
+        b=K8lk9/iOmrZB9FULwWp+0/mcmrFO5pUlzPmV4/RAzC/lAnwVB5ZbK5NDXQLAlG502e
+         y3uNgEv1bRK227X5QgJKjhocaOgfG7RcP6LdXqSyVE4MKHmWpB3IESPqcPwczK0mvU23
+         CpMaXT4qXwS2b/sTc+Arg0iOP7URGx0aiRe1VClCce6E09pRJYSfcge5T7GEusuIlhGv
+         SMwykkPtL7SDqebDyYcnwXFqe/qb7tBNSHEiISLm/d35SXxWfAyvrAE0w+KfglNxjNvP
+         QlMKoYcmEWhWGdtBlq+xMLTRMfbcPnZBasfPRTHU1VMxROIobLWm5rNk1m1jxewEbMmm
+         DEKg==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:cc:subject:message-id
+         :references:mime-version:content-disposition:in-reply-to;
+        bh=T6ualBv4fzgTEhmeVIagcPsiNBDA5mkwh+NR7uMFVLg=;
+        b=j929qvKAagl082Cw7WtQ1T+S0InaNZ3P2a76t7PwpN/Q2i07TqB3hoHZJVQjQ2TNxc
+         awN2QfE56oO5xxRxS0oR8qdyvfjxxYmTDjaS4i0VxBiDAy8APtwYKRuqZKAtrYACgOz5
+         e0TKJk1RZOPYg2ESj3QXDjSbqTjbLtuaxTag2Xs8QFjOo2Z78GP2opCS89mCOZwnyE6W
+         ubtGzB9IMXQZJsNc75+QXTzomkgArFe3hwlKQ5ojmGuVl0XJRz2QTHwJEsVuOOMtuNi0
+         SsHITnRl6mV3HIljGRK4qWEh2cQMnQrlMUrVbrGHLGaHN+qgB5riMuPPIGujpmtOwhxL
+         F0jA==
+X-Gm-Message-State: AOAM531QrM8GK3WxRcs9serD9D93li99uhUYDi6Hyo9+zaav/V+WJIeM
+	QdQogfYv97N/jw9XERh66KQ=
+X-Google-Smtp-Source: ABdhPJw8/cG6HXkicieQfvpH6VtMC1UaUMBolJhrc/sba0ZG4pLrnfw3KSAVLEa4wm002/tNL3Klhg==
+X-Received: by 2002:a50:c3cf:0:b0:41d:5fc4:7931 with SMTP id i15-20020a50c3cf000000b0041d5fc47931mr2070157edf.244.1649452539767;
+        Fri, 08 Apr 2022 14:15:39 -0700 (PDT)
+Received: from localhost (host-31-196-35-164.business.telecomitalia.it. [31.196.35.164])
+        by smtp.gmail.com with ESMTPSA id et21-20020a170907295500b006e7f1abe2ccsm5851105ejc.75.2022.04.08.14.15.39
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Fri, 08 Apr 2022 14:15:39 -0700 (PDT)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Sat, 9 Apr 2022 00:15:38 +0300
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~laurynasl <laurynasl@uber.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: Re: [PATCH bazel-zig-cc 0/1] Fix the register parameter in register
+ toolchain
+Message-ID: <20220408211538.srx5swx4reuf4n2x@mtpad.i.jakstys.lt>
+References: <164942303327.26005.14403108374611803240-0@git.sr.ht>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+In-Reply-To: <164942303327.26005.14403108374611803240-0@git.sr.ht>
+Status: O
+Content-Length: 917
+Lines: 27
+
+On Fri, Apr 08, 2022 at 01:03:53PM +0000, ~laurynasl wrote:
+> Looks like this slipped through the CI. We should think about how to
+> catch cases like these.
+
+I think the next step, where you suggested replacing
+`--extra_toolchains` with
+registering-all-toolchains-and-specifying-the-platforms, would have
+helped here?
+
+Once transitioned to platforms, I expect us to stop specifying the
+`--extra_toolchains` and only use platform constraints. Then write a
+couple of test targets and confirm they are building artifacts for
+correct architectures
+
+Transitions can even allow `sh_test` targets, which would run `file` on
+the output binary and assert it's architecture. The `ci/test` script
+would become even simpler.
+
+> laurynasl (1):
+>   Fix register toolchain
+> 
+>  toolchain/defs.bzl | 2 +-
+>  1 file changed, 1 insertion(+), 1 deletion(-)
+
+Applied and released v0.6.1. Thank you.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lj1-f174.google.com (mail-lj1-f174.google.com [209.85.208.174])
+	by mail-b.sr.ht (Postfix) with ESMTPS id D3B0811EF91
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 15 Apr 2022 14:07:34 +0000 (UTC)
+Received: by mail-lj1-f174.google.com with SMTP id o16so9637455ljp.3
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 15 Apr 2022 07:07:34 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:mime-version
+         :content-disposition;
+        bh=DYZFEA10ndkjk3Nw/v/IJwhyoiaYK+RyhpqCX8E9dNI=;
+        b=kz97bojPLS2sAG7la0yMsahi5VXSJkYcstG0UI04sfRhEQj5jeIRzobD01qctJOzrv
+         Cos5ZTR03J165vE13NM4L8kXu0lO2pwqoPOO4UeZhuQKMIqevuqakIdh47CxpaGU4TEM
+         83pj+sTmPm4pc5KAJc+86XHUUT8X8/X6nnSNyPLR0SXNyfpZYRFkQdE0UMH6K5ef9uv3
+         9GPa1s5X5JA5jTxYLvnyc1e5UzT+coNadLBrbZJZXeW83Wm6Q9gcFj59GwE2vBnXBF8p
+         osDUkSEp1/PuvHe5ywTRsqX7uR28g23kcg2M+Vd5QGrwT8iuE857nS1IGSAmCLv9nuh1
+         NvcA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :mime-version:content-disposition;
+        bh=DYZFEA10ndkjk3Nw/v/IJwhyoiaYK+RyhpqCX8E9dNI=;
+        b=6xjSQans+iTR4OYcKHXsnetp3rTPpR21R/3zqmIGZO8WtYwbCKRS9BT5WewQh+zZ/+
+         WPYmXPY0jvPgDyH6Cx+CbgOWP8RFLZMFgR4F7NazWR3UptDF/o5JR2hRMHdP9xIOD2QY
+         A+L0A0LEa1ZpTI6YTONrRNCt1d6uWLmm4XyGRQNp2U4gFZ+ObQLLNHhhwjSxrzYhB+Zw
+         fGaFDdbtH6LMKuuGW59HH38Fh5SXUHL//+VF1xefcJ58Ppl43c4Nnys27W3XHHr+aCK9
+         TmXANarefB/gWc0wc3vih+AovCMlQ/kStVbfwu1ue1pOLDIKh/C82h2v9PxrpXXPP5nl
+         EPdw==
+X-Gm-Message-State: AOAM532eXbr2h9nepWoQpDHvSDG/w0ZWY/2P5yUQofV9XP8kFrAmyGW4
+	6PUn6ceAUD4/ei6GK/EPUDfXq8YO14I=
+X-Google-Smtp-Source: ABdhPJxY3M4sKfoYu+xn8BNqH5oPR+AUahNkb1tYOVkji8skDNsvMHnycAyZML2oMpWwVYqFSGW9kA==
+X-Received: by 2002:a05:651c:154b:b0:24c:7f44:2448 with SMTP id y11-20020a05651c154b00b0024c7f442448mr4446359ljp.129.1650031653191;
+        Fri, 15 Apr 2022 07:07:33 -0700 (PDT)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id y21-20020a2e7d15000000b0024dab6213cfsm45129ljc.48.2022.04.15.07.07.31
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Fri, 15 Apr 2022 07:07:31 -0700 (PDT)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Fri, 15 Apr 2022 17:07:30 +0300
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: upcoming changes in bazel-zig-cc v0.7
+Message-ID: <20220415140730.xpx6sap4yu4bt3ix@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Status: O
+Content-Length: 902
+Lines: 24
+
+Hi all,
+
+Laurynas rewrote bazel-zig-cc. Now it will support specifying
+arch/os/libc via *platforms* alone (provided toolchains are registered).
+E.g.
+
+    --platforms @zig_sdk//libc_aware/platform:linux_amd64_gnu.2.28
+    --platforms @zig_sdk//libc_aware/platform:linux_amd64_musl
+
+I intend to merge this on ~Tuesday. There will be (almost) no breaking
+changes, but many new ways to use bazel-zig-cc. I am excited about this
+release, as now it makes many things "right". Read the README. :)
+
+While updating documentation, I accidentally wrote my mental model on
+how `--platforms`, `--toolchains` and constraints interact. If you find
+lies there, please let me know, I will un-lie them.
+
+Here are the updated docs; notice they are much longer than the
+original:
+https://git.sr.ht/~motiejus/bazel-zig-cc/tree/laurynasl_libc/item/README.md?view-rendered
+
+Thanks Laurynai!
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lf1-f48.google.com (mail-lf1-f48.google.com [209.85.167.48])
+	by mail-b.sr.ht (Postfix) with ESMTPS id D2AE611EEFE
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 20 Apr 2022 09:37:41 +0000 (UTC)
+Received: by mail-lf1-f48.google.com with SMTP id w1so1807094lfa.4
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 20 Apr 2022 02:37:41 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:mime-version
+         :content-disposition;
+        bh=e/BIiG8y5IC+Nio1ZqSP9xLinXXy6mN1Tuj5Q9vgRJ4=;
+        b=R6YYS60AyESm13henlgoSEcCgC6fExYNs5liGC6Xai43OaEL+3r2XmZ0jbL4p+fubO
+         GTYUoqCVI7n4XuB21yCQgHpir1XSC/faRC1bTL6R14HJz7yqhCSNlIxZgaCSJfl4phQO
+         uyyiyRHMLtExInhl0vIyf+dH5N+tW9apoFR3GAi+LVYeGqDCqDZtT7MOoBJzLGvOXhR2
+         gjCIsOZvagRo3IxvYv87T/2PwrnHWPsHSnYlHMGVeDl5MnRLmBGAezs3XeI343mPi2hr
+         20aU1EpDLJ4Z1fZZeJZDXf0D01F9jU4O7IkWILkNEKd/YYNCD9houePRvsyAVIKzS7JE
+         ydUg==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :mime-version:content-disposition;
+        bh=e/BIiG8y5IC+Nio1ZqSP9xLinXXy6mN1Tuj5Q9vgRJ4=;
+        b=CJaYLURaogIn3HjAmu0vyIlIVRMU53J48fS32VIhvax6GfSyFcg5xrMSgYY06lL5rJ
+         CRgPC2lPq2DoMDx3li4Kuk9zrMfcHU/ri9xT5nsavxTjt/KwtDVhtbrf56ixqfMNMOGp
+         prwPYjBPuAyBlIeVUhTQ/HR7lmd6MVK8VUg24ubXmlGFhcOMElJTK4+iVzpqNxTWRKYy
+         9+cPB91TaGO6fwP+LaqsLa5GS9cUgBGvAgICl4iIKIQ+dOeB1mt41YLyfgHNAaVkwihO
+         eKXqpSslGlRQQtPgDqerU54PMUfCmTKwCdYM/Q9DMelaUDxbeL7xKAw+4PdkVcs9X/5F
+         k4cw==
+X-Gm-Message-State: AOAM530+qV2Jf95daul3BUlni1Cm8y016QwMs7bQ9jeiHQ4TehGbueMR
+	MrqtBCzPZfVmyyu3xXYzg1EXyTOhZZg=
+X-Google-Smtp-Source: ABdhPJwDJH7o0BLFkci7pYyyQS2lkVpxPUS8QhSaXjtLKDtA2gQGfyj7baifuoui/IZYMESX4qnKfw==
+X-Received: by 2002:a05:6512:3d94:b0:471:2436:f8f4 with SMTP id k20-20020a0565123d9400b004712436f8f4mr12131641lfv.441.1650447459162;
+        Wed, 20 Apr 2022 02:37:39 -0700 (PDT)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id s12-20020ac25fac000000b004435e2e0a08sm1773901lfe.251.2022.04.20.02.37.37
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Wed, 20 Apr 2022 02:37:38 -0700 (PDT)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Wed, 20 Apr 2022 12:37:36 +0300
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: bazel-zig-cc v0.7.0
+Message-ID: <20220420093736.x4hjjpkkkzvjolsa@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Status: O
+Content-Length: 1282
+Lines: 43
+
+Hi all,
+
+I've released bazel-zig-cc v0.7.0. It's a rewrite by laurynasl@ and
+major documentation upgrade by myself.
+
+Incompatible changes
+--------------------
+
+1. `register_toolchains` renamed to `toolchains`. Before:
+
+        load("@bazel-zig-cc//toolchain:defs.bzl", zig_register_toolchains = "register_toolchains")
+
+    After:
+
+        load("@bazel-zig-cc//toolchain:defs.bzl", zig_toolchains = "toolchains")
+
+2. `toolchains(register = ...)` was removed. You should be registering
+    the toolchains directly in the WORKSPACE or via `.bazelrc` (see README).
+
+3. "glibc version autodetection" is removed: the glibc version must now
+    be always specified.
+
+New Features
+------------
+
+1. Now one can specify the libc variant (glibc+version or libc) via
+   `--platforms` alone. See README.
+
+2. Internal: more examples with multiple architectures, transitions, and
+   a new "C" test case.
+
+Ecosystem
+---------
+
+While testing this internally, we've realized that the new version of
+rules_docker[1] is not compatible with the new libc-in-the-platform
+feature, since the libc version is *part of the platform now*. Laurynas
+will comment in the PR with more details.
+
+Enjoy!
+Motiejus
+
+[1]: https://github.com/bazelbuild/rules_docker/pull/1963
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=uber.com header.i=@uber.com
+Received: from mail-yb1-f173.google.com (mail-yb1-f173.google.com [209.85.219.173])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 7F24311EEFE
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 20 Apr 2022 12:20:37 +0000 (UTC)
+Received: by mail-yb1-f173.google.com with SMTP id m132so2520419ybm.4
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 20 Apr 2022 05:20:37 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=uber.com; s=google;
+        h=mime-version:references:in-reply-to:from:date:message-id:subject:to
+         :cc:content-transfer-encoding;
+        bh=Si4fflkXFvBbGMHW6tzu8X1ndgXjt2CVYKJ63HXkqsU=;
+        b=wkLIewIZTdy5Yo2bypHKpzs9BCFUb5hiHPrJzkEX38yMcm6aeQ/uWqtqTFvvLQOrw2
+         Miirr9R3V7rw73x7zjvtRSP3fh17HtB7rhfTm9yAnnU6/mpnYxlVuPYR7licTwgIoUuA
+         u2DH3uwNXcNHa7WMa6ZNZ+ENbi/8V2vos5V/Y=
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:references:in-reply-to:from:date
+         :message-id:subject:to:cc:content-transfer-encoding;
+        bh=Si4fflkXFvBbGMHW6tzu8X1ndgXjt2CVYKJ63HXkqsU=;
+        b=OVFWoGoe2wT7Y0FrrnKO8a6RErxwp4AsvBbwuXdqHPIoShi8OnwHfDwo1emuZdrvoT
+         DAnul7WXATL7b0rBk4Ikdkox+KcZYAob8ND81zOWu1StVevlC9DhIbdAzoZZM5BD0fkO
+         fOzratZXdyyxzmG/ru1hK/Q2nvYDv3gIsOnvQt6YfXHGN5ezkgSY6+/LWwXD+PL8wJBX
+         cpjP04Nqd4UZrQxYcdFw0wkmdtmHpr3EyUdeNwtOdjizT+rwRIkzsixsCcjUC/VfVerp
+         NRaJSvfrOeFG7qZPQ50tHPeFCgitKHkWK2OFPBx7fbvwx4upqugSXEmKpbblp2aJ5ouz
+         p4qQ==
+X-Gm-Message-State: AOAM533kYOYHpPwkBnHl/dTv8qEDuWsJ0AyTeUAFS7AtPzXTG3fRTj46
+	3wYSTQY19hL8zTy30l1h2TsIt/wBngWYHMwC8Qqd
+X-Google-Smtp-Source: ABdhPJxQzRDS8ORw5uj4MePwvOSr0rXhs0nrVKdFp6k3pRFOihTnKNwhaPTLESjIoL1MpCqEhr21SgS/WL31cDfB96w=
+X-Received: by 2002:a25:bf86:0:b0:641:4772:923a with SMTP id
+ l6-20020a25bf86000000b006414772923amr20506048ybk.265.1650457236952; Wed, 20
+ Apr 2022 05:20:36 -0700 (PDT)
+MIME-Version: 1.0
+References: <20220420093736.x4hjjpkkkzvjolsa@mtpad.i.jakstys.lt>
+In-Reply-To: <20220420093736.x4hjjpkkkzvjolsa@mtpad.i.jakstys.lt>
+From: Laurynas Lubys <laurynasl@uber.com>
+Date: Wed, 20 Apr 2022 15:20:26 +0300
+Message-ID: <CAG09j4-XZtiP-zs6GGW=5uZrN2OZ2DcX+nD58Odpfgbc85JP8w@mail.gmail.com>
+Subject: Re: bazel-zig-cc v0.7.0
+To: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 1955
+Lines: 63
+
+Regarding rules_docker:
+
+In 0.23.0, rules_docker added transitions based on the architecture
+and operating system specified on the container_image. The platform
+transition is "hard-coded" in a sense where it will use a specific
+platform that only includes the os and cpu constraints. This means
+that it is not possible to provide a platform which includes a libc
+version. There seem to still be some discussion on how this should
+best be solved in rules_docker.
+
+Cheers,
+Laurynas
+
+
+On Wed, Apr 20, 2022 at 12:37 PM Motiejus Jak=C5=A1tys <motiejus@jakstys.lt=
+> wrote:
+>
+> Hi all,
+>
+> I've released bazel-zig-cc v0.7.0. It's a rewrite by laurynasl@ and
+> major documentation upgrade by myself.
+>
+> Incompatible changes
+> --------------------
+>
+> 1. `register_toolchains` renamed to `toolchains`. Before:
+>
+>         load("@bazel-zig-cc//toolchain:defs.bzl", zig_register_toolchains=
+ =3D "register_toolchains")
+>
+>     After:
+>
+>         load("@bazel-zig-cc//toolchain:defs.bzl", zig_toolchains =3D "too=
+lchains")
+>
+> 2. `toolchains(register =3D ...)` was removed. You should be registering
+>     the toolchains directly in the WORKSPACE or via `.bazelrc` (see READM=
+E).
+>
+> 3. "glibc version autodetection" is removed: the glibc version must now
+>     be always specified.
+>
+> New Features
+> ------------
+>
+> 1. Now one can specify the libc variant (glibc+version or libc) via
+>    `--platforms` alone. See README.
+>
+> 2. Internal: more examples with multiple architectures, transitions, and
+>    a new "C" test case.
+>
+> Ecosystem
+> ---------
+>
+> While testing this internally, we've realized that the new version of
+> rules_docker[1] is not compatible with the new libc-in-the-platform
+> feature, since the libc version is *part of the platform now*. Laurynas
+> will comment in the PR with more details.
+>
+> Enjoy!
+> Motiejus
+>
+> [1]: https://github.com/bazelbuild/rules_docker/pull/1963
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lj1-f173.google.com (mail-lj1-f173.google.com [209.85.208.173])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 2FFBD11EFC9
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu,  5 May 2022 12:24:31 +0000 (UTC)
+Received: by mail-lj1-f173.google.com with SMTP id 4so5354824ljw.11
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 05 May 2022 05:24:31 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:mime-version
+         :content-disposition;
+        bh=DPz95s72paZNhFzkhCmu5Co2WHEUgIjoRgB9imbXDeo=;
+        b=d0IqLFnfdu8dngOJZTw07JvW5LT9HrfCoXXQqr0Lb0L1Tc5kzU5QdBLcTo7ogw8/8C
+         8tsoVV0/FS1pmY6c5LvRPpdNeD/VJ1PxYbjLdw8Ffzb1BKTEHdonfT3+mV+Q233sTE52
+         QqP7G7kAkYrfRKrqahe7fPmZmx1qxL+VxSKfXqRO4bOIMwIqth41eLqPsexubcM3c3Qg
+         Hvd4lYHB7RtFnD1eXWNwlQm5Qu04CwlveRYMyYghsBIexA5amoFhozj2Yf6WdpImEjdR
+         FRullx436PFfMGdDuTNJpGakPgBLiy0ay6FBmQ0LEaPSdRFeS+JNtkTqQ2e0b11gC5fS
+         lHhA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :mime-version:content-disposition;
+        bh=DPz95s72paZNhFzkhCmu5Co2WHEUgIjoRgB9imbXDeo=;
+        b=QeqwXbc7RcTsP3r0JpOYZMzFysfTlb0oH40S3h1LQn68iLbTA5qEDg9RKF0zc8zxGv
+         037aAXtxGL7yCY3yDLJv0Fmtbbfw7CV8A9hG73TayW8POYCYyQbzeAiSHEfSD6HjS2sp
+         2siat9WQza+oyVpRjF1bc+dr/a+2L97s9JX04Hv3UvcOB0XkUXlCzH2eOeyzFF/6Fp2Q
+         VOaxUVtR73Wj2e9IEaCxz1Ssg0VVsVsTaRh4Hs5OwqZm3TUTgC3xIz0U2+kcYpoZO8XR
+         ftTcTOP9c2ZXoTTVF1NFiHqC1ct31iRInlfQVUeZU918UWiAE84LC3q2aF4krgqH+jAV
+         2fZQ==
+X-Gm-Message-State: AOAM532917vUSn7ZJjPjTaQM0kwj5Kkg+mj61IDCIpZNLHKII2ybEjsg
+	mZQG5kTkYaZHfOb6s4NQ4f4ZelB/NbM=
+X-Google-Smtp-Source: ABdhPJxymRE2fMyZuBWxilRsv6/J66rbJWyL0qqetIRfxJvnaTUTn9AwJzs159Bjb6wyYYoG4R++9w==
+X-Received: by 2002:a05:651c:399:b0:24f:18d:5bbd with SMTP id e25-20020a05651c039900b0024f018d5bbdmr15972991ljp.481.1651753468442;
+        Thu, 05 May 2022 05:24:28 -0700 (PDT)
+Received: from localhost (h6.n.technopolis.lt. [194.157.155.165])
+        by smtp.gmail.com with ESMTPSA id k30-20020a0565123d9e00b0047255d2116asm198317lfv.153.2022.05.05.05.24.27
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Thu, 05 May 2022 05:24:27 -0700 (PDT)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Thu, 5 May 2022 15:24:25 +0300
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: bazel-zig-cc v0.7.1
+Message-ID: <20220505122425.ipd2p6kykd7iph7b@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Status: O
+Content-Length: 650
+Lines: 19
+
+Hi everyone,
+
+I just cut bazel-zig-cc v0.7.1, which adds a workaround for the infamous
+libc linking problem:
+
+    net(.text): relocation target __errno_location not defined
+    net(.text): relocation target getaddrinfo not defined
+    <...>
+
+Read about it, as well as related issues, in this github summary[1].
+Many thanks to Andrew Kelley and Ken Micklas for working on it!
+
+What is the cause? Because `zig cc` adds `--gc-sections` to the `ld.lld`
+flags, which does not play well with cgo. So the workaround adds
+`--no-gc-sections` to the linker flags for the time being.
+
+Motiejus
+
+[1]: https://github.com/ziglang/zig/pull/11577
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-pg1-f180.google.com (mail-pg1-f180.google.com [209.85.215.180])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 1CB2111EE04
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 17 May 2022 12:10:08 +0000 (UTC)
+Received: by mail-pg1-f180.google.com with SMTP id s68so231212pgb.13
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 17 May 2022 05:10:08 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:subject:message-id:mime-version
+         :content-disposition;
+        bh=IWaI4txxzUHCf/h00uDh3KfvJXVISgwnHPxQJz2ibfs=;
+        b=hUk9qnSPHnqyrA649fdnHmNzD1KYWH4fMC5iKz11VtaGHA/RUygB3BJEfHD5Oi//Rk
+         wxgyuAYJwr/TVaM0h59WgH+D+KdYYfCBJUO6FGzjt+9plpGcx472/jtd2J26zO1cePYI
+         vUD1YXTPYm8W87Ny+fb+uAggwd9gXZQQHRaPFcn27xeoYnunML+aQm96ZBtlkhscOZpm
+         H+7nQ/qGzeexY90t/P2tf970Ahpexdd5y2XXZyzeY+MZz4vkevUOwkg+aiO4hgsjISn9
+         m58jrnEMe6qPsD9q0UcGfMfaeD/Wv1m1C9jtSDrAv0c84dDUJVkUUpsKl0+1J3FBJ2A4
+         iplg==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:subject:message-id
+         :mime-version:content-disposition;
+        bh=IWaI4txxzUHCf/h00uDh3KfvJXVISgwnHPxQJz2ibfs=;
+        b=wIbUgTGC2YcCkUB9qFfBrMHKDlMWTurA6w+Dia70qOaHYuzmyQGWk/69k8WbLZb8N1
+         SA5y9MAVVzrXEGPSw4n+Lf84Aiccxk1jwVE6vRf4I+e1BD67QfiCwJZKpSVIrEaB5xWK
+         R5k+vlmCg4ZT03xOhgfDZOXu3FbIFmJUQoBkObOmu20elI+d/iwtZ8/BVBu6itZRX6uC
+         R681fw7R3XD5Mvn3XRupV+V3jduoknSyGnmkWxfXT5eHU+OxdlqDehtKz3HQF6nD1Xxl
+         +9CYsIMOmSmPYKZZ46TsgNUZF9E9/zAIcfoHfopsw3dEcce5A/bQMs7xAR2F/U7Ss2S4
+         fn3A==
+X-Gm-Message-State: AOAM532SuC4WNL5JVBOlC/qInJ4lDNki6O/NXhM3P7YLGWSVq12jYxM8
+	sL7fDNuSPX+WAknFIy36zaXvVmXZ2jU=
+X-Google-Smtp-Source: ABdhPJw1d1EB0C+hU/YWdovM+HwBDdL306zXpzTdd+Fv0nkRxrtXhqJPl2JIbmaSeIHlD2iDHVlMVw==
+X-Received: by 2002:a63:1b62:0:b0:3f2:5438:e553 with SMTP id b34-20020a631b62000000b003f25438e553mr11729797pgm.4.1652789406870;
+        Tue, 17 May 2022 05:10:06 -0700 (PDT)
+Received: from localhost (88-119-96-125.static.zebra.lt. [88.119.96.125])
+        by smtp.gmail.com with ESMTPSA id s10-20020a17090ae68a00b001da3920d985sm1502926pjy.12.2022.05.17.05.10.05
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Tue, 17 May 2022 05:10:06 -0700 (PDT)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Tue, 17 May 2022 15:10:02 +0300
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: bazel-zig-cc v0.7.2
+Message-ID: <20220517121002.f4tnfcmgvk4nwbxe@mtpad.i.jakstys.lt>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Status: O
+Content-Length: 500
+Lines: 14
+
+Hi all,
+
+It was a long time ago since the last Zig SDK update. I just released
+v0.7.2, which updates the zig to tonight's build
+zig-0.10.0-dev.2252+a4369918b, along with bazel-zig-cc's test
+dependencies (rules_go, bazel-gazelle, golang).
+
+Also, I removed many prehistorical zig-sdk versions from the
+dl.jakstys.lt mirror and left only the ones referenced by v0.7.1 and
+v0.7.2. If your build broke as a result, it's a good time to reconsider
+hosting zig sdk yourself.
+
+Regards,
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 2B1C411EEE1
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 20 May 2022 15:03:15 +0000 (UTC)
+From: Fabian Hahn <fabian@hahn.graphics>
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1653058987;
+	bh=WuiZ7bx3eBUnfp4Rd/cpDWbrJ2vFH6FtT4n1wRwaYCE=;
+	h=From:To:Cc:Subject;
+	b=jZdvefn6XZoUkBiHgUFQFi/ORKH0hSpl6MW78FxvJ5uwpvv5m9icZF3zbWeJvwLUP
+	 Bb2aPWb78td0ycMl+ZCvW3ZdCw08+dMNduegQZnryNBuGyjSvC+DUS7RCNPRYhDu3d
+	 vuMaTddVgNaHTTp6R3FBCAjpiuEqgmi9eedchEgc=
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Fabian Hahn <fabian@hahn.graphics>
+Subject: [PATCH bazel-zig-cc 0/3] Windows support
+Date: Fri, 20 May 2022 16:02:29 +0100
+Message-Id: <20220520150232.15515-1-fabian@hahn.graphics>
+Status: O
+Content-Length: 1604
+Lines: 39
+
+Hello there,
+
+First of all, thank you for this great project! I was always intrigued
+by zig's C/C++ compilation abilities but wasn't too keen on adopting it
+as a build system. Being able to use zig as a bazel toolchain using this
+project is incredible and exactly the way I always wanted to use zig.
+
+My intended use case for bazel-zig-cc was to enable cross compilation
+between the two supported platforms Linux and Windows in my project [1].
+To this end, I started looking into extending bazel-zig-cc with Windows
+support both as a host and target system. The attached three commits in
+made this work and successfully allowed me to cross compile all of my
+cc_binary targets between Linux and Windows using zig cc. That said,
+they do not actually depend on each other and can be used individually.
+I hope others might find them useful, too, and would like to ask you to
+consider accepting them into the mainline of the project.
+
+Best,
+Fabian
+
+[1] https://github.com/FabianHahn/shoveler
+
+Fabian Hahn (3):
+  added windows host support
+  added support for Windows targets
+  added platform constraint setting for selecting if zig cc is used
+
+ toolchain/BUILD.sdk.bazel           |  1 +
+ toolchain/defs.bzl                  | 58 +++++++++++++++++++++++------
+ toolchain/platform/BUILD            | 15 ++++++++
+ toolchain/platform/defs.bzl         |  8 +++-
+ toolchain/private/BUILD.sdk.bazel   |  1 +
+ toolchain/private/cc_toolchains.bzl |  6 +--
+ toolchain/private/defs.bzl          | 27 +++++++++++++-
+ 7 files changed, 99 insertions(+), 17 deletions(-)
+
+-- 
+2.17.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 6FE2611EEFC
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 20 May 2022 15:03:15 +0000 (UTC)
+From: Fabian Hahn <fabian@hahn.graphics>
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1653058987;
+	bh=M18VNogtyHCImW8/WKI5DKn27fgQ/L/hFUyDeVCjvPo=;
+	h=From:To:Cc:Subject:In-Reply-To:References;
+	b=Z+nrbSoBHrmUF6zWjz0RpE0+aDbrYMRKtNUZMcoEn82Dq775R2ycqRoqGJmo2ly7t
+	 zZ6zK+VTlfGykAd5BffWOtp3ofuWF8ZA3fkQoy9PIYLu/uyN4ZC+WVTSK+UznjkF6L
+	 qmP+nvSyd9Qe9ZttsqkfBoGT7V369XNjEoGClrBs=
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Fabian Hahn <fabian@hahn.graphics>
+Subject: [PATCH bazel-zig-cc 1/3] added windows host support
+Date: Fri, 20 May 2022 16:02:30 +0100
+Message-Id: <20220520150232.15515-2-fabian@hahn.graphics>
+In-Reply-To: <20220520150232.15515-1-fabian@hahn.graphics>
+References: <20220520150232.15515-1-fabian@hahn.graphics>
+Status: O
+Content-Length: 10516
+Lines: 262
+
+---
+This commit adds support for Windows as a host system. For example, given
+an existing bazel project on Windows, this commit enables cross
+compilation to other supported target platforms of bazel-zig-cc such as
+Linux. I've successfully used it to cross compile a Linux cc_binary from a
+Windows machine and validated that it works correctly by copying it to a
+Linux box and launching it there.
+
+Apart from downloading the correct zig SDK version on Windows, the main
+crux here was to actually make all of the zig tools properly executable.
+In order for the wrapper script to be executable, it needs to be a batch
+script with the proper extension instead of bash. Further, the actual
+zig binary itself is called zig.exe instead of just zig on Windows.
+
+ toolchain/BUILD.sdk.bazel           |  1 +
+ toolchain/defs.bzl                  | 58 +++++++++++++++++++++++------
+ toolchain/private/BUILD.sdk.bazel   |  1 +
+ toolchain/private/cc_toolchains.bzl |  6 +--
+ toolchain/private/defs.bzl          |  8 +++-
+ 5 files changed, 58 insertions(+), 16 deletions(-)
+
+diff --git a/toolchain/BUILD.sdk.bazel b/toolchain/BUILD.sdk.bazel
+index ada3e5d..e1505b1 100644
+--- a/toolchain/BUILD.sdk.bazel
++++ b/toolchain/BUILD.sdk.bazel
+@@ -7,6 +7,7 @@ package(
+ 
+ 
+ declare_files(
++    os = {os},
+     zig_include_root = {zig_include_root},
+ )
+ 
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 9ab4e88..d334aca 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -1,6 +1,6 @@
+ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_user_netrc", "use_netrc")
+-load("@bazel-zig-cc//toolchain/private:defs.bzl", "DEFAULT_INCLUDE_DIRECTORIES", "ZIG_TOOL_PATH", "target_structs")
++load("@bazel-zig-cc//toolchain/private:defs.bzl", "DEFAULT_INCLUDE_DIRECTORIES", "zig_tool_path", "target_structs")
+ 
+ _fcntl_map = """
+ GLIBC_2.2.5 {
+@@ -16,21 +16,21 @@ __asm__(".symver fcntl64, fcntl@GLIBC_2.2.5");
+ """
+ 
+ # Official recommended version. Should use this when we have a usable release.
+-URL_FORMAT_RELEASE = "https://ziglang.org/download/{version}/zig-{host_platform}-{version}.tar.xz"
++URL_FORMAT_RELEASE = "https://ziglang.org/download/{version}/zig-{host_platform}-{version}.{ext}"
+ 
+ # Caution: nightly releases are purged from ziglang.org after ~90 days. A real
+ # solution would be to allow the downstream project specify their own mirrors.
+ # This is explained in
+ # https://sr.ht/~motiejus/bazel-zig-cc/#alternative-download-urls and is
+ # awaiting my attention or your contribution.
+-URL_FORMAT_NIGHTLY = "https://ziglang.org/builds/zig-{host_platform}-{version}.tar.xz"
++URL_FORMAT_NIGHTLY = "https://ziglang.org/builds/zig-{host_platform}-{version}.{ext}"
+ 
+ # Author's mirror that doesn't purge the nightlies so aggressively. I will be
+ # cleaning those up manually only after the artifacts are not in use for many
+ # months in bazel-zig-cc. dl.jakstys.lt is a small x86_64 server with an NVMe
+ # drive sitting in my home closet on a 1GB/s symmetric residential connection,
+ # which, as of writing, has been quite reliable.
+-URL_FORMAT_JAKSTYS = "https://dl.jakstys.lt/zig/zig-{host_platform}-{version}.tar.xz"
++URL_FORMAT_JAKSTYS = "https://dl.jakstys.lt/zig/zig-{host_platform}-{version}.{ext}"
+ 
+ _VERSION = "0.10.0-dev.2252+a4369918b"
+ 
+@@ -39,12 +39,22 @@ _HOST_PLATFORM_SHA256 = {
+     "linux-x86_64": "1d3c3769eba85a4334c93a3cfa35ad0ef914dd8cf9fd502802004c6908f5370c",
+     "macos-aarch64": "ab46e7499e5bd7b6d6ff2ac331e1a4aa875a01b270dc40306bc29dbaf216fccf",
+     "macos-x86_64": "fb213f996bcab805839e401292c42a92b63cd97deb1631e31bd61f534b7f6b1c",
++    "windows-x86_64": "14e43a64026512161f3d6201d8972a28f0508da2782c16e980f2ffa3bb7e6720",
++}
++
++_HOST_PLATFORM_EXT = {
++    "linux-aarch64": "tar.xz",
++    "linux-x86_64": "tar.xz",
++    "macos-aarch64": "tar.xz",
++    "macos-x86_64": "tar.xz",
++    "windows-x86_64": "zip",
+ }
+ 
+ def toolchains(
+         version = _VERSION,
+         url_formats = [URL_FORMAT_NIGHTLY, URL_FORMAT_JAKSTYS],
+-        host_platform_sha256 = _HOST_PLATFORM_SHA256):
++        host_platform_sha256 = _HOST_PLATFORM_SHA256,
++        host_platform_ext = _HOST_PLATFORM_EXT):
+     """
+         Download zig toolchain and declare bazel toolchains.
+         The platforms are not registered automatically, that should be done by
+@@ -56,11 +66,13 @@ def toolchains(
+         version = version,
+         url_formats = url_formats,
+         host_platform_sha256 = host_platform_sha256,
++        host_platform_ext = host_platform_ext,
+         host_platform_include_root = {
+             "linux-aarch64": "lib/zig/",
+             "linux-x86_64": "lib/",
+             "macos-aarch64": "lib/zig/",
+             "macos-x86_64": "lib/zig/",
++            "windows-x86_64": "lib/",
+         },
+     )
+ 
+@@ -81,6 +93,10 @@ export ZIG_GLOBAL_CACHE_DIR=$ZIG_LOCAL_CACHE_DIR
+ exec "{zig}" "{zig_tool}" "$@"
+ """
+ 
++ZIG_TOOL_WRAPPER_WINDOWS = """@echo off
++"{zig}" "{zig_tool}" %*
++"""
++
+ _ZIG_TOOLS = [
+     "c++",
+     "cc",
+@@ -103,11 +119,16 @@ def _zig_repository_impl(repository_ctx):
+     if os.startswith("mac os"):
+         os = "macos"
+ 
++    if os.startswith("windows"):
++        os = "windows"
++
+     host_platform = "{}-{}".format(os, arch)
+ 
+     zig_include_root = repository_ctx.attr.host_platform_include_root[host_platform]
+     zig_sha256 = repository_ctx.attr.host_platform_sha256[host_platform]
++    zig_ext = repository_ctx.attr.host_platform_ext[host_platform]
+     format_vars = {
++        "ext": zig_ext,
+         "version": repository_ctx.attr.version,
+         "host_platform": host_platform,
+     }
+@@ -121,12 +142,19 @@ def _zig_repository_impl(repository_ctx):
+     )
+ 
+     for zig_tool in _ZIG_TOOLS:
+-        repository_ctx.file(
+-            ZIG_TOOL_PATH.format(zig_tool = zig_tool),
+-            ZIG_TOOL_WRAPPER.format(
+-                zig = str(repository_ctx.path("zig")),
++        zig_tool_wrapper = ZIG_TOOL_WRAPPER.format(
++            zig = str(repository_ctx.path("zig")),
++            zig_tool = zig_tool,
++        )
++        if os == "windows":
++            zig_tool_wrapper = ZIG_TOOL_WRAPPER_WINDOWS.format(
++                zig = str(repository_ctx.path("zig")).replace('/', '\\') + ".exe",
+                 zig_tool = zig_tool,
+-            ),
++            )
++
++        repository_ctx.file(
++            zig_tool_path(os).format(zig_tool = zig_tool),
++            zig_tool_wrapper,
+         )
+ 
+     repository_ctx.file(
+@@ -157,6 +185,7 @@ def _zig_repository_impl(repository_ctx):
+             executable = False,
+             substitutions = {
+                 "{absolute_path}": _quote(str(repository_ctx.path(""))),
++                "{os}": _quote(os),
+                 "{zig_include_root}": _quote(zig_include_root),
+             },
+         )
+@@ -167,6 +196,7 @@ zig_repository = repository_rule(
+         "host_platform_sha256": attr.string_dict(),
+         "url_formats": attr.string_list(allow_empty = False),
+         "host_platform_include_root": attr.string_dict(),
++        "host_platform_ext": attr.string_dict(),
+     },
+     implementation = _zig_repository_impl,
+ )
+@@ -175,9 +205,13 @@ def filegroup(name, **kwargs):
+     native.filegroup(name = name, **kwargs)
+     return ":" + name
+ 
+-def declare_files(zig_include_root):
++def declare_files(os, zig_include_root):
+     filegroup(name = "empty")
+-    native.exports_files(["zig"], visibility = ["//visibility:public"])
++    if os == "windows":
++        native.exports_files(["zig.exe"], visibility = ["//visibility:public"])
++        native.alias(name = "zig", actual = ":zig.exe")
++    else:
++        native.exports_files(["zig"], visibility = ["//visibility:public"])
+     filegroup(name = "lib/std", srcs = native.glob(["lib/std/**"]))
+ 
+     lazy_filegroups = {}
+diff --git a/toolchain/private/BUILD.sdk.bazel b/toolchain/private/BUILD.sdk.bazel
+index 39a6a93..3e7c23e 100644
+--- a/toolchain/private/BUILD.sdk.bazel
++++ b/toolchain/private/BUILD.sdk.bazel
+@@ -1,6 +1,7 @@
+ load("@bazel-zig-cc//toolchain/private:cc_toolchains.bzl", "declare_cc_toolchains")
+ 
+ declare_cc_toolchains(
++    os = {os},
+     absolute_path = {absolute_path},
+     zig_include_root = {zig_include_root},
+ )
+diff --git a/toolchain/private/cc_toolchains.bzl b/toolchain/private/cc_toolchains.bzl
+index 64e99f1..a0c7da0 100644
+--- a/toolchain/private/cc_toolchains.bzl
++++ b/toolchain/private/cc_toolchains.bzl
+@@ -1,4 +1,4 @@
+-load(":defs.bzl", "DEFAULT_INCLUDE_DIRECTORIES", "ZIG_TOOL_PATH", "target_structs")
++load(":defs.bzl", "DEFAULT_INCLUDE_DIRECTORIES", "zig_tool_path", "target_structs")
+ load("@bazel-zig-cc//toolchain:zig_toolchain.bzl", "zig_cc_toolchain_config")
+ 
+ DEFAULT_TOOL_PATHS = {
+@@ -11,7 +11,7 @@ DEFAULT_TOOL_PATHS = {
+     "strip": "/usr/bin/false",
+ }.items()
+ 
+-def declare_cc_toolchains(absolute_path, zig_include_root):
++def declare_cc_toolchains(os, absolute_path, zig_include_root):
+     for target_config in target_structs():
+         gotarget = target_config.gotarget
+         zigtarget = target_config.zigtarget
+@@ -28,7 +28,7 @@ def declare_cc_toolchains(absolute_path, zig_include_root):
+             if path[0] == "/":
+                 absolute_tool_paths[name] = path
+                 continue
+-            tool_path = ZIG_TOOL_PATH.format(zig_tool = path)
++            tool_path = zig_tool_path(os).format(zig_tool = path)
+             absolute_tool_paths[name] = "%s/%s" % (absolute_path, tool_path)
+ 
+         linkopts = target_config.linkopts
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+index 6059065..6804104 100644
+--- a/toolchain/private/defs.bzl
++++ b/toolchain/private/defs.bzl
+@@ -4,7 +4,7 @@ DEFAULT_INCLUDE_DIRECTORIES = [
+     "libcxxabi/include",
+ ]
+ 
+-ZIG_TOOL_PATH = "tools/{zig_tool}"
++_ZIG_TOOL_PATH = "tools/{zig_tool}"
+ 
+ # Zig supports even older glibcs than defined below, but we have tested only
+ # down to 2.17.
+@@ -30,6 +30,12 @@ _GLIBCS = [
+ 
+ LIBCS = ["musl"] + ["gnu.{}".format(glibc) for glibc in _GLIBCS]
+ 
++def zig_tool_path(os):
++    if os == "windows":
++        return _ZIG_TOOL_PATH + ".bat"
++    else:
++        return _ZIG_TOOL_PATH
++
+ def target_structs():
+     ret = []
+     for zigcpu, gocpu in (("x86_64", "amd64"), ("aarch64", "arm64")):
+-- 
+2.17.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 6BB9911EF8C
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 20 May 2022 15:03:16 +0000 (UTC)
+From: Fabian Hahn <fabian@hahn.graphics>
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1653058987;
+	bh=WZJtonkY6mfvO0efhXOOXo/ZME5GMA+oRkCH2uKaaQo=;
+	h=From:To:Cc:Subject:In-Reply-To:References;
+	b=cuL9Mm4St/jFVu4mhTXv40bFFT5F/3ACSwACloJcCYn22TWGsngPi33HO0w8W54uw
+	 4uqY2jBtwvQsGrBqG8XJ6Me1/9Jc0sBNQm1N++C6jLc2OJPRk7rBqENu3pHTdWg8d8
+	 AtSpdb1Y56XtoICP66NYxbP+DK9G6xa1dFYF5EYU=
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Fabian Hahn <fabian@hahn.graphics>
+Subject: [PATCH bazel-zig-cc 2/3] added support for Windows targets
+Date: Fri, 20 May 2022 16:02:31 +0100
+Message-Id: <20220520150232.15515-3-fabian@hahn.graphics>
+In-Reply-To: <20220520150232.15515-1-fabian@hahn.graphics>
+References: <20220520150232.15515-1-fabian@hahn.graphics>
+Status: O
+Content-Length: 3082
+Lines: 81
+
+---
+This commit adds support for Windows targets to bazel-zig-cc by
+registering the appropriate toolchains and platforms for it. I've
+validated this by building a cc_binary on Linux targeting
+the windows_amd64 platform/toolchain combination, copying the resulting
+binary to a Windows box and successfully executing it there. I was also
+able to run the resulting binary under wine.
+
+One thing to note is that even though cross compilation builds work
+completely fine, the resulting build outputs are named .a for static
+libraries (instead of .lib), .so for dynamic libraries (instead of
+.dll), and have no extension for executables (instead of .exe). I tried
+to find out why this is but unfortunately couldn't figure it out. That
+said, the resulting binaries work completely fine.
+
+ toolchain/platform/defs.bzl |  7 ++++++-
+ toolchain/private/defs.bzl  | 19 +++++++++++++++++++
+ 2 files changed, 25 insertions(+), 1 deletion(-)
+
+diff --git a/toolchain/platform/defs.bzl b/toolchain/platform/defs.bzl
+index cf42191..07e69a6 100644
+--- a/toolchain/platform/defs.bzl
++++ b/toolchain/platform/defs.bzl
+@@ -1,11 +1,16 @@
+ load("@bazel-zig-cc//toolchain/private:defs.bzl", "LIBCS")
+ 
+ _CPUS = (("x86_64", "amd64"), ("aarch64", "arm64"))
++_OS = {
++    "linux": ["linux"],
++    "macos": ["macos", "darwin"],
++    "windows": ["windows"],
++}
+ 
+ def declare_platforms():
+     # create @zig_sdk//{os}_{arch}_platform entries with zig and go conventions
+     for zigcpu, gocpu in _CPUS:
+-        for bzlos, oss in {"linux": ["linux"], "macos": ["macos", "darwin"]}.items():
++        for bzlos, oss in _OS.items():
+             for os in oss:
+                 declare_platform(gocpu, zigcpu, bzlos, os)
+ 
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+index 6804104..2ba61f7 100644
+--- a/toolchain/private/defs.bzl
++++ b/toolchain/private/defs.bzl
+@@ -40,6 +40,7 @@ def target_structs():
+     ret = []
+     for zigcpu, gocpu in (("x86_64", "amd64"), ("aarch64", "arm64")):
+         ret.append(_target_darwin(gocpu, zigcpu))
++        ret.append(_target_windows(gocpu, zigcpu))
+         ret.append(_target_linux_musl(gocpu, zigcpu))
+         for glibc in _GLIBCS:
+             ret.append(_target_linux_gnu(gocpu, zigcpu, glibc))
+@@ -69,6 +70,24 @@ def _target_darwin(gocpu, zigcpu):
+         tool_paths = {"ld": "ld64.lld"},
+     )
+ 
++def _target_windows(gocpu, zigcpu):
++    return struct(
++        gotarget = "windows_{}".format(gocpu),
++        zigtarget = "{}-windows-gnu".format(zigcpu),
++        includes = [
++            "libunwind/include",
++            "libc/include/any-windows-any",
++        ],
++        linkopts = [],
++        copts = [],
++        bazel_target_cpu = "x64_windows",
++        constraint_values = [
++            "@platforms//os:windows",
++            "@platforms//cpu:{}".format(zigcpu),
++        ],
++        tool_paths = {"ld": "ld64.lld"},
++    )
++
+ def _target_linux_gnu(gocpu, zigcpu, glibc_version):
+     glibc_suffix = "gnu.{}".format(glibc_version)
+ 
+-- 
+2.17.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 21BA211EEE1
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 20 May 2022 15:03:21 +0000 (UTC)
+From: Fabian Hahn <fabian@hahn.graphics>
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1653058987;
+	bh=1hc8pt5ADYckXmmdbUi2ZXn7H2S1yVLYeTI2hZhiaD4=;
+	h=From:To:Cc:Subject:In-Reply-To:References;
+	b=bXSn8NEfNw2YQI/C50iXZXvJMPS/lRoFLfT05y3LpzsvyWkYdgJUVuqTGDnL8H1Kq
+	 W0KSLQ2d+VMlbXIhFEhE+SlGiJGQMfHxZDLsWWeMmdm9j+vJtPBUFTzYCD+xHCtpu/
+	 gT4Glnq13cT1HcyWbt7qM2AAxDK7fyxM8JEbsBhI=
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Fabian Hahn <fabian@hahn.graphics>
+Subject: [PATCH bazel-zig-cc 3/3] added platform constraint setting for selecting if zig cc is used
+Date: Fri, 20 May 2022 16:02:32 +0100
+Message-Id: <20220520150232.15515-4-fabian@hahn.graphics>
+In-Reply-To: <20220520150232.15515-1-fabian@hahn.graphics>
+References: <20220520150232.15515-1-fabian@hahn.graphics>
+Status: O
+Content-Length: 2570
+Lines: 81
+
+---
+This commit adds a constraint_setting that can be used to select()
+between builds with and without zig cc. The reason I added this is
+because I found that selecting on @bazel_tools//platforms:windows is not
+enough for Windows builds since that constraint value alone will match
+both native builds using the MSVC compiler as well as builds using zig
+cc. The problem arises when passing custom compiler on linker flags that
+differ in syntax between MSVC and zig's clang format. For example, to
+link the gdi32 system library on Windows MSVC expects the argument
+"-DEFAULTLIB:gdi32.lib". However, with zig cc this needs to be "-lgdi32"
+instead. Having the additional constraint setting for the bazel-zig-cc
+platforms allows you to define more specific config settings such as:
+
+config_setting(
+    name = "windows",
+    constraint_values = [
+        "@bazel_tools//platforms:windows",
+        "@zig_sdk//platform:zig_cc_disabled",
+    ],
+)
+
+config_setting(
+    name = "windows_zig",
+    constraint_values = [
+        "@bazel_tools//platforms:windows",
+        "@zig_sdk//platform:zig_cc_enabled",
+    ],
+)
+
+This can then be used to switch between linker options as follows:
+cc_binary(
+    # [...]
+    linkopts = select({
+        ":windows": ["-DEFAULTLIB:gdi32.lib"],
+        ":windows_zig": ["-lgdi32"],
+    }),
+)
+
+ toolchain/platform/BUILD    | 15 +++++++++++++++
+ toolchain/platform/defs.bzl |  1 +
+ 2 files changed, 16 insertions(+)
+
+diff --git a/toolchain/platform/BUILD b/toolchain/platform/BUILD
+index f43b852..807ac3c 100644
+--- a/toolchain/platform/BUILD
++++ b/toolchain/platform/BUILD
+@@ -4,4 +4,19 @@ package(
+     default_visibility = ["//visibility:public"],
+ )
+ 
++constraint_setting(
++    name = "using_zig_cc",
++    default_constraint_value = "zig_cc_disabled",
++)
++
++constraint_value(
++    name = "zig_cc_disabled",
++    constraint_setting = "using_zig_cc",
++)
++
++constraint_value(
++    name = "zig_cc_enabled",
++    constraint_setting = "using_zig_cc",
++)
++
+ declare_platforms()
+diff --git a/toolchain/platform/defs.bzl b/toolchain/platform/defs.bzl
+index 07e69a6..05c0744 100644
+--- a/toolchain/platform/defs.bzl
++++ b/toolchain/platform/defs.bzl
+@@ -32,6 +32,7 @@ def declare_platform(gocpu, zigcpu, bzlos, os, suffix = "", extra_constraints =
+     constraint_values = [
+         "@platforms//os:{}".format(bzlos),
+         "@platforms//cpu:{}".format(zigcpu),
++        "@zig_sdk//platform:zig_cc_enabled",
+     ] + extra_constraints
+ 
+     native.platform(
+-- 
+2.17.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=nPs7mO//26/A4dat0ZQHrPvplq+tqK8f6RDslDMAXe8=;
+ c=simple/simple; d=sr.ht; h=Date:Cc:From:In-Reply-To:Subject:To;
+ q=dns/txt; s=srht; t=1653059791; v=1;
+ b=hesBOAENLh+/Q7g6faXp848hKQx0oVDnsNwfbAwOD65qE84CT34SFC6YTlDqHMR2huOG6kDM
+ eOaCz+dh9Smx/eL0Q2ooGj+wqMexgA0qJR772IocY/Sp1hAjEICFDeO5wKWOaGwJCrypQ8veIkC
+ zFXoODQOtMxs4IN4xx9DlPcgCOaEjVts/HOvo5Bujo5zUOtd7EJqOv+IZ2ZpmKZDRZj8CbarFhu
+ h3zGrWulZHOWSMvUeTpSlGjTaunXV7kInFD0XGBJrkV7ICdh+KdgjQ/8jX9UAZI2kf3a/sPekMq
+ 1RF5EPiygu96HFi1dlBzEAvWKh57KfPDhG9tnVKJ8IrGg==
+Received: from localhost (unknown [173.195.146.244])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id E9E2B11EE9A;
+	Fri, 20 May 2022 15:16:31 +0000 (UTC)
+MIME-Version: 1.0
+Date: Fri, 20 May 2022 15:16:31 +0000
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CK4OSGM2HOGL.FLUSLQ3ZKRTK@cirno2>
+In-Reply-To: <20220520150232.15515-4-fabian@hahn.graphics>
+Subject: [bazel-zig-cc/patches/.build.yml] build failed
+To: "Fabian Hahn" <fabian@hahn.graphics>
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 300
+Lines: 9
+
+bazel-zig-cc/patches/.build.yml: FAILED in 13m9s
+
+[Windows support][0] from [Fabian Hahn][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/32423
+[1]: mailto:fabian@hahn.graphics
+
+=E2=9C=97 #762646 FAILED bazel-zig-cc/patches/.build.yml https://builds.sr.=
+ht/~motiejus/job/762646
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lf1-f47.google.com (mail-lf1-f47.google.com [209.85.167.47])
+	by mail-b.sr.ht (Postfix) with ESMTPS id CDF6311EEB5
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat, 21 May 2022 12:56:32 +0000 (UTC)
+Received: by mail-lf1-f47.google.com with SMTP id br17so6132349lfb.2
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat, 21 May 2022 05:56:32 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:cc:subject:message-id:references:mime-version
+         :content-disposition:in-reply-to;
+        bh=ATnOdOSygYdGzkL8M7tYyFx6z7ujwjgOIQ4j81L2J5M=;
+        b=i7aI7xAyfLt68zB7AskVUupgnVfbcm+QTmVSfmZ8H/k6retDziOiJo6Pjj3nwgte/R
+         xmQPYhJozQDpwsKqr4sL3VjXT7p9YOBqPqdzc9/7HqCXt9h3Q51PhqJIexQBySoXFe6d
+         FqCouLLqJ+KUvA4m/nR+lL9JaJKPGT3ovX5UMQ/S2Lqdpg8mz39e4jzb7968wG0zzp3B
+         eiPjd2Qe4ALZawrnCjgTjAe8gxpVqlQFAuVXl1sHb2GrtBWAgCRR/dzf+Hx9PchGbUhW
+         RLuYYUwJHhhMM4cEPmO5+7qvtDhlyu/gbfN+sg68gaH9jWZf/53LgowfaonoI0y+uHvj
+         Zj0A==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:cc:subject:message-id
+         :references:mime-version:content-disposition:in-reply-to;
+        bh=ATnOdOSygYdGzkL8M7tYyFx6z7ujwjgOIQ4j81L2J5M=;
+        b=O4f6fbZh+jRHIrL1xuHdYkwue2WSll9cz73fwBnP8jWVY0pbl5/GP/appvJG4vYfj3
+         EW75Ynl1hmnTOdMveJYJsOx1Oy0yzRHFZmz0xK1G9nNfAmZ8SdEnV17YQPcZ82sCwTYn
+         ukxDvMQwXSqveAJx0zNiuC9NyqboxfPPCsqNGOUqnQ7sPb+GPXYktOg5EBHfSDaOdLBs
+         VuDWZx77CWBZNdenowY0ndfglKRf1uEnr3Lf4N74r4wfsbKM064TBZVp7hzyZEZWA79V
+         1nxUAlqL4HtTK2ZAw5WBGyURSZ48IgXRFo8yqgtCD1oOkwDJ8qsmL7LE063/82aHcV6e
+         Ye7Q==
+X-Gm-Message-State: AOAM5304zgsl6LWiGr8g5MRB5P6/1zfV8n3KB9X6DiDSt8BAIsnrZNvH
+	BDi3MdWM/P3UfFCs1czrdHU=
+X-Google-Smtp-Source: ABdhPJzBGnyF4lHpPw25PyxJIMSfq+LkXzhak+wzfn7jPZ4f/W8B2wdaJeK9G3s6tv+26eeuYozRFg==
+X-Received: by 2002:a05:6512:2607:b0:477:96ea:d387 with SMTP id bt7-20020a056512260700b0047796ead387mr10773156lfb.79.1653137790039;
+        Sat, 21 May 2022 05:56:30 -0700 (PDT)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id d18-20020a05651233d200b00477ce8cf243sm229392lfg.55.2022.05.21.05.56.29
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Sat, 21 May 2022 05:56:29 -0700 (PDT)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Sat, 21 May 2022 15:56:28 +0300
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: Fabian Hahn <fabian@hahn.graphics>, laurynasl@uber.com
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: Re: [PATCH bazel-zig-cc 0/3] Windows support
+Message-ID: <20220521125628.dqwgp3p6m6n76jdl@mtpad.i.jakstys.lt>
+References: <20220520150232.15515-1-fabian@hahn.graphics>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+In-Reply-To: <20220520150232.15515-1-fabian@hahn.graphics>
+Status: O
+Content-Length: 2068
+Lines: 52
+
+Hi Fabian,
+
+On Fri, May 20, 2022 at 04:02:29PM +0100, Fabian Hahn wrote:
+> Hello there,
+> 
+> First of all, thank you for this great project! I was always intrigued
+> by zig's C/C++ compilation abilities but wasn't too keen on adopting it
+> as a build system. Being able to use zig as a bazel toolchain using this
+> project is incredible and exactly the way I always wanted to use zig.
+> 
+> My intended use case for bazel-zig-cc was to enable cross compilation
+> between the two supported platforms Linux and Windows in my project [1].
+> To this end, I started looking into extending bazel-zig-cc with Windows
+> support both as a host and target system.
+
+Happy to see you are finding it useful!
+
+> The attached three commits in
+> made this work and successfully allowed me to cross compile all of my
+> cc_binary targets between Linux and Windows using zig cc. That said,
+> they do not actually depend on each other and can be used individually.
+> I hope others might find them useful, too, and would like to ask you to
+> consider accepting them into the mainline of the project.
+> 
+> [1] https://github.com/FabianHahn/shoveler
+
+I don't mind Windows support, as long as there is somebody to
+test and maintain it. Once we land this, that will be you. :)
+
+Since none of the bazel-zig-cc contributors are using Windows for
+development, we don't have means to test if we did not break something.
+So, until we can have a Windows CI, you will be on the hook to test it
+with new bazel-zig-cc releases.
+
+And until we are no sr.ht, there is no chance we will have Windows CI.
+Unless it can be run under Wine? Do you have appetite to try?
+
+Now regarding your patches:
+
+> Fabian Hahn (3):
+>   added windows host support
+>   added support for Windows targets
+
+The above look reasonable.
+
+>   added platform constraint setting for selecting if zig cc is used
+
+I am not sure about this. Laurynai, can you have a peek if this can't be
+expressed via a platform instead? This setting doesn't look right from a
+quick glimpse.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=uber.com header.i=@uber.com
+Received: from mail-yb1-f175.google.com (mail-yb1-f175.google.com [209.85.219.175])
+	by mail-b.sr.ht (Postfix) with ESMTPS id AD5A411EE06
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 23 May 2022 16:06:28 +0000 (UTC)
+Received: by mail-yb1-f175.google.com with SMTP id v71so26240013ybi.4
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 23 May 2022 09:06:28 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=uber.com; s=google;
+        h=mime-version:references:in-reply-to:from:date:message-id:subject:to
+         :cc;
+        bh=5vtryZ6xaAJdMUCozGtUCc3J9VCuSysaLwvwFMqlEug=;
+        b=NdYXjznI4y4wNjdv7b9l1wJujrRws7AVo9zNnavycg1xTwr8YVe2caSr6lSVfgWZ6g
+         hbo/2N8V0ZoONyQpqTA5kR7HzEdbKouR6l3D1ThcyAOE7biknV7UgMR9FeBZvTOq72Vq
+         lulqAIxgBxfXviIUQJYgtZFKjcAijbfe21+4I=
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:references:in-reply-to:from:date
+         :message-id:subject:to:cc;
+        bh=5vtryZ6xaAJdMUCozGtUCc3J9VCuSysaLwvwFMqlEug=;
+        b=2AFI/XV2Xgs7xAPhm0Nk4ixV7LLyb4OMqRyAhHuqQvmB8p07KtepT6mRN9ZLutFrfi
+         OvnXMYRybbqKgGHzPUyraf+xvICbBN8aZ0zxHcRCb7R2h6ZTxZfv641vHR7TSHq+Jx9L
+         9cR23dJvrLZ24GwMRBFux/DASu71glsuekMhBuAC8qJSxztfzjRKKNQfJdID+LZXjVdF
+         deI2XB7vdqKgZLRyAj/TiTqVTIGQQc0Y77RxDplWiYBFxMUVjprk6CXN9GQ+YhrpQl1w
+         iObxaRpdXRw1aQ7curgU+LMfy+uQvpgtXWMdd2RyeWOspRyh1lhK9ldj+fTTOta5syoS
+         wdrg==
+X-Gm-Message-State: AOAM533x2XFDW2TgMjI3pASV2wae0EINry54Brea38F8O4U17wpN+wLb
+	4pNPZcir8aBwK/NLzhszeNJ0eA3u56uUiIELnE59WS3zFDc8XbRbdd70zaeaqb9bW32/zeuEj9p
+	IB13sYC/LG9x6CiGUJBNO4FMEgT8l8AiYVUPszZCOJ1J71wtVeq9j/vuw4c4pqL7UYHUU8MSq7Q
+	TlRNjga1tnXhj/AI5teUZeig0JfY8Q9SylomBR98BKsU1b9ezpUQ910mo=
+X-Google-Smtp-Source: ABdhPJx7y7w0s+5ARFWmVIuDSzpv783GnlOYcMmKzID70ZNnxhwz9p3eqGCBS2RCJTzA3YR5CgpMBF+W9iK5Y+071eg=
+X-Received: by 2002:a25:3891:0:b0:64d:68b1:c455 with SMTP id
+ f139-20020a253891000000b0064d68b1c455mr21792810yba.400.1653321987747; Mon, 23
+ May 2022 09:06:27 -0700 (PDT)
+MIME-Version: 1.0
+References: <20220520150232.15515-1-fabian@hahn.graphics> <20220520150232.15515-4-fabian@hahn.graphics>
+In-Reply-To: <20220520150232.15515-4-fabian@hahn.graphics>
+From: Laurynas Lubys <laurynasl@uber.com>
+Date: Mon, 23 May 2022 19:06:16 +0300
+Message-ID: <CAG09j49GZxNQJJZX5a5wZ0f12VPzfWqbLmzEfTKfS4KvwvwPtg@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc 3/3] added platform constraint setting for
+ selecting if zig cc is used
+To: Fabian Hahn <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 3434
+Lines: 99
+
+Hi Fabian,
+
+While I see your use case, I think the solution you outlined is a bit
+too invasive for the problem you raised. I would prefer bazel-zig-cc
+to only deal with terms related to zig-cc and not other compilers.
+
+Here's how you could solve this bit without changes in bazel-zig-cc:
+1. Define the `constraint_value`s in your project
+2. Define a custom platform (e.g. windows_msvc and windows_zig),
+specifying the bazel-zig-cc platform in the `parents` field and adding
+the `constraint_values` from step 1 accordingly.
+3. Use your custom platforms instead of the ones from bazel-zig-cc directly.
+
+Cheers,
+Laurynas
+
+On Fri, May 20, 2022 at 6:03 PM Fabian Hahn <fabian@hahn.graphics> wrote:
+>
+> ---
+> This commit adds a constraint_setting that can be used to select()
+> between builds with and without zig cc. The reason I added this is
+> because I found that selecting on @bazel_tools//platforms:windows is not
+> enough for Windows builds since that constraint value alone will match
+> both native builds using the MSVC compiler as well as builds using zig
+> cc. The problem arises when passing custom compiler on linker flags that
+> differ in syntax between MSVC and zig's clang format. For example, to
+> link the gdi32 system library on Windows MSVC expects the argument
+> "-DEFAULTLIB:gdi32.lib". However, with zig cc this needs to be "-lgdi32"
+> instead. Having the additional constraint setting for the bazel-zig-cc
+> platforms allows you to define more specific config settings such as:
+>
+> config_setting(
+>     name = "windows",
+>     constraint_values = [
+>         "@bazel_tools//platforms:windows",
+>         "@zig_sdk//platform:zig_cc_disabled",
+>     ],
+> )
+>
+> config_setting(
+>     name = "windows_zig",
+>     constraint_values = [
+>         "@bazel_tools//platforms:windows",
+>         "@zig_sdk//platform:zig_cc_enabled",
+>     ],
+> )
+>
+> This can then be used to switch between linker options as follows:
+> cc_binary(
+>     # [...]
+>     linkopts = select({
+>         ":windows": ["-DEFAULTLIB:gdi32.lib"],
+>         ":windows_zig": ["-lgdi32"],
+>     }),
+> )
+>
+>  toolchain/platform/BUILD    | 15 +++++++++++++++
+>  toolchain/platform/defs.bzl |  1 +
+>  2 files changed, 16 insertions(+)
+>
+> diff --git a/toolchain/platform/BUILD b/toolchain/platform/BUILD
+> index f43b852..807ac3c 100644
+> --- a/toolchain/platform/BUILD
+> +++ b/toolchain/platform/BUILD
+> @@ -4,4 +4,19 @@ package(
+>      default_visibility = ["//visibility:public"],
+>  )
+>
+> +constraint_setting(
+> +    name = "using_zig_cc",
+> +    default_constraint_value = "zig_cc_disabled",
+> +)
+> +
+> +constraint_value(
+> +    name = "zig_cc_disabled",
+> +    constraint_setting = "using_zig_cc",
+> +)
+> +
+> +constraint_value(
+> +    name = "zig_cc_enabled",
+> +    constraint_setting = "using_zig_cc",
+> +)
+> +
+>  declare_platforms()
+> diff --git a/toolchain/platform/defs.bzl b/toolchain/platform/defs.bzl
+> index 07e69a6..05c0744 100644
+> --- a/toolchain/platform/defs.bzl
+> +++ b/toolchain/platform/defs.bzl
+> @@ -32,6 +32,7 @@ def declare_platform(gocpu, zigcpu, bzlos, os, suffix = "", extra_constraints =
+>      constraint_values = [
+>          "@platforms//os:{}".format(bzlos),
+>          "@platforms//cpu:{}".format(zigcpu),
+> +        "@zig_sdk//platform:zig_cc_enabled",
+>      ] + extra_constraints
+>
+>      native.platform(
+> --
+> 2.17.1
+>
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id C52A811F09B
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 23 May 2022 19:25:17 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1653333912;
+	bh=lTpCQBPmFHy+ZrUZuVb8dj7xFPM6sEfKSthpoDrfgVM=;
+	h=From:To:Cc:Subject:In-Reply-To:References;
+	b=aPSMQDR/e7O9D5SlGFAdEeaTCPXjrUbPUIQMqsqHaQAiuKCLnyxLcVZJ6R6Q9zjO7
+	 Zh54WL+w7V//Smv/UzmfSq1B/Mp8IUR7zaqgJVVU0EYWFmrweobFCmdt9SPbbJOKoG
+	 8/s6VxrJwvwOnfCcKN532EfRkh88OWOyVPk6KDuA=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8;
+ format=flowed
+Content-Transfer-Encoding: 8bit
+Date: Mon, 23 May 2022 20:25:05 +0100
+From: fabian@hahn.graphics
+To: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Cc: laurynasl@uber.com, ~motiejus/bazel-zig-cc@lists.sr.ht, =?UTF-8?Q?Mot?=
+ =?UTF-8?Q?iejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Subject: Re: [PATCH bazel-zig-cc 0/3] Windows support
+In-Reply-To: <20220521125628.dqwgp3p6m6n76jdl@mtpad.i.jakstys.lt>
+References: <20220520150232.15515-1-fabian@hahn.graphics>
+ <20220521125628.dqwgp3p6m6n76jdl@mtpad.i.jakstys.lt>
+Message-ID: <4f67edd521daf91a7230b16e69275175@hahn.graphics>
+X-Sender: fabian@hahn.graphics
+Status: O
+Content-Length: 1602
+Lines: 40
+
+Hi Motiejus,
+
+On 2022-05-21 13:56, Motiejus Jakštys wrote:
+> I don't mind Windows support, as long as there is somebody to
+> test and maintain it. Once we land this, that will be you. :)
+> 
+> Since none of the bazel-zig-cc contributors are using Windows for
+> development, we don't have means to test if we did not break something.
+> So, until we can have a Windows CI, you will be on the hook to test it
+> with new bazel-zig-cc releases.
+
+I'm happy to try doing this. I'm definitely interested in keeping my own
+project up to date with new releases of the rules too, which should
+provide some implicit coverage.
+
+> And until we are no sr.ht, there is no chance we will have Windows CI.
+> Unless it can be run under Wine? Do you have appetite to try?
+
+I will look into this. I'm pretty confident that the Windows target
+support (second patch) can be covered by wine testing. I'm more 
+sceptical
+about Windows host support, since you'd have to run Windows bazel itself
+under Wine which I'm not sure is supported and might not work.
+
+> I am not sure about this. Laurynai, can you have a peek if this can't 
+> be
+> expressed via a platform instead? This setting doesn't look right from 
+> a
+> quick glimpse.
+
+I'll look into Laurynai's suggestion of using a custom platform for 
+this.
+I'm by no means a bazel expert so this patch was the best I could get
+working, and I'm very happy to try a better solution if there is one.
+
+I'll submit a second version of the patch set once I've done this. There
+is also a linter failure that I'm going to address.
+
+Best,
+Fabian
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 8C2C111F09B
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 23 May 2022 19:28:34 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1653334112;
+	bh=mFg1KSkQZ/dKgcivF4eqbD1A5iBLIQCRG7Lzu21191I=;
+	h=From:To:Cc:Subject:In-Reply-To:References;
+	b=Du4GKYLAgXGhf6hRDpe6kbgXMqLrT+hd/jakz1gq4lWpGTdCfXn72xEJ97dIrVl7W
+	 cWP5MM8U1odYTK1pXrI9ZkRn5LTXmTJAlkLpDNmNB36Elj/V1pd2rQk8R9A++zH24c
+	 s0VanF4JWRkc4vqaLObZe4g74ygSiJO1LkANDdZY=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=US-ASCII;
+ format=flowed
+Content-Transfer-Encoding: 7bit
+Date: Mon, 23 May 2022 20:28:32 +0100
+From: fabian@hahn.graphics
+To: Laurynas Lubys <laurynasl@uber.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: Re: [PATCH bazel-zig-cc 3/3] added platform constraint setting for
+ selecting if zig cc is used
+In-Reply-To: <CAG09j49GZxNQJJZX5a5wZ0f12VPzfWqbLmzEfTKfS4KvwvwPtg@mail.gmail.com>
+References: <20220520150232.15515-1-fabian@hahn.graphics>
+ <20220520150232.15515-4-fabian@hahn.graphics>
+ <CAG09j49GZxNQJJZX5a5wZ0f12VPzfWqbLmzEfTKfS4KvwvwPtg@mail.gmail.com>
+Message-ID: <17e9d6378e74647834146edf5ca400c8@hahn.graphics>
+X-Sender: fabian@hahn.graphics
+Status: O
+Content-Length: 596
+Lines: 16
+
+Hi Laurynas,
+
+On 2022-05-23 17:06, Laurynas Lubys wrote:
+> Here's how you could solve this bit without changes in bazel-zig-cc:
+> 1. Define the `constraint_value`s in your project
+> 2. Define a custom platform (e.g. windows_msvc and windows_zig),
+> specifying the bazel-zig-cc platform in the `parents` field and adding
+> the `constraint_values` from step 1 accordingly.
+> 3. Use your custom platforms instead of the ones from bazel-zig-cc 
+> directly.
+
+Thanks a lot for the pointers, I didn't realize that defining a custom
+platform could help here. I'll try this.
+
+Best,
+Fabian
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-pl1-f174.google.com (mail-pl1-f174.google.com [209.85.214.174])
+	by mail-b.sr.ht (Postfix) with ESMTPS id AEECB11EF44
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 24 May 2022 07:54:41 +0000 (UTC)
+Received: by mail-pl1-f174.google.com with SMTP id n18so15197451plg.5
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 24 May 2022 00:54:41 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:cc:subject:message-id:references:mime-version
+         :content-disposition:content-transfer-encoding:in-reply-to;
+        bh=u9URII2FSPSfQdXcqCVRfJ9UATexSKFU4WWZGQOrURU=;
+        b=GVmGMeUlvUqru+iomkPHxo5celoyu4+SfLM5BilzySyJrd+ECWceb2PDB0FzxGng3Q
+         cz1/n2ITO3gpRy9Spe68yEnCDsEC11dIBRZMFEWkZJdbry9jYC253mXF6aGaBgPkPgB9
+         LxfrG8DM/E5yntkovS6sbt7P1WA3ILfO4p0rTj5AtI2ZzaIF2BX/wwUzSCMJOiA6DoMX
+         Uj7VRhH+l3VT/UzY7nxLTdmDlhjjWigxAwFdNpRdCm/wVmvSue+LVYnzzbqBactlxoH2
+         cREplS4u8hzs43acQLFn9eJ0Kp3si49xcRFQR/M57ucvNyk122N85fakwqDYgYT0BI9v
+         Z4tQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:cc:subject:message-id
+         :references:mime-version:content-disposition
+         :content-transfer-encoding:in-reply-to;
+        bh=u9URII2FSPSfQdXcqCVRfJ9UATexSKFU4WWZGQOrURU=;
+        b=7sA41G17p81NhXyVaTC8yUKznPinSP2/SXUb/fQ6matlEUL1+O4UBKUN+E8I67Nund
+         NEnCCmHP80A95nDo6kCRMJQ62boYXhbf9BgpTvRvchE6FHGPVrlMsz/YwXwzzUcBro2C
+         w+HWOGafeRom7LhpPp3ace1P4B+p6gZvWVK4Pf/ibAEQxWq3RiTiYlCyyAGhTOa9+I2A
+         G/4MBhu3lBy+ARkPFqurQOuJealxiqYMVc96CWMbaqFGtYVybq47zgHd1QTD0mck3dR4
+         g5+F6MPjCeg8SYhxVK4f42TkchaHkY2dEOcOX7ij03O0FV+ty6wnSzWVz+vLWr5o4Y1t
+         it1g==
+X-Gm-Message-State: AOAM531qrFJclaGtXWrAQNR7zkRSaoTHg1kbGvxJ8BCEitE+tMi4zpjt
+	giBuxWI1LdhBdmb4jlEOMgg=
+X-Google-Smtp-Source: ABdhPJzznTq6anEeeDNHGYXk190BspOLx8ffO69B1QyHnec3aW1WsE/sqdtTmyHGsYY19ikjSxe/gg==
+X-Received: by 2002:a17:90a:e7d2:b0:1e0:237:d3fe with SMTP id kb18-20020a17090ae7d200b001e00237d3femr3439782pjb.50.1653378879363;
+        Tue, 24 May 2022 00:54:39 -0700 (PDT)
+Received: from localhost (88-119-96-125.static.zebra.lt. [88.119.96.125])
+        by smtp.gmail.com with ESMTPSA id b6-20020a170902a9c600b001624dab05edsm429711plr.8.2022.05.24.00.54.38
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Tue, 24 May 2022 00:54:38 -0700 (PDT)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Tue, 24 May 2022 10:54:34 +0300
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: fabian@hahn.graphics
+Cc: laurynasl@uber.com, ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: Re: [PATCH bazel-zig-cc 0/3] Windows support
+Message-ID: <20220524075434.wsgc4xy3u5gw4qpc@mtpad.i.jakstys.lt>
+References: <20220520150232.15515-1-fabian@hahn.graphics>
+ <20220521125628.dqwgp3p6m6n76jdl@mtpad.i.jakstys.lt>
+ <4f67edd521daf91a7230b16e69275175@hahn.graphics>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Content-Transfer-Encoding: 8bit
+In-Reply-To: <4f67edd521daf91a7230b16e69275175@hahn.graphics>
+Status: O
+Content-Length: 1141
+Lines: 25
+
+On Mon, May 23, 2022 at 08:25:05PM +0100, fabian@hahn.graphics wrote:
+> Hi Motiejus,
+> 
+> On 2022-05-21 13:56, Motiejus Jakštys wrote:
+> > And until we are no sr.ht, there is no chance we will have Windows CI.
+> > Unless it can be run under Wine? Do you have appetite to try?
+> 
+> I will look into this. I'm pretty confident that the Windows target
+> support (second patch) can be covered by wine testing. I'm more sceptical
+> about Windows host support, since you'd have to run Windows bazel itself
+> under Wine which I'm not sure is supported and might not work.
+
+Out of curiosity I applied your patches, downloaded bazelisk.exe, and
+tried to run it via wine, to be greeted with:
+
+    $ wine ./bin/bazelisk.exe query ...
+    ERROR: SymlinkDirectories(C:/users/motiejus/_bazel_motiejus/install/5f8090d9a86a5bdc9afbbd92e4f1b167,
+        c:\users\motiejus\_bazel_motiejus\n3lawf4n\install): CreateJunction: 
+    FATAL: failed to create installation symlink 'c:\users\motiejus\_bazel_motiejus\n3lawf4n\install': success
+
+... And no obvious suggestions from my favorite search engine.
+
+At least we tried. :)
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id ED42B11F0BD;
+	Wed, 25 May 2022 01:41:49 +0000 (UTC)
+From: ~jvolkman <jvolkman@git.sr.ht>
+Date: Wed, 25 May 2022 01:41:49 +0000
+Subject: [PATCH bazel-zig-cc 0/2] Ignore undefined symbols when building
+ dynamic libraries on darwin
+MIME-Version: 1.0
+Message-ID: <165344290967.21743.14923213680999840378-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~jvolkman <jeremy@jvolkman.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: jeremy@jvolkman.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 1488
+Lines: 37
+
+Hi,
+
+I'm working on a rule set to build Python modules using bazel cc
+toolchains, and found that with bazel-zig-cc, I'm unable to build native
+modules on macos. The issue turns out to be differences in handling
+undefined symbols at link time in linux vs. macos. When building for a
+linux target, zig ignores undefined symbols, but for macos they generate
+errors. In the case of Python, native modules never link against
+libpython. Instead, its symbols are provided when the module is loaded
+by the cpython interpreter (at least that's my understanding).
+
+See some discussion of this at
+https://github.com/ziglang/zig/issues/8180.
+
+This change adds dynamic_library_linkopts to zig_cc_toolchain_config
+which apply only to the cpp_link_dynamic_library and
+cpp_link_nodeps_dynamic_library. For darwin targets, I specify the
+-Wl,-undefined=3Ddynamic_lookup flag. This logic is adapted from bazel's
+built-in macos toolchain [1].
+
+Thanks!
+
+[1]
+https://cs.github.com/bazelbuild/bazel/blob/ca40a514b8bc609478f769194909dd0be=
+0afa1f9/tools/osx/crosstool/cc_toolchain_config.bzl#L1125-L1131
+
+Jeremy Volkman (2):
+  Adds dynamic_library_linkopts to zig_cc_toolchain_config
+  Pass "-Wl,-undefined=3Ddynamic_lookup" for dynamic libraries on darwin.
+
+ toolchain/private/cc_toolchains.bzl |  2 ++
+ toolchain/private/defs.bzl          |  3 +++
+ toolchain/zig_toolchain.bzl         | 17 ++++++++++++++---
+ 3 files changed, 19 insertions(+), 3 deletions(-)
+
+--=20
+2.34.2
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 14A7D11F105;
+	Wed, 25 May 2022 01:41:50 +0000 (UTC)
+From: ~jvolkman <jvolkman@git.sr.ht>
+Date: Tue, 24 May 2022 17:14:35 -0700
+Subject: [PATCH bazel-zig-cc 1/2] Adds dynamic_library_linkopts to
+ zig_cc_toolchain_config
+Message-ID: <165344290967.21743.14923213680999840378-1@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~jvolkman <jeremy@jvolkman.com>
+In-Reply-To: <165344290967.21743.14923213680999840378-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: jeremy@jvolkman.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 4617
+Lines: 118
+
+From: Jeremy Volkman <jeremy@jvolkman.com>
+
+If specified, the flags in dynamic_library_linkopts are included in
+cpp_link_dynamic_library and cpp_link_nodeps_dynamic_library actions.
+---
+ toolchain/private/cc_toolchains.bzl |  2 ++
+ toolchain/private/defs.bzl          |  3 +++
+ toolchain/zig_toolchain.bzl         | 17 ++++++++++++++---
+ 3 files changed, 19 insertions(+), 3 deletions(-)
+
+diff --git a/toolchain/private/cc_toolchains.bzl b/toolchain/private/cc_toolc=
+hains.bzl
+index 64e99f1..3a1e1cb 100644
+--- a/toolchain/private/cc_toolchains.bzl
++++ b/toolchain/private/cc_toolchains.bzl
+@@ -32,6 +32,7 @@ def declare_cc_toolchains(absolute_path, zig_include_root):
+             absolute_tool_paths[name] =3D "%s/%s" % (absolute_path, tool_pat=
+h)
+=20
+         linkopts =3D target_config.linkopts
++        dynamic_library_linkopts =3D target_config.dynamic_library_linkopts
+         copts =3D target_config.copts
+         for s in getattr(target_config, "linker_version_scripts", []):
+             linkopts =3D linkopts + ["-Wl,--version-script,%s/%s" % (absolut=
+e_path, s)]
+@@ -45,6 +46,7 @@ def declare_cc_toolchains(absolute_path, zig_include_root):
+             cxx_builtin_include_directories =3D cxx_builtin_include_director=
+ies,
+             copts =3D copts,
+             linkopts =3D linkopts,
++            dynamic_library_linkopts =3D dynamic_library_linkopts,
+             target_cpu =3D target_config.bazel_target_cpu,
+             target_system_name =3D "unknown",
+             target_libc =3D "unknown",
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+index 6059065..053641c 100644
+--- a/toolchain/private/defs.bzl
++++ b/toolchain/private/defs.bzl
+@@ -54,6 +54,7 @@ def _target_darwin(gocpu, zigcpu):
+             "libc/include/any-macos-any",
+         ],
+         linkopts =3D [],
++        dynamic_library_linkopts =3D [],
+         copts =3D [],
+         bazel_target_cpu =3D "darwin",
+         constraint_values =3D [
+@@ -84,6 +85,7 @@ def _target_linux_gnu(gocpu, zigcpu, glibc_version):
+         compiler_extra_includes =3D ["glibc-hacks/glibchack-fcntl.h"] if fcn=
+tl_hack else [],
+         linker_version_scripts =3D ["glibc-hacks/fcntl.map"] if fcntl_hack e=
+lse [],
+         linkopts =3D ["-lc++", "-lc++abi"],
++        dynamic_library_linkopts =3D [],
+         copts =3D [],
+         bazel_target_cpu =3D "k8",
+         constraint_values =3D [
+@@ -105,6 +107,7 @@ def _target_linux_musl(gocpu, zigcpu):
+             "libc/include/{}-linux-any".format(zigcpu),
+         ] + (["libc/include/x86-linux-any"] if zigcpu =3D=3D "x86_64" else [=
+]),
+         linkopts =3D ["-s", "-w"],
++        dynamic_library_linkopts =3D [],
+         copts =3D ["-D_LIBCPP_HAS_MUSL_LIBC", "-D_LIBCPP_HAS_THREAD_API_PTHR=
+EAD"],
+         bazel_target_cpu =3D "k8",
+         constraint_values =3D [
+diff --git a/toolchain/zig_toolchain.bzl b/toolchain/zig_toolchain.bzl
+index aa14ec1..8676471 100644
+--- a/toolchain/zig_toolchain.bzl
++++ b/toolchain/zig_toolchain.bzl
+@@ -14,6 +14,11 @@ all_link_actions =3D [
+     ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+ ]
+=20
++dynamic_library_link_actions =3D [
++    ACTION_NAMES.cpp_link_dynamic_library,
++    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
++]
++
+ compile_and_link_actions =3D [
+     ACTION_NAMES.c_compile,
+     ACTION_NAMES.cpp_compile,
+@@ -79,15 +84,20 @@ def _zig_cc_toolchain_config_impl(ctx):
+         flag_sets =3D [
+             flag_set(
+                 actions =3D all_link_actions,
+-                flag_groups =3D ([
++                flag_groups =3D [
+                     flag_group(
+                         flags =3D ["-target", ctx.attr.target] +
+                                 no_gc_sections +
+                                 ctx.attr.linkopts,
+                     ),
+-                ]),
++                ],
+             ),
+-        ],
++        ] + [
++            flag_set(
++                actions =3D dynamic_library_link_actions,
++                flag_groups =3D [flag_group(flags =3D ctx.attr.dynamic_libra=
+ry_linkopts)],
++            ),
++        ] if ctx.attr.dynamic_library_linkopts else [],
+     )
+=20
+     features =3D [
+@@ -119,6 +129,7 @@ zig_cc_toolchain_config =3D rule(
+     attrs =3D {
+         "cxx_builtin_include_directories": attr.string_list(),
+         "linkopts": attr.string_list(),
++        "dynamic_library_linkopts": attr.string_list(),
+         "copts": attr.string_list(),
+         "tool_paths": attr.string_dict(),
+         "target": attr.string(),
+--=20
+2.34.2
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 3160A11F117;
+	Wed, 25 May 2022 01:41:50 +0000 (UTC)
+From: ~jvolkman <jvolkman@git.sr.ht>
+Date: Tue, 24 May 2022 17:17:33 -0700
+Subject: [PATCH bazel-zig-cc 2/2] Pass "-Wl,-undefined=dynamic_lookup" for
+ dynamic libraries on darwin.
+Message-ID: <165344290967.21743.14923213680999840378-2@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~jvolkman <jeremy@jvolkman.com>
+In-Reply-To: <165344290967.21743.14923213680999840378-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: jeremy@jvolkman.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+MIME-Version: 1.0
+Status: O
+Content-Length: 920
+Lines: 25
+
+From: Jeremy Volkman <jeremy@jvolkman.com>
+
+This linker flag causes undefined symbols to be ignored, which is the
+default behavior on linux but not macos. This is required when building
+shared libraries to use as e.g. Python modules. This also matches what
+Bazel's built-in macos cc toolchain does.
+---
+ toolchain/private/defs.bzl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+index 053641c..42aaaeb 100644
+--- a/toolchain/private/defs.bzl
++++ b/toolchain/private/defs.bzl
+@@ -54,7 +54,7 @@ def _target_darwin(gocpu, zigcpu):
+             "libc/include/any-macos-any",
+         ],
+         linkopts = [],
+-        dynamic_library_linkopts = [],
++        dynamic_library_linkopts = ["-Wl,-undefined=dynamic_lookup"],
+         copts = [],
+         bazel_target_cpu = "darwin",
+         constraint_values = [
+-- 
+2.34.2
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=uve8fTCVpt6Gdf7uz7dBrgAhQF80SbAq3lissg6dG5s=;
+ c=simple/simple; d=sr.ht; h=Date:Subject:To:Cc:From:In-Reply-To;
+ q=dns/txt; s=srht; t=1653443104; v=1;
+ b=cpLSLwkb+0IZpY2maPGAimHdV25W4rn/HTM4gezdDhYy6Nz7vadHsTrn9mV8JAVcwYwz8ldt
+ aqaqClVgWHoYO0y1zYPX0li98UJhUOXHG/7kaW1N13umGN39hYYSedf4AFnsO7a8IqtyGF2FmYP
+ roDtGyAxo5VKvOxEMGlfm/FJQh+7jsz8TmDDpE++0WCcLSnE9PJxgmZXCoCj52p7n7c7G//nnG4
+ hxIdUr3cSsY3MH4T3mJqRq+9pt9CS1bd4KxxIMaLwkaYuREt/GBSA6Jk91wXI+aDisIa7FHuRdb
+ Fd0XbdUmqapSf27k+cOtoQ75iAxy+pbLmsTHDVR6e6r2A==
+Received: from localhost (unknown [173.195.146.249])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id 5939611F028;
+	Wed, 25 May 2022 01:45:04 +0000 (UTC)
+MIME-Version: 1.0
+Date: Wed, 25 May 2022 01:45:04 +0000
+Subject: [bazel-zig-cc/patches/.build.yml] build failed
+To: "~jvolkman" <jeremy@jvolkman.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CK8GNVX9K24M.2M83AAZ0IL6QY@cirno>
+In-Reply-To: <165344290967.21743.14923213680999840378-2@git.sr.ht>
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 351
+Lines: 10
+
+bazel-zig-cc/patches/.build.yml: FAILED in 3m12s
+
+[Ignore undefined symbols when building dynamic libraries on darwin][0] fro=
+m [~jvolkman][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/32501
+[1]: mailto:jeremy@jvolkman.com
+
+=E2=9C=97 #765889 FAILED bazel-zig-cc/patches/.build.yml https://builds.sr.=
+ht/~motiejus/job/765889
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lj1-f179.google.com (mail-lj1-f179.google.com [209.85.208.179])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 21B9D11EF1E
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 25 May 2022 02:50:15 +0000 (UTC)
+Received: by mail-lj1-f179.google.com with SMTP id 1so9638526ljh.8
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 24 May 2022 19:50:15 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=sender:date:from:to:cc:subject:message-id:references:mime-version
+         :content-disposition:in-reply-to;
+        bh=M6ImvImR96Ds5NBcNS9eiuyRYKVOS/7aVSKKI29NR2k=;
+        b=Ss+a+fbmnRGRan6UWhJmEEi491HAFVW++yLowAvSp+eAwe3G1kYbLYatI15eFhRlBO
+         6MYVXA+DWC6ou5hN9zvcpKHefSTVSFf9gtk5CGY4UCNc4Pm970snnLoeTKhLfbZtiFvu
+         Xa02mFESqtfYQe1d/CDjyUmFRjq+IEhfjfzlWtCLTG6onEgNleUJXoPag6e5CErgbVn3
+         apY/8HCyqI8Rcd0fdZI2D12XC8/SuSTM5aP/pvQWdTd8QvltAU65k2hESiYwoQEeB8cJ
+         lwhXu80vBGp9c2gBXWp2v3YmXodZ4A2fsSLl/pDyO/zhpoDix2fgj77eCPGkMfdwsYAT
+         Cqcw==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:sender:date:from:to:cc:subject:message-id
+         :references:mime-version:content-disposition:in-reply-to;
+        bh=M6ImvImR96Ds5NBcNS9eiuyRYKVOS/7aVSKKI29NR2k=;
+        b=RP9MVCeiAkzUgW+8Cx2N4l9TRDds9LhofDJu/0WTITMnQXt51ZOz+Us9215G5Hs5gG
+         CUt08JvSW6P0c2H/mz5NH+h4ijw2NiswaxQ3myLwM6ycABNZKQ5bXn3+O13aswlS8GgN
+         Xvp7VNxhzqL49BIwnHrL2TtKQPNWU9LuvzvdSryJSkUMJdZQ0s8dycHUHhgxDMuaO2ZL
+         hkcIa7Oa+nfT8gyPkbC+PqwL0nqzPnFnFm8LQGDnJjxwMFzbfxM0WppJ2fH9qvlefIAS
+         +idYuVojGS0yTgjJIHvQkxef8AQC9XrLtGMEMUzVKRk95c/mSOru0d0iPE+hMC/LhEcA
+         57RA==
+X-Gm-Message-State: AOAM532Z+L4CRVoLiKmG4SaxmYADyqLgxNtxF7ZXutznVL0LMwkXJ8wb
+	VV3iO82XyhcZpaaSOF1YUUM=
+X-Google-Smtp-Source: ABdhPJz71KGHZwRPQacfdHo5gTaMKr8pG+Z3O/kMM88cxCnX4vzaoF8LIL72Z3QN69US97FTkEykwg==
+X-Received: by 2002:a2e:b994:0:b0:253:ec28:b0f4 with SMTP id p20-20020a2eb994000000b00253ec28b0f4mr7391013ljp.376.1653447012453;
+        Tue, 24 May 2022 19:50:12 -0700 (PDT)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id o14-20020a05651205ce00b0047255d211c2sm2845912lfo.241.2022.05.24.19.50.11
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Tue, 24 May 2022 19:50:11 -0700 (PDT)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Wed, 25 May 2022 05:50:12 +0300
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: ~jvolkman <jeremy@jvolkman.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: Re: [PATCH bazel-zig-cc 0/2] Ignore undefined symbols when building
+ dynamic libraries on darwin
+Message-ID: <20220525025012.jol5rxmt6trw2iph@mtpad.i.jakstys.lt>
+References: <165344290967.21743.14923213680999840378-0@git.sr.ht>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+In-Reply-To: <165344290967.21743.14923213680999840378-0@git.sr.ht>
+Status: O
+Content-Length: 1586
+Lines: 38
+
+On Wed, May 25, 2022 at 01:41:49AM +0000, ~jvolkman wrote:
+> Hi,
+> 
+> I'm working on a rule set to build Python modules using bazel cc
+> toolchains, and found that with bazel-zig-cc, I'm unable to build native
+> modules on macos. The issue turns out to be differences in handling
+> undefined symbols at link time in linux vs. macos. When building for a
+> linux target, zig ignores undefined symbols, but for macos they generate
+> errors. In the case of Python, native modules never link against
+> libpython. Instead, its symbols are provided when the module is loaded
+> by the cpython interpreter (at least that's my understanding).
+> 
+> See some discussion of this at
+> https://github.com/ziglang/zig/issues/8180.
+> 
+> This change adds dynamic_library_linkopts to zig_cc_toolchain_config
+> which apply only to the cpp_link_dynamic_library and
+> cpp_link_nodeps_dynamic_library. For darwin targets, I specify the
+> -Wl,-undefined=dynamic_lookup flag. This logic is adapted from bazel's
+> built-in macos toolchain [1].
+> 
+> Thanks!
+> 
+> [1]
+> https://cs.github.com/bazelbuild/bazel/blob/ca40a514b8bc609478f769194909dd0be0afa1f9/tools/osx/crosstool/cc_toolchain_config.bzl#L1125-L1131
+> 
+> Jeremy Volkman (2):
+>   Adds dynamic_library_linkopts to zig_cc_toolchain_config
+>   Pass "-Wl,-undefined=dynamic_lookup" for dynamic libraries on darwin.
+
+Hi Jeremy,
+
+looks like the patch broke ELF[1] on x86_64. Thus I did not reach your
+patch carefully. Please let me know when I should take action.
+
+Motiejus
+
+[1]: https://builds.sr.ht/~motiejus/job/765889
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 30D7911EF8F
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sun, 29 May 2022 16:35:45 +0000 (UTC)
+From: Fabian Hahn <fabian@hahn.graphics>
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1653842139;
+	bh=3lr/B8kctcohxJulceGXqrAeF0rAo4vvlAUlJjPKfB8=;
+	h=From:To:Cc:Subject;
+	b=RnVyPvVZu72MYYeZl6JCFjkGNW+6rJos0RdIpO3ixufurxys7LLDuIsBPS3s5tKAz
+	 z7+bsC4SkJXFcpoQuLwq5R/zkTNNisxASzjNWGtmTW4GW2vid+9y0xwke7NSEFuOeJ
+	 js0r565hbuLspbO3qgJ97QtwazB68bNivlVYuMAY=
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Fabian Hahn <fabian@hahn.graphics>
+Subject: [PATCH bazel-zig-cc v2 0/3] Windows support
+Date: Sun, 29 May 2022 17:35:15 +0100
+Message-Id: <20220529163518.182119-1-fabian@hahn.graphics>
+Mime-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Status: O
+Content-Length: 1433
+Lines: 42
+
+Hello,
+
+Second version of my patchset adding Windows support to bazel-zig-cc.
+
+Changelog compared to v1:
+ - fixed lint failures
+ - dropped patch to add extra platform constraint settings
+ - added patch to add testing for Windows target using wine-binfmt
+ - added README.md entries explaining Windows support
+
+I hope it passes CI, but I do not know how to trigger it other than
+sending you a second patch version. In case of further failures, I
+will of course look into fixing them.  Please let me know if anything
+looks like it is missing :)
+
+Best,
+Fabian
+
+
+Fabian Hahn (3):
+  added Windows host support
+  added support for Windows targets
+  added Windows target testing
+
+ .build.yml                          |  1 +
+ README.md                           | 25 ++++++++++++-
+ WORKSPACE                           |  4 +-
+ ci/test                             | 14 ++++++-
+ test/c/BUILD                        | 24 +++++++++++-
+ test/c/main_winver.c                | 16 ++++++++
+ toolchain/BUILD.sdk.bazel           |  1 +
+ toolchain/defs.bzl                  | 58 +++++++++++++++++++++++------
+ toolchain/platform/defs.bzl         |  7 +++-
+ toolchain/private/BUILD.sdk.bazel   |  1 +
+ toolchain/private/cc_toolchains.bzl |  6 +--
+ toolchain/private/defs.bzl          | 27 +++++++++++++-
+ 12 files changed, 161 insertions(+), 23 deletions(-)
+ create mode 100644 test/c/main_winver.c
+
+-- 
+2.25.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 037A311EFDA
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sun, 29 May 2022 16:35:47 +0000 (UTC)
+From: Fabian Hahn <fabian@hahn.graphics>
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1653842139;
+	bh=DRX7i9Ak/QGm9u8e4hlcE65I6CQ3ouVLcq1JhLQrf2s=;
+	h=From:To:Cc:Subject:In-Reply-To:References;
+	b=bhodRaWuU/xYDmHDfUi8bDJ+i/RsjhdZXiDKf9FtQaSvw4vpjsaeRPzsNTSarp5Vb
+	 hjgSqJO6WepySqY+jvmjJT6WEfJuAeOhCaRjod7eAJiN5wRZ9XR3K2FXYfa7p1Szmq
+	 B8lmHGvzA3fKIiJGKi47j9jHQaGq9N8tarIAH6kg=
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Fabian Hahn <fabian@hahn.graphics>
+Subject: [PATCH bazel-zig-cc v2 3/3] added Windows target testing
+Date: Sun, 29 May 2022 17:35:18 +0100
+Message-Id: <20220529163518.182119-4-fabian@hahn.graphics>
+In-Reply-To: <20220529163518.182119-1-fabian@hahn.graphics>
+References: <20220529163518.182119-1-fabian@hahn.graphics>
+Mime-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Status: O
+Content-Length: 4366
+Lines: 150
+
+---
+ .build.yml           |  1 +
+ README.md            | 10 ++++++++--
+ WORKSPACE            |  4 +++-
+ ci/test              | 14 ++++++++++++--
+ test/c/BUILD         | 24 +++++++++++++++++++++++-
+ test/c/main_winver.c | 16 ++++++++++++++++
+ 6 files changed, 63 insertions(+), 6 deletions(-)
+ create mode 100644 test/c/main_winver.c
+
+diff --git a/.build.yml b/.build.yml
+index 6aeec50..c9cbfa0 100644
+--- a/.build.yml
++++ b/.build.yml
+@@ -5,6 +5,7 @@ packages:
+   - qemu-user-static
+   - binfmt-support
+   - moreutils
++  - wine-binfmt
+ sources:
+   - https://git.sr.ht/~motiejus/bazel-zig-cc
+ environment:
+diff --git a/README.md b/README.md
+index e6fd5e2..7a86ced 100644
+--- a/README.md
++++ b/README.md
+@@ -401,8 +401,9 @@ This repository is used on the following (host) platforms:
+ - `windows_amd64`, a.k.a. `x64`.
+ 
+ The tests are running (CId) on linux-amd64, and are assuming the kernel is
+-configured to run arm64 binaries. There are two reasonably convenient ways to
+-configure arm64 emulation:
++configured to run `linux_arm64` and `windows_amd64` binaries.
++
++There are two reasonably convenient ways to configure `linux_arm64` emulation:
+ 
+ 1. Install and configure [`binfmt_misc`][binfmt_misc]:
+    ```
+@@ -414,6 +415,11 @@ configure arm64 emulation:
+    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    ```
+ 
++In order to install and configure `windows_amd64` emulation:
++```
++apt install wine-binfmt
++```
++
+ ## Transient docker environment
+ 
+ A standalone Docker environment to play with bazel-zig-cc:
+diff --git a/WORKSPACE b/WORKSPACE
+index eff4a8f..c1b3c0f 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -51,11 +51,13 @@ zig_toolchains()
+ 
+ register_toolchains(
+     # if no `--platform` is specified, these toolchains will be used for
+-    # (linux,darwin)x(amd64,arm64)
++    # (linux,darwin,windows)x(amd64,arm64)
+     "@zig_sdk//toolchain:linux_amd64_gnu.2.19",
+     "@zig_sdk//toolchain:linux_arm64_gnu.2.28",
+     "@zig_sdk//toolchain:darwin_amd64",
+     "@zig_sdk//toolchain:darwin_arm64",
++    "@zig_sdk//toolchain:windows_amd64",
++    "@zig_sdk//toolchain:windows_arm64",
+ 
+     # amd64 toolchains for libc-aware platforms:
+     "@zig_sdk//libc_aware/toolchain:linux_amd64_gnu.2.19",
+diff --git a/ci/test b/ci/test
+index debdc0b..1ba6285 100755
+--- a/ci/test
++++ b/ci/test
+@@ -1,3 +1,13 @@
+-#!/bin/sh
++#!/bin/bash
++set -euo pipefail
+ 
+-exec bazel test ...
++bazel test ...
++
++# Windows tests
++# Unfortunately wine-binfmt breaks within the bazel sandbox, so we disable it
++# to run this test.
++bazel test //test/c:winver_windows_amd64 \
++    --spawn_strategy=standalone
++# There is no no easy way to run windows_arm64 binaries on Linux, so we just
++# cross compile one for testing.
++bazel build //test/c:winver_windows_arm64
+diff --git a/test/c/BUILD b/test/c/BUILD
+index 99e36c4..698c798 100644
+--- a/test/c/BUILD
++++ b/test/c/BUILD
+@@ -1,4 +1,4 @@
+-load("@bazel-zig-cc//rules:platform.bzl", "platform_binary")
++load("@bazel-zig-cc//rules:platform.bzl", "platform_binary", "platform_test")
+ 
+ cc_binary(
+     name = "which_libc",
+@@ -34,3 +34,25 @@ cc_binary(
+         ("linux_arm64", "//platform:linux_arm64", "glibc_2.28"),
+     ]
+ ]
++
++cc_binary(
++    name = "winver",
++    srcs = ["main_winver.c"],
++    target_compatible_with = [
++        "@platforms//os:windows",
++    ],
++)
++
++platform_test(
++    name = "winver_windows_amd64",
++    src = "winver",
++    platform = "//platform:windows_amd64",
++    tags = ["manual"],
++)
++
++platform_binary(
++    name = "winver_windows_arm64",
++    src = "winver",
++    platform = "//platform:windows_arm64",
++    tags = ["manual"],
++)
+diff --git a/test/c/main_winver.c b/test/c/main_winver.c
+new file mode 100644
+index 0000000..b5302af
+--- /dev/null
++++ b/test/c/main_winver.c
+@@ -0,0 +1,16 @@
++#include <stdio.h>
++#include <windows.h>
++
++int main() {
++    DWORD version = GetVersion();
++    DWORD majorVersion = (DWORD)(LOBYTE(LOWORD(version)));
++    DWORD minorVersion = (DWORD)(HIBYTE(LOWORD(version)));
++
++    DWORD build = 0;
++    if (version < 0x80000000) {
++        build = (DWORD)(HIWORD(version));
++    }
++
++    printf("Running Windows version %d.%d (%d).\n", majorVersion, minorVersion, build);
++    return 0;
++}
+-- 
+2.25.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id BFE6D11EFCE
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sun, 29 May 2022 16:35:47 +0000 (UTC)
+From: Fabian Hahn <fabian@hahn.graphics>
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1653842139;
+	bh=tvaGuRzASGGiRRWTMcTMnnGQ3oGSDo1KfvGZLm3bx7U=;
+	h=From:To:Cc:Subject:In-Reply-To:References;
+	b=FF3KNoDO304ASBliu5lnL3qb3EVE14uIhSxW6TkJv18XRW1pIwfdA54hXQU+wlnJD
+	 XFXyabVgPEZ2Zly3B/fcxXnDdZ9DXXt/M40f9zQx+sdoS8+Cd+Y98sJUdCptoz1pbY
+	 dJ3C1QWXhvSIh+psgQNKN8VZDDf/lXBE02PYTvdw=
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Fabian Hahn <fabian@hahn.graphics>
+Subject: [PATCH bazel-zig-cc v2 1/3] added Windows host support
+Date: Sun, 29 May 2022 17:35:16 +0100
+Message-Id: <20220529163518.182119-2-fabian@hahn.graphics>
+In-Reply-To: <20220529163518.182119-1-fabian@hahn.graphics>
+References: <20220529163518.182119-1-fabian@hahn.graphics>
+Mime-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Status: O
+Content-Length: 10291
+Lines: 262
+
+---
+ README.md                           |  1 +
+ toolchain/BUILD.sdk.bazel           |  1 +
+ toolchain/defs.bzl                  | 58 +++++++++++++++++++++++------
+ toolchain/private/BUILD.sdk.bazel   |  1 +
+ toolchain/private/cc_toolchains.bzl |  6 +--
+ toolchain/private/defs.bzl          |  8 +++-
+ 6 files changed, 59 insertions(+), 16 deletions(-)
+
+diff --git a/README.md b/README.md
+index bbbd5bc..b092ae0 100644
+--- a/README.md
++++ b/README.md
+@@ -384,6 +384,7 @@ This repository is used on the following (host) platforms:
+ - `linux_arm64`, a.k.a. `AArch64`.
+ - `darwin_amd64`, the 64-bit post-PowerPC models.
+ - `darwin_arm64`, the M1.
++- `windows_amd64`, a.k.a. `x64`.
+ 
+ The tests are running (CId) on linux-amd64, and are assuming the kernel is
+ configured to run arm64 binaries. There are two reasonably convenient ways to
+diff --git a/toolchain/BUILD.sdk.bazel b/toolchain/BUILD.sdk.bazel
+index ada3e5d..e1505b1 100644
+--- a/toolchain/BUILD.sdk.bazel
++++ b/toolchain/BUILD.sdk.bazel
+@@ -7,6 +7,7 @@ package(
+ 
+ 
+ declare_files(
++    os = {os},
+     zig_include_root = {zig_include_root},
+ )
+ 
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 9ab4e88..df2441d 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -1,6 +1,6 @@
+ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_user_netrc", "use_netrc")
+-load("@bazel-zig-cc//toolchain/private:defs.bzl", "DEFAULT_INCLUDE_DIRECTORIES", "ZIG_TOOL_PATH", "target_structs")
++load("@bazel-zig-cc//toolchain/private:defs.bzl", "DEFAULT_INCLUDE_DIRECTORIES", "target_structs", "zig_tool_path")
+ 
+ _fcntl_map = """
+ GLIBC_2.2.5 {
+@@ -16,21 +16,21 @@ __asm__(".symver fcntl64, fcntl@GLIBC_2.2.5");
+ """
+ 
+ # Official recommended version. Should use this when we have a usable release.
+-URL_FORMAT_RELEASE = "https://ziglang.org/download/{version}/zig-{host_platform}-{version}.tar.xz"
++URL_FORMAT_RELEASE = "https://ziglang.org/download/{version}/zig-{host_platform}-{version}.{ext}"
+ 
+ # Caution: nightly releases are purged from ziglang.org after ~90 days. A real
+ # solution would be to allow the downstream project specify their own mirrors.
+ # This is explained in
+ # https://sr.ht/~motiejus/bazel-zig-cc/#alternative-download-urls and is
+ # awaiting my attention or your contribution.
+-URL_FORMAT_NIGHTLY = "https://ziglang.org/builds/zig-{host_platform}-{version}.tar.xz"
++URL_FORMAT_NIGHTLY = "https://ziglang.org/builds/zig-{host_platform}-{version}.{ext}"
+ 
+ # Author's mirror that doesn't purge the nightlies so aggressively. I will be
+ # cleaning those up manually only after the artifacts are not in use for many
+ # months in bazel-zig-cc. dl.jakstys.lt is a small x86_64 server with an NVMe
+ # drive sitting in my home closet on a 1GB/s symmetric residential connection,
+ # which, as of writing, has been quite reliable.
+-URL_FORMAT_JAKSTYS = "https://dl.jakstys.lt/zig/zig-{host_platform}-{version}.tar.xz"
++URL_FORMAT_JAKSTYS = "https://dl.jakstys.lt/zig/zig-{host_platform}-{version}.{ext}"
+ 
+ _VERSION = "0.10.0-dev.2252+a4369918b"
+ 
+@@ -39,12 +39,22 @@ _HOST_PLATFORM_SHA256 = {
+     "linux-x86_64": "1d3c3769eba85a4334c93a3cfa35ad0ef914dd8cf9fd502802004c6908f5370c",
+     "macos-aarch64": "ab46e7499e5bd7b6d6ff2ac331e1a4aa875a01b270dc40306bc29dbaf216fccf",
+     "macos-x86_64": "fb213f996bcab805839e401292c42a92b63cd97deb1631e31bd61f534b7f6b1c",
++    "windows-x86_64": "14e43a64026512161f3d6201d8972a28f0508da2782c16e980f2ffa3bb7e6720",
++}
++
++_HOST_PLATFORM_EXT = {
++    "linux-aarch64": "tar.xz",
++    "linux-x86_64": "tar.xz",
++    "macos-aarch64": "tar.xz",
++    "macos-x86_64": "tar.xz",
++    "windows-x86_64": "zip",
+ }
+ 
+ def toolchains(
+         version = _VERSION,
+         url_formats = [URL_FORMAT_NIGHTLY, URL_FORMAT_JAKSTYS],
+-        host_platform_sha256 = _HOST_PLATFORM_SHA256):
++        host_platform_sha256 = _HOST_PLATFORM_SHA256,
++        host_platform_ext = _HOST_PLATFORM_EXT):
+     """
+         Download zig toolchain and declare bazel toolchains.
+         The platforms are not registered automatically, that should be done by
+@@ -56,11 +66,13 @@ def toolchains(
+         version = version,
+         url_formats = url_formats,
+         host_platform_sha256 = host_platform_sha256,
++        host_platform_ext = host_platform_ext,
+         host_platform_include_root = {
+             "linux-aarch64": "lib/zig/",
+             "linux-x86_64": "lib/",
+             "macos-aarch64": "lib/zig/",
+             "macos-x86_64": "lib/zig/",
++            "windows-x86_64": "lib/",
+         },
+     )
+ 
+@@ -81,6 +93,10 @@ export ZIG_GLOBAL_CACHE_DIR=$ZIG_LOCAL_CACHE_DIR
+ exec "{zig}" "{zig_tool}" "$@"
+ """
+ 
++ZIG_TOOL_WRAPPER_WINDOWS = """@echo off
++"{zig}" "{zig_tool}" %*
++"""
++
+ _ZIG_TOOLS = [
+     "c++",
+     "cc",
+@@ -103,11 +119,16 @@ def _zig_repository_impl(repository_ctx):
+     if os.startswith("mac os"):
+         os = "macos"
+ 
++    if os.startswith("windows"):
++        os = "windows"
++
+     host_platform = "{}-{}".format(os, arch)
+ 
+     zig_include_root = repository_ctx.attr.host_platform_include_root[host_platform]
+     zig_sha256 = repository_ctx.attr.host_platform_sha256[host_platform]
++    zig_ext = repository_ctx.attr.host_platform_ext[host_platform]
+     format_vars = {
++        "ext": zig_ext,
+         "version": repository_ctx.attr.version,
+         "host_platform": host_platform,
+     }
+@@ -121,12 +142,19 @@ def _zig_repository_impl(repository_ctx):
+     )
+ 
+     for zig_tool in _ZIG_TOOLS:
+-        repository_ctx.file(
+-            ZIG_TOOL_PATH.format(zig_tool = zig_tool),
+-            ZIG_TOOL_WRAPPER.format(
+-                zig = str(repository_ctx.path("zig")),
++        zig_tool_wrapper = ZIG_TOOL_WRAPPER.format(
++            zig = str(repository_ctx.path("zig")),
++            zig_tool = zig_tool,
++        )
++        if os == "windows":
++            zig_tool_wrapper = ZIG_TOOL_WRAPPER_WINDOWS.format(
++                zig = str(repository_ctx.path("zig")).replace("/", "\\") + ".exe",
+                 zig_tool = zig_tool,
+-            ),
++            )
++
++        repository_ctx.file(
++            zig_tool_path(os).format(zig_tool = zig_tool),
++            zig_tool_wrapper,
+         )
+ 
+     repository_ctx.file(
+@@ -157,6 +185,7 @@ def _zig_repository_impl(repository_ctx):
+             executable = False,
+             substitutions = {
+                 "{absolute_path}": _quote(str(repository_ctx.path(""))),
++                "{os}": _quote(os),
+                 "{zig_include_root}": _quote(zig_include_root),
+             },
+         )
+@@ -167,6 +196,7 @@ zig_repository = repository_rule(
+         "host_platform_sha256": attr.string_dict(),
+         "url_formats": attr.string_list(allow_empty = False),
+         "host_platform_include_root": attr.string_dict(),
++        "host_platform_ext": attr.string_dict(),
+     },
+     implementation = _zig_repository_impl,
+ )
+@@ -175,9 +205,13 @@ def filegroup(name, **kwargs):
+     native.filegroup(name = name, **kwargs)
+     return ":" + name
+ 
+-def declare_files(zig_include_root):
++def declare_files(os, zig_include_root):
+     filegroup(name = "empty")
+-    native.exports_files(["zig"], visibility = ["//visibility:public"])
++    if os == "windows":
++        native.exports_files(["zig.exe"], visibility = ["//visibility:public"])
++        native.alias(name = "zig", actual = ":zig.exe")
++    else:
++        native.exports_files(["zig"], visibility = ["//visibility:public"])
+     filegroup(name = "lib/std", srcs = native.glob(["lib/std/**"]))
+ 
+     lazy_filegroups = {}
+diff --git a/toolchain/private/BUILD.sdk.bazel b/toolchain/private/BUILD.sdk.bazel
+index 39a6a93..3e7c23e 100644
+--- a/toolchain/private/BUILD.sdk.bazel
++++ b/toolchain/private/BUILD.sdk.bazel
+@@ -1,6 +1,7 @@
+ load("@bazel-zig-cc//toolchain/private:cc_toolchains.bzl", "declare_cc_toolchains")
+ 
+ declare_cc_toolchains(
++    os = {os},
+     absolute_path = {absolute_path},
+     zig_include_root = {zig_include_root},
+ )
+diff --git a/toolchain/private/cc_toolchains.bzl b/toolchain/private/cc_toolchains.bzl
+index 64e99f1..e6594db 100644
+--- a/toolchain/private/cc_toolchains.bzl
++++ b/toolchain/private/cc_toolchains.bzl
+@@ -1,4 +1,4 @@
+-load(":defs.bzl", "DEFAULT_INCLUDE_DIRECTORIES", "ZIG_TOOL_PATH", "target_structs")
++load(":defs.bzl", "DEFAULT_INCLUDE_DIRECTORIES", "target_structs", "zig_tool_path")
+ load("@bazel-zig-cc//toolchain:zig_toolchain.bzl", "zig_cc_toolchain_config")
+ 
+ DEFAULT_TOOL_PATHS = {
+@@ -11,7 +11,7 @@ DEFAULT_TOOL_PATHS = {
+     "strip": "/usr/bin/false",
+ }.items()
+ 
+-def declare_cc_toolchains(absolute_path, zig_include_root):
++def declare_cc_toolchains(os, absolute_path, zig_include_root):
+     for target_config in target_structs():
+         gotarget = target_config.gotarget
+         zigtarget = target_config.zigtarget
+@@ -28,7 +28,7 @@ def declare_cc_toolchains(absolute_path, zig_include_root):
+             if path[0] == "/":
+                 absolute_tool_paths[name] = path
+                 continue
+-            tool_path = ZIG_TOOL_PATH.format(zig_tool = path)
++            tool_path = zig_tool_path(os).format(zig_tool = path)
+             absolute_tool_paths[name] = "%s/%s" % (absolute_path, tool_path)
+ 
+         linkopts = target_config.linkopts
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+index 6059065..6804104 100644
+--- a/toolchain/private/defs.bzl
++++ b/toolchain/private/defs.bzl
+@@ -4,7 +4,7 @@ DEFAULT_INCLUDE_DIRECTORIES = [
+     "libcxxabi/include",
+ ]
+ 
+-ZIG_TOOL_PATH = "tools/{zig_tool}"
++_ZIG_TOOL_PATH = "tools/{zig_tool}"
+ 
+ # Zig supports even older glibcs than defined below, but we have tested only
+ # down to 2.17.
+@@ -30,6 +30,12 @@ _GLIBCS = [
+ 
+ LIBCS = ["musl"] + ["gnu.{}".format(glibc) for glibc in _GLIBCS]
+ 
++def zig_tool_path(os):
++    if os == "windows":
++        return _ZIG_TOOL_PATH + ".bat"
++    else:
++        return _ZIG_TOOL_PATH
++
+ def target_structs():
+     ret = []
+     for zigcpu, gocpu in (("x86_64", "amd64"), ("aarch64", "arm64")):
+-- 
+2.25.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 4AC1111EFC5
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sun, 29 May 2022 16:35:48 +0000 (UTC)
+From: Fabian Hahn <fabian@hahn.graphics>
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1653842139;
+	bh=shT4KHFKEaq2CJ4sf4KM1Z6DfL5toz9ES9J0EV2qlW0=;
+	h=From:To:Cc:Subject:In-Reply-To:References;
+	b=Wi6W5SI4d9ZzEXT6WO62mHVqCT9CiAfIqdx2D8658kTd7w8Yt2qr4Z64v1etaYyZk
+	 YCcBTw217N5J/ug4J6AsWuu85pBBe9rBgMaNl57L61MaxH8KU/p0izn7ePdg6liXB6
+	 2aEh8lNIHmjQye0ZtrYmaR2vN3S01X9UWn3sQmc8=
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Fabian Hahn <fabian@hahn.graphics>
+Subject: [PATCH bazel-zig-cc v2 2/3] added support for Windows targets
+Date: Sun, 29 May 2022 17:35:17 +0100
+Message-Id: <20220529163518.182119-3-fabian@hahn.graphics>
+In-Reply-To: <20220529163518.182119-1-fabian@hahn.graphics>
+References: <20220529163518.182119-1-fabian@hahn.graphics>
+Mime-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Status: O
+Content-Length: 3604
+Lines: 100
+
+---
+ README.md                   | 14 ++++++++++++++
+ toolchain/platform/defs.bzl |  7 ++++++-
+ toolchain/private/defs.bzl  | 19 +++++++++++++++++++
+ 3 files changed, 39 insertions(+), 1 deletion(-)
+
+diff --git a/README.md b/README.md
+index b092ae0..e6fd5e2 100644
+--- a/README.md
++++ b/README.md
+@@ -152,6 +152,8 @@ register_toolchains(
+     "@zig_sdk//toolchain:linux_arm64_gnu.2.28",
+     "@zig_sdk//toolchain:darwin_amd64",
+     "@zig_sdk//toolchain:darwin_arm64",
++    "@zig_sdk//toolchain:windows_amd64",
++    "@zig_sdk//toolchain:windows_arm64",
+ )
+ ```
+ 
+@@ -318,6 +320,18 @@ is currently not implemented.
+ target macos.10 (Catalina), macos.11 (Big Sur) or macos.12 (Monterey). It
+ currently targets the lowest version, without ability to change it.
+ 
++## Windows: output file extensions
++
++Bazel won't use common Windows file extensions for built output binaries.
++Instead, it will generate binaries with common Unix extensions that you might
++have to manually rename before deploying them to an actual Windows system:
++
++| Binary type    | Bazel extension | Windows extension |
++|----------------|-----------------|-------------------|
++| Static library | .a              | .lib              |
++| Shared library | .so             | .dll              |
++| Executable     | (no extension)  | .exe              |
++
+ # Known Issues In Upstream
+ 
+ This section lists issues that I've stumbled into when using `zig cc`, and is
+diff --git a/toolchain/platform/defs.bzl b/toolchain/platform/defs.bzl
+index cf42191..07e69a6 100644
+--- a/toolchain/platform/defs.bzl
++++ b/toolchain/platform/defs.bzl
+@@ -1,11 +1,16 @@
+ load("@bazel-zig-cc//toolchain/private:defs.bzl", "LIBCS")
+ 
+ _CPUS = (("x86_64", "amd64"), ("aarch64", "arm64"))
++_OS = {
++    "linux": ["linux"],
++    "macos": ["macos", "darwin"],
++    "windows": ["windows"],
++}
+ 
+ def declare_platforms():
+     # create @zig_sdk//{os}_{arch}_platform entries with zig and go conventions
+     for zigcpu, gocpu in _CPUS:
+-        for bzlos, oss in {"linux": ["linux"], "macos": ["macos", "darwin"]}.items():
++        for bzlos, oss in _OS.items():
+             for os in oss:
+                 declare_platform(gocpu, zigcpu, bzlos, os)
+ 
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+index 6804104..2ba61f7 100644
+--- a/toolchain/private/defs.bzl
++++ b/toolchain/private/defs.bzl
+@@ -40,6 +40,7 @@ def target_structs():
+     ret = []
+     for zigcpu, gocpu in (("x86_64", "amd64"), ("aarch64", "arm64")):
+         ret.append(_target_darwin(gocpu, zigcpu))
++        ret.append(_target_windows(gocpu, zigcpu))
+         ret.append(_target_linux_musl(gocpu, zigcpu))
+         for glibc in _GLIBCS:
+             ret.append(_target_linux_gnu(gocpu, zigcpu, glibc))
+@@ -69,6 +70,24 @@ def _target_darwin(gocpu, zigcpu):
+         tool_paths = {"ld": "ld64.lld"},
+     )
+ 
++def _target_windows(gocpu, zigcpu):
++    return struct(
++        gotarget = "windows_{}".format(gocpu),
++        zigtarget = "{}-windows-gnu".format(zigcpu),
++        includes = [
++            "libunwind/include",
++            "libc/include/any-windows-any",
++        ],
++        linkopts = [],
++        copts = [],
++        bazel_target_cpu = "x64_windows",
++        constraint_values = [
++            "@platforms//os:windows",
++            "@platforms//cpu:{}".format(zigcpu),
++        ],
++        tool_paths = {"ld": "ld64.lld"},
++    )
++
+ def _target_linux_gnu(gocpu, zigcpu, glibc_version):
+     glibc_suffix = "gnu.{}".format(glibc_version)
+ 
+-- 
+2.25.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=5nZe6SoH5njYr0DiIik//7O2RdQQvmVMMBKXvF8TMmU=;
+ c=simple/simple; d=sr.ht; h=Date:Subject:To:Cc:From:In-Reply-To;
+ q=dns/txt; s=srht; t=1653843929; v=1;
+ b=OXPzKb9TP2M16GsDGD3093RXX7AcPNyYxKWNMMcCJYv0VvTzTKwx0dhlzjrFkuTljfr0hkq0
+ QBwIWHuM/TXA7UQa6YJvrvozaFyMyJ20sxsPP20w3YGXtrm3o4txzZVNWb1JsqpFc3rH0Y5ss3d
+ VX6dHzPhRSoWj+SNseJJjWTNqfipZa4WgZ6tQl7XjPTFkql8hGSYtlssyDc9bEvX7M2pMIG10jR
+ G+REG2qGCLYFANEL2HscJTivgz2JU2PII0CzNbSVWnQqzuYwXKHTxrNF7kot/UMiAGSv+l6LqZ1
+ HG6zKLQmMRyvdefSjH9IKiDOE30hT0XxhUzcBvsrAfs9w==
+Received: from localhost (unknown [173.195.146.249])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id 3A33311EF8F;
+	Sun, 29 May 2022 17:05:29 +0000 (UTC)
+MIME-Version: 1.0
+Date: Sun, 29 May 2022 17:05:29 +0000
+Subject: [bazel-zig-cc/patches/.build.yml] build failed
+To: "Fabian Hahn" <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CKCEQSA31LED.TXUT9YCT7H6C@cirno>
+In-Reply-To: <20220529163518.182119-3-fabian@hahn.graphics>
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 304
+Lines: 9
+
+bazel-zig-cc/patches/.build.yml: FAILED in 29m34s
+
+[Windows support][0] v2 from [Fabian Hahn][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/32601
+[1]: mailto:fabian@hahn.graphics
+
+=E2=9C=97 #769696 FAILED bazel-zig-cc/patches/.build.yml https://builds.sr.=
+ht/~motiejus/job/769696
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f49.google.com (mail-oa1-f49.google.com [209.85.160.49])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 7C40811EFC4
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 30 May 2022 12:37:58 +0000 (UTC)
+Received: by mail-oa1-f49.google.com with SMTP id 586e51a60fabf-f2cd424b9cso14148271fac.7
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 30 May 2022 05:37:58 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=mime-version:references:in-reply-to:from:date:message-id:subject:to
+         :cc;
+        bh=c9kaxEn5khS5ZUu9L05plIIYjAP/cRIY0U2L/uJNU9s=;
+        b=eT+xGhFVI7OXVj9EXDESyy9NhCBw37dzafrDthILfbfLdoKBYbZF4/SgYfIfSXlDXL
+         Mn7ErZ9VcsqePCIZPfg8lUFrdbRwcp7jkJvmP01Z7JK/0gOIUawcUP4oSi2VQKGLGMxa
+         Jc0jq6N62ZLuRhDP0B2GvSLRO/eRaOlqlg1kVQwGcnW9mWzSTPhNn7JnrvOD9len9/Ng
+         aOBHH9ElRKTMTec0DAbuqHN49lZ5etEhuNLNFYzDLrvrfEwUxBaXdIQB7uG1Dd1gNI2r
+         MN4FnIxDFmCy9voLUK1HSl6PnQkeSsw73NwhSlGPe89deIjBwz+SDZ3mmm7wv6CMGkcu
+         4HQg==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:references:in-reply-to:from:date
+         :message-id:subject:to:cc;
+        bh=c9kaxEn5khS5ZUu9L05plIIYjAP/cRIY0U2L/uJNU9s=;
+        b=cWtcqEx6XzOdyk7UzX3BB+Lw0sWmmQz5rnztJ0HTOEL8PERDHrShvop8l+RfCvmmfx
+         pXbl0es9HOSoDPAbOGOBp0F5xMQriDvAMqXRgxCsvVnbVoptauoV3GiuEL8t4ZE4augb
+         /TAQxRjP8kImsIrxAj3tu9CoisSKO2dlQi6VVWPFidIM5+hisLXW2ZJpD7t9QREAzM5Y
+         2mtLNKldnrl8+5NlGpFKeD9jjVdwiuoLL2G/8WpQPq6FoU1D7JIR7ux0im49NLfHG2N7
+         BX6Y8OlnXQVd/oRK5rzDVieNyKqJ8lSkxWhjx/WHF3BZR/lMeF7M8/X2I3wiA1TjiP+X
+         fmBw==
+X-Gm-Message-State: AOAM530pMRMnobCAVrBpI/rRXeVHg1e6d7TAu+SFng02De0B4dXfOfh8
+	bOKAZLr22/ncTxwlFh1a6mCp3xCJhOXimBcoSK1mdpz4aIo=
+X-Google-Smtp-Source: ABdhPJytiM3jP/NZaZk6e2A+jBV8hM3t6yyEXzKj98SF5eY7zpf/7vi/cceIOLwMzO4C6D0Twm0suGK7iZ2vGiUBQtw=
+X-Received: by 2002:a05:6870:f5a5:b0:f2:d204:cc3c with SMTP id
+ eh37-20020a056870f5a500b000f2d204cc3cmr10633803oab.35.1653914277843; Mon, 30
+ May 2022 05:37:57 -0700 (PDT)
+MIME-Version: 1.0
+References: <20220529163518.182119-1-fabian@hahn.graphics>
+In-Reply-To: <20220529163518.182119-1-fabian@hahn.graphics>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Mon, 30 May 2022 15:37:47 +0300
+Message-ID: <CAFVMu-ps+Pt5DqSnUZ323sDcQB-MmjBg01nMfHK+kxtgr0Ew_g@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc v2 0/3] Windows support
+To: Fabian Hahn <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 1289
+Lines: 32
+
+On Sun, May 29, 2022 at 7:35 PM Fabian Hahn <fabian@hahn.graphics> wrote:
+>
+> Hello,
+>
+> Second version of my patchset adding Windows support to bazel-zig-cc.
+>
+> Changelog compared to v1:
+>  - fixed lint failures
+>  - dropped patch to add extra platform constraint settings
+>  - added patch to add testing for Windows target using wine-binfmt
+>  - added README.md entries explaining Windows support
+>
+> I hope it passes CI, but I do not know how to trigger it other than
+> sending you a second patch version. In case of further failures, I
+> will of course look into fixing them.  Please let me know if anything
+> looks like it is missing :)
+
+Hi, Fabian,
+
+As you may have noticed, the past patchset doesn't pass CI. If you
+have a Linux machine, the tests are quite easy to execute manually[1].
+Otherwise don't worry about sending multiple patch versions; I am
+happy to ignore the patchsets (and the emails from the CI) until the
+tests pass. That's what they are there for!
+
+You can also use a transient docker environment[2] to isolate yourself
+from the host OS. Let me know if that works for you.
+
+Motiejus
+
+[1]: https://git.sr.ht/~motiejus/bazel-zig-cc/tree/main/item/.build.yml
+[2]: https://git.sr.ht/~motiejus/bazel-zig-cc#transient-docker-environment
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id C570811EEAC
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed,  1 Jun 2022 01:58:18 +0000 (UTC)
+From: ~jvolkman <jvolkman@git.sr.ht>
+Date: Wed, 01 Jun 2022 01:58:18 +0000
+Subject: [PATCH bazel-zig-cc 0/2] Ignore undefined symbols when building
+ dynamic libraries on darwin
+MIME-Version: 1.0
+Message-ID: <165404869855.21942.14779642481390967131-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~jvolkman <jeremy@jvolkman.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+Status: O
+Content-Length: 678
+Lines: 20
+
+Hi,
+
+Here's an updated version of this patchset that fixes an operator
+precedence issue in zig_toolchain.bzl when building flag_sets.
+//test/gorace:gorace_test was failing before, but now passes.
+
+I haven't been able to get the arm64 tests to pass locally. Here's
+hoping they work too!
+
+Jeremy Volkman (2):
+  Adds dynamic_library_linkopts to zig_cc_toolchain_config
+  Pass "-Wl,-undefined=dynamic_lookup" for dynamic libraries on darwin.
+
+ toolchain/private/cc_toolchains.bzl |  2 ++
+ toolchain/private/defs.bzl          |  3 +++
+ toolchain/zig_toolchain.bzl         | 22 +++++++++++++++++++---
+ 3 files changed, 24 insertions(+), 3 deletions(-)
+
+-- 
+2.34.2
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id F408D11EF01
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed,  1 Jun 2022 01:58:18 +0000 (UTC)
+From: ~jvolkman <jvolkman@git.sr.ht>
+Date: Tue, 24 May 2022 17:14:35 -0700
+Subject: [PATCH bazel-zig-cc 1/2] Adds dynamic_library_linkopts to
+ zig_cc_toolchain_config
+Message-ID: <165404869855.21942.14779642481390967131-1@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~jvolkman <jeremy@jvolkman.com>
+In-Reply-To: <165404869855.21942.14779642481390967131-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 4882
+Lines: 129
+
+From: Jeremy Volkman <jeremy@jvolkman.com>
+
+If specified, the flags in dynamic_library_linkopts are included in
+cpp_link_dynamic_library and cpp_link_nodeps_dynamic_library actions.
+---
+ toolchain/private/cc_toolchains.bzl |  2 ++
+ toolchain/private/defs.bzl          |  3 +++
+ toolchain/zig_toolchain.bzl         | 22 +++++++++++++++++++---
+ 3 files changed, 24 insertions(+), 3 deletions(-)
+
+diff --git a/toolchain/private/cc_toolchains.bzl b/toolchain/private/cc_toolc=
+hains.bzl
+index 64e99f1..3a1e1cb 100644
+--- a/toolchain/private/cc_toolchains.bzl
++++ b/toolchain/private/cc_toolchains.bzl
+@@ -32,6 +32,7 @@ def declare_cc_toolchains(absolute_path, zig_include_root):
+             absolute_tool_paths[name] =3D "%s/%s" % (absolute_path, tool_pat=
+h)
+=20
+         linkopts =3D target_config.linkopts
++        dynamic_library_linkopts =3D target_config.dynamic_library_linkopts
+         copts =3D target_config.copts
+         for s in getattr(target_config, "linker_version_scripts", []):
+             linkopts =3D linkopts + ["-Wl,--version-script,%s/%s" % (absolut=
+e_path, s)]
+@@ -45,6 +46,7 @@ def declare_cc_toolchains(absolute_path, zig_include_root):
+             cxx_builtin_include_directories =3D cxx_builtin_include_director=
+ies,
+             copts =3D copts,
+             linkopts =3D linkopts,
++            dynamic_library_linkopts =3D dynamic_library_linkopts,
+             target_cpu =3D target_config.bazel_target_cpu,
+             target_system_name =3D "unknown",
+             target_libc =3D "unknown",
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+index 6059065..053641c 100644
+--- a/toolchain/private/defs.bzl
++++ b/toolchain/private/defs.bzl
+@@ -54,6 +54,7 @@ def _target_darwin(gocpu, zigcpu):
+             "libc/include/any-macos-any",
+         ],
+         linkopts =3D [],
++        dynamic_library_linkopts =3D [],
+         copts =3D [],
+         bazel_target_cpu =3D "darwin",
+         constraint_values =3D [
+@@ -84,6 +85,7 @@ def _target_linux_gnu(gocpu, zigcpu, glibc_version):
+         compiler_extra_includes =3D ["glibc-hacks/glibchack-fcntl.h"] if fcn=
+tl_hack else [],
+         linker_version_scripts =3D ["glibc-hacks/fcntl.map"] if fcntl_hack e=
+lse [],
+         linkopts =3D ["-lc++", "-lc++abi"],
++        dynamic_library_linkopts =3D [],
+         copts =3D [],
+         bazel_target_cpu =3D "k8",
+         constraint_values =3D [
+@@ -105,6 +107,7 @@ def _target_linux_musl(gocpu, zigcpu):
+             "libc/include/{}-linux-any".format(zigcpu),
+         ] + (["libc/include/x86-linux-any"] if zigcpu =3D=3D "x86_64" else [=
+]),
+         linkopts =3D ["-s", "-w"],
++        dynamic_library_linkopts =3D [],
+         copts =3D ["-D_LIBCPP_HAS_MUSL_LIBC", "-D_LIBCPP_HAS_THREAD_API_PTHR=
+EAD"],
+         bazel_target_cpu =3D "k8",
+         constraint_values =3D [
+diff --git a/toolchain/zig_toolchain.bzl b/toolchain/zig_toolchain.bzl
+index aa14ec1..f22bc4c 100644
+--- a/toolchain/zig_toolchain.bzl
++++ b/toolchain/zig_toolchain.bzl
+@@ -14,6 +14,11 @@ all_link_actions =3D [
+     ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+ ]
+=20
++dynamic_library_link_actions =3D [
++    ACTION_NAMES.cpp_link_dynamic_library,
++    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
++]
++
+ compile_and_link_actions =3D [
+     ACTION_NAMES.c_compile,
+     ACTION_NAMES.cpp_compile,
+@@ -73,21 +78,31 @@ def _zig_cc_toolchain_config_impl(ctx):
+         ],
+     )
+=20
++    if ctx.attr.dynamic_library_linkopts:
++        dynamic_library_flag_sets =3D [
++            flag_set(
++                actions =3D dynamic_library_link_actions,
++                flag_groups =3D [flag_group(flags =3D ctx.attr.dynamic_libra=
+ry_linkopts)],
++            ),
++        ]
++    else:
++        dynamic_library_flag_sets =3D []
++
+     default_linker_flags =3D feature(
+         name =3D "default_linker_flags",
+         enabled =3D True,
+         flag_sets =3D [
+             flag_set(
+                 actions =3D all_link_actions,
+-                flag_groups =3D ([
++                flag_groups =3D [
+                     flag_group(
+                         flags =3D ["-target", ctx.attr.target] +
+                                 no_gc_sections +
+                                 ctx.attr.linkopts,
+                     ),
+-                ]),
++                ],
+             ),
+-        ],
++        ] + dynamic_library_flag_sets,
+     )
+=20
+     features =3D [
+@@ -119,6 +134,7 @@ zig_cc_toolchain_config =3D rule(
+     attrs =3D {
+         "cxx_builtin_include_directories": attr.string_list(),
+         "linkopts": attr.string_list(),
++        "dynamic_library_linkopts": attr.string_list(),
+         "copts": attr.string_list(),
+         "tool_paths": attr.string_dict(),
+         "target": attr.string(),
+--=20
+2.34.2
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 1C59911EEAC
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed,  1 Jun 2022 01:58:19 +0000 (UTC)
+From: ~jvolkman <jvolkman@git.sr.ht>
+Date: Tue, 24 May 2022 17:17:33 -0700
+Subject: [PATCH bazel-zig-cc 2/2] Pass "-Wl,-undefined=dynamic_lookup" for
+ dynamic libraries on darwin.
+Message-ID: <165404869855.21942.14779642481390967131-2@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~jvolkman <jeremy@jvolkman.com>
+In-Reply-To: <165404869855.21942.14779642481390967131-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+MIME-Version: 1.0
+Status: O
+Content-Length: 920
+Lines: 25
+
+From: Jeremy Volkman <jeremy@jvolkman.com>
+
+This linker flag causes undefined symbols to be ignored, which is the
+default behavior on linux but not macos. This is required when building
+shared libraries to use as e.g. Python modules. This also matches what
+Bazel's built-in macos cc toolchain does.
+---
+ toolchain/private/defs.bzl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+index 053641c..42aaaeb 100644
+--- a/toolchain/private/defs.bzl
++++ b/toolchain/private/defs.bzl
+@@ -54,7 +54,7 @@ def _target_darwin(gocpu, zigcpu):
+             "libc/include/any-macos-any",
+         ],
+         linkopts = [],
+-        dynamic_library_linkopts = [],
++        dynamic_library_linkopts = ["-Wl,-undefined=dynamic_lookup"],
+         copts = [],
+         bazel_target_cpu = "darwin",
+         constraint_values = [
+-- 
+2.34.2
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=ROrH1fl4aXGJDhhg7ecSxnS+aDbQ/KM1o2w4Tc4xcDU=;
+ c=simple/simple; d=sr.ht; h=Date:From:In-Reply-To:Subject:To:Cc;
+ q=dns/txt; s=srht; t=1654049536; v=1;
+ b=G9xsTIIzrHF9PoYIBvYHxZTNKGD3IUnLiG3ErFS0TzBko6BOSlwFfdVEeNN3OLg3oxuKTFk+
+ 5orIhabsTCsewC4HzAHwpF4jRcH6EeafODJTJMLC6DY8empAgXM+afq91SwXhVkzWK6Jjnp3rDr
+ EzvtdH/LIt9PydQQo+vs5WXm/dgU/AKxK4iNCFv1FzbmBVYuwGGdhCpn0rHDyO/W5+tekMEMss0
+ 03ISP7EHmrNyQg6PiaXA5wRjzOnRIrMAD8Oldrhn3Qh0013TxPUkT/YzYVbZO9QV/TQb/vMKnN5
+ BLjZ0bltbf+m3GDjhaoSfRH20AdtpEFo931Zx0xwRNwyw==
+Received: from localhost (unknown [173.195.146.244])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id E94AD11EEAC;
+	Wed,  1 Jun 2022 02:12:16 +0000 (UTC)
+MIME-Version: 1.0
+Date: Wed, 01 Jun 2022 02:12:16 +0000
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CKEFMJ9V23W8.2WPHUNU0SM2FZ@cirno2>
+In-Reply-To: <165404869855.21942.14779642481390967131-2@git.sr.ht>
+Subject: [bazel-zig-cc/patches/.build.yml] build success
+To: "~jvolkman" <jeremy@jvolkman.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 354
+Lines: 10
+
+bazel-zig-cc/patches/.build.yml: SUCCESS in 13m55s
+
+[Ignore undefined symbols when building dynamic libraries on darwin][0] fro=
+m [~jvolkman][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/32674
+[1]: mailto:jeremy@jvolkman.com
+
+=E2=9C=93 #771513 SUCCESS bazel-zig-cc/patches/.build.yml https://builds.sr=
+.ht/~motiejus/job/771513
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oi1-f180.google.com (mail-oi1-f180.google.com [209.85.167.180])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 8750411EEB5
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed,  1 Jun 2022 09:02:18 +0000 (UTC)
+Received: by mail-oi1-f180.google.com with SMTP id k11so1787872oia.12
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 01 Jun 2022 02:02:18 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=mime-version:references:in-reply-to:from:date:message-id:subject:to
+         :cc;
+        bh=WVBKt6nKOhROJQBG791R/QKA4rxCC0/sxfJ8tzBFMQw=;
+        b=zN2PmSeHoXVMoGsCOfUSVeXe9H2tokMaebDGt6CG5zutUSs7l5+/kG9P9plKjCF6C6
+         mmW6bn+WCfzX59AsyVWZ7rGCp63a8mE16BVlNfWAKL/B6Pi3rO0C294Eyb0ctmsDWB52
+         FJ4SAKfyN7FOSSsn68nQ9urXbLeNnwo0fNVOieeuqF5hTefCCp7WF2QbI0iAb6hHrEZs
+         u8yRKeR8v+vqtPzLodYJDb/hnGUHZPpDD7t4AlKJig15Fua2v1bV/agqJBp6tllnX6vb
+         cLOpK8r1h7JBU4b8+9nMsGeF5+KlWCxyiWnmNRGAXdEVNySjeylaGVrL+QtROTxFGtMY
+         9xlQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:references:in-reply-to:from:date
+         :message-id:subject:to:cc;
+        bh=WVBKt6nKOhROJQBG791R/QKA4rxCC0/sxfJ8tzBFMQw=;
+        b=BfI9J3uByh1jmDTGqcIEa5a1NJuGGrgEcUWRnFWTtDzVVVxsf2kP4Dqzyu/GI1LxQg
+         FX5ef1+A9zIyMnoC6K2okZyJ0jMpZxPpbSFBJSkAZrhy9lNimrcFSs1+OecfCE3HTy0n
+         B9it/Yn7yKHC81rBcy9GNnjq5ggTOkC8fYEMh1VAX3107zEf+EBpD43NZqQfI/tcAEM6
+         epm+btgCAfiDugPfcYW6M3yXjQ4cQgyKIIhWGwm/qwehwnwW8zcDRXzXW6v8JT0rNIFt
+         rby6xAbJoWaIPMYVQnizg0nTYwAC/+uDqZwl750bmwJ4nqk642sK5hvu0SKWbjzPmrUQ
+         h13g==
+X-Gm-Message-State: AOAM533x71M6Z1X9nsmyUyMMthKZiurThyQ6pYXcGLdvJkbYGzMMkhh8
+	uT1RFGg9CgXFPpp+iOkhwNzLL9NspYQ3HQWx1FHfwRI29ic=
+X-Google-Smtp-Source: ABdhPJwK3jxz73xdi701oWU7OHVC3Xp+wc+iXNniSo/ze9tK6TeP6YYVCT2nqfg9oAFRpWLhq7i8aPpNYi1HyqKmhYg=
+X-Received: by 2002:a05:6808:1527:b0:32e:8d6:d30f with SMTP id
+ u39-20020a056808152700b0032e08d6d30fmr3844407oiw.35.1654074137829; Wed, 01
+ Jun 2022 02:02:17 -0700 (PDT)
+MIME-Version: 1.0
+References: <165404869855.21942.14779642481390967131-0@git.sr.ht>
+In-Reply-To: <165404869855.21942.14779642481390967131-0@git.sr.ht>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Wed, 1 Jun 2022 12:02:06 +0300
+Message-ID: <CAFVMu-qEJGEUdQSpzYegi+3Z8c1iEDagdd8a1Jv2JP-6+pBy8Q@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc 0/2] Ignore undefined symbols when building
+ dynamic libraries on darwin
+To: "~jvolkman" <jeremy@jvolkman.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 1042
+Lines: 28
+
+On Wed, Jun 1, 2022 at 4:58 AM ~jvolkman <jvolkman@git.sr.ht> wrote:
+>
+> Hi,
+>
+> Here's an updated version of this patchset that fixes an operator
+> precedence issue in zig_toolchain.bzl when building flag_sets.
+> //test/gorace:gorace_test was failing before, but now passes.
+
+As I have no idea how this works on Darwin, and we don't use Darwin
+targets internally yet, my acceptance criteria for Darwin is:
+- CI passes.
+- after reading the commit messages it seems like you know what you
+are doing. Though for next time please add more links where those are
+discussed.
+- I trust people on internet by default (in other words, I don't have
+a reason to not trust you).
+
+Applied.
+
+> I haven't been able to get the arm64 tests to pass locally. Here's
+> hoping they work too!
+
+I assume you mean linux_arm64. That fails for me too, because it is
+relying on system's arm64 libc. The real resolution would be to use a
+hermetic libc, which I haven't gotten around doing yet. But as long as
+CI passes, we're good.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-oi1-f174.google.com (mail-oi1-f174.google.com [209.85.167.174])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 8EC6211EEB5
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed,  1 Jun 2022 09:10:38 +0000 (UTC)
+Received: by mail-oi1-f174.google.com with SMTP id s188so1863389oie.4
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 01 Jun 2022 02:10:38 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=mime-version:from:date:message-id:subject:to;
+        bh=SYDruTTY8y1MIH2djeXys76g+D0h3n0YFtaTqdy94p0=;
+        b=jyyMYy4HuUsG2Cues1SfIeDKJ3Rhd+VZDBJljapjqPIgVSbRIQTVOOpOgZmjoPVrZG
+         HuJ4sgSmbXE9WYp8K6DQ2v8pXK9x74EeC93W6WTOo21aoZdgGQ/JjJaTcOv/7h+FfGRR
+         ECrc/aRcEmTR3owfLD0prvzIf5rgzCqUC4wdeju/oq8t/1JNDbTZayufN8ZFdyacL4Xl
+         4zRMZaAC0apEJw82yHqRcsMSFiqxO/ctf6cqIwBzd5oWs9ckoR4BfYvmQvLlVu8trOuO
+         d4PySMJd8sfFj0FaDPtEQpiLDMPa/UAIizjlLFs3nBlroDHyWc/Syv2SuGk3tHx4XXxN
+         nppA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:from:date:message-id:subject:to;
+        bh=SYDruTTY8y1MIH2djeXys76g+D0h3n0YFtaTqdy94p0=;
+        b=3KyVRjk21TECUzgt2TeTRwrTFv7CJutrrfhFMcbjBjiYLSE2tf0h+yJw6PaY5Kfk9A
+         PJs6WzC1aOkD3Fyii5IrCgohJ09HvALZCaaqIEikoYrNg+ePhqToi0CS5+M3Yr6nFepv
+         L3cNaSdKQdGD3+pCg6RT3YdzXp4FID/MBll2h3umIeFNCxiGCfgv+EpD1pXxRiercFua
+         bKIiGL62OSYKmx4t1ZU2I/N9iBsKowh9a0iUtUG9VtdWC7oXUePVpx2ABd3QekoedROU
+         4oE9W641IKCUB8L9Q5L27w74YEfsoTDQpFORarJBqDpiXVgnfdYqqsdletX5kWOAaQrm
+         xLaQ==
+X-Gm-Message-State: AOAM531ZvlTWjQGpQ2IbCGm9H37tPVQ/sKcdc/RQ5U8b1+L2ARLz1FF8
+	QpBM7XOXZ/SxUcJUa/zkgpBexYuwYyI5UxJqmBNITAgwTkM=
+X-Google-Smtp-Source: ABdhPJx9CF9smdMFad3mTie8ZS7qx1apPTPd+Oxde83skYWTEYidXd1oV7vnvNMgGBjr538sl8c/CsTMJC709uDFvQs=
+X-Received: by 2002:a05:6808:1527:b0:32e:8d6:d30f with SMTP id
+ u39-20020a056808152700b0032e08d6d30fmr3866277oiw.35.1654074637846; Wed, 01
+ Jun 2022 02:10:37 -0700 (PDT)
+MIME-Version: 1.0
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus.jakstys@gmail.com>
+Date: Wed, 1 Jun 2022 12:10:27 +0300
+Message-ID: <CAFVMu-qt+27Xq+SAZsJvNJjKG5DyXQ9Rp71GqWg+f-zgn3WFaA@mail.gmail.com>
+Subject: bazel-zig-cc v0.7.3 and published Zig Milan talk
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 826
+Lines: 20
+
+Hi folks,
+
+If you haven't seen, my Zig Milan talk about Zig and Uber was
+published[1], together with an accompanying blog post[2].
+
+Now to our bazel-zig-cc changelog from v0.7.2 to v0.7.3:
+
+# zig sdk: download from zig upstream as well as jakstys.lt
+This will prefer Zig upstream mirror over my server. This should
+increase reliability. I hope Bazel will try the secondary mirror when
+it gets a 404 from Zig's. Time will tell.
+
+# Darwin changes by Jeremy Volkman
+See the thread discussing the patch[3] for more info.
+
+Motiejus
+
+[1]: https://www.youtube.com/watch?v=SCj2J3HcEfc
+[2]: https://jakstys.lt/2022/how-uber-uses-zig/
+[3]: https://lists.sr.ht/~motiejus/bazel-zig-cc/%3C165404869855.21942.14779642481390967131-0%40git.sr.ht%3E#%3CCAFVMu-qEJGEUdQSpzYegi+3Z8c1iEDagdd8a1Jv2JP-6+pBy8Q@mail.gmail.com%3E
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f54.google.com (mail-oa1-f54.google.com [209.85.160.54])
+	by mail-b.sr.ht (Postfix) with ESMTPS id D569211EEC2
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed,  1 Jun 2022 09:36:42 +0000 (UTC)
+Received: by mail-oa1-f54.google.com with SMTP id 586e51a60fabf-e93bbb54f9so1922362fac.12
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 01 Jun 2022 02:36:42 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=mime-version:references:in-reply-to:from:date:message-id:subject:to
+         :cc;
+        bh=S29EghuRv0xDMDewiWDbsQxoklo64IZhi7BpI4ARk1Q=;
+        b=6UHUA0nUrQU1beG/CFRQLYXIvKac0Q/9T11PcpIqIZN+MuT8v3VsTlFPYanRFVIyMv
+         S6QxEFG59ya+Vxf5yL6RPf+BDf1o+YfF0xJ8FwyerH1MVGol6VtqQEUUukN5bRdns2hj
+         NNgcgQ1LKBFwd4IOVsYJKdoCDS4c0DiQU7KumIAqJqkzIC5LXS76sPBpSPx2Gmgit7Df
+         ES4twf/scRyqf5gTiJZo5L9DwRkUevZVtiiq5PbpBRUOiKXYT10TeebFQxXizvNeCtK+
+         mg6ScDcElyeT/N3Aq0MdJSp6ubDl0NF3VDzzs+jfnpcLhfbj6CKbttLHn9vMaS7sFTd3
+         VP7A==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:references:in-reply-to:from:date
+         :message-id:subject:to:cc;
+        bh=S29EghuRv0xDMDewiWDbsQxoklo64IZhi7BpI4ARk1Q=;
+        b=UNMGJSsI/6RUHKQpJwhwgVZ9miGFMgDiiNIyUwufbRlRYj6kQy7D9NStCykUSQI0GU
+         udxx48AqQiyKHT70z9EregICJHDRrMqv2z/cZl2VpRn1v4LlLtUGQ3+PZf+KBy/u54X0
+         uG+iN+ppT9rb4Sr6bmsTINFJ8TaVwRfi5H2s6y8ThjlkeWx1kClUYCaPrd5rS/puWk6r
+         iDyjjv4KWYE1IdrX0Vl+j/WHP76l2umuN6QsA6r4m+aZ9wXQ/LevaDIh1dNQHcUJlMK2
+         ILjBI+8RJzDpy9Sj6MJUZQwFyURBWH2Vag+9yOgd5vMsXvGT82JCMrU/dy33Ii7Smmk1
+         9IkA==
+X-Gm-Message-State: AOAM532ujUtlcKzD/tZlXm2Lbst9yg8ixlSkHPpN/ectBkCX/X8/tJEb
+	h6xkds7kF4Cx4OLggUI9QTjsOlvBCsAeklvnXlY=
+X-Google-Smtp-Source: ABdhPJxaJ2k2zabWiTQwNUAXB9MUKBuMdG7G9Nlm0plHLyVLDTFaWJ8eauLOQhDO0MKv0SLOBi/nsWprU/vNVighKUo=
+X-Received: by 2002:a05:6870:f5a5:b0:f2:d204:cc3c with SMTP id
+ eh37-20020a056870f5a500b000f2d204cc3cmr16669592oab.35.1654076202100; Wed, 01
+ Jun 2022 02:36:42 -0700 (PDT)
+MIME-Version: 1.0
+References: <165404869855.21942.14779642481390967131-0@git.sr.ht>
+ <CAFVMu-qEJGEUdQSpzYegi+3Z8c1iEDagdd8a1Jv2JP-6+pBy8Q@mail.gmail.com> <CAFuCWxsW2e8jXJsynoBw1TCts2UTrPjbRwEFyF6-bec_6ErsZw@mail.gmail.com>
+In-Reply-To: <CAFuCWxsW2e8jXJsynoBw1TCts2UTrPjbRwEFyF6-bec_6ErsZw@mail.gmail.com>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Wed, 1 Jun 2022 12:36:30 +0300
+Message-ID: <CAFVMu-ryTs9=nO8-F2y88FPgr-TcrfCnKa-=tBC6A4ryc1TuMg@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc 0/2] Ignore undefined symbols when building
+ dynamic libraries on darwin
+To: Jeremy Volkman <jeremy@jvolkman.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 697
+Lines: 16
+
+On Wed, Jun 1, 2022 at 12:30 PM Jeremy Volkman <jeremy@jvolkman.com> wrote:
+>
+> Hi Motiejus,
+>
+> Thanks for accepting. I'm not sure if you saw, but I had submitted this patch a week ago (broken) with more discussion and links in the overview. I forgot to increment the version number, so it wasn't obvious.
+
+I had a vague memory of looking into this, but wasn't sure where.
+Turns out that wasn't that long ago. :)
+
+Anyhow, reason I am asking this: I try to apply patches as-is, so all
+re-posts should be self-contained, as if earlier of them didn't
+happen, because they are not going to the git history. Let's err on
+the side of more verbosity than less, always.
+
+Thanks,
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jvolkman-com.20210112.gappssmtp.com header.i=@jvolkman-com.20210112.gappssmtp.com
+Received: from mail-lf1-f42.google.com (mail-lf1-f42.google.com [209.85.167.42])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 9F77E11EEB5
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed,  1 Jun 2022 09:43:03 +0000 (UTC)
+Received: by mail-lf1-f42.google.com with SMTP id a15so1774509lfb.9
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 01 Jun 2022 02:43:03 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jvolkman-com.20210112.gappssmtp.com; s=20210112;
+        h=mime-version:references:in-reply-to:from:date:message-id:subject:to
+         :cc:content-transfer-encoding;
+        bh=jdqcTS1RkXNMnxW573lfZaSsgJzDVJarhUtgCPUUgtU=;
+        b=1cw3UKYJcVvPojTkZrC2bXXd/z8fMimLqhsBMboKks8PwK9utzO9ZF9qL9lFV6clki
+         hemPorZ34+gZkC16P/5jvyzz08Lb4r57sIUZi0+PQIe/QUW6zlZdNn06DfxTHXFAjPwd
+         XmByJIYrupVXYSOIVG/yHzEVT5RtHfnwb4H/MFI3SxG/IycIQVAOI7R1fPxMqZf/ly7n
+         oEPqTxygY+bLJcw2isa8KKS/ph4s03e+aKAD1mgF1nwL1wgoV9qtVuQf1GH3ADDYUkxi
+         EuUSDgS8RD+CMKIgkOR86R7z20dLI7SRvvrGRGjld+JO0R6i3VxcCgvm18nlekQGth2g
+         shpw==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:references:in-reply-to:from:date
+         :message-id:subject:to:cc:content-transfer-encoding;
+        bh=jdqcTS1RkXNMnxW573lfZaSsgJzDVJarhUtgCPUUgtU=;
+        b=M4OVYloWiHGECdWwS+ysUFlFsh57/m19UyA3yskiph1re5fvg41UOEKCrFH/NDISF3
+         ob2OKtOR1kPGkWk2DolqXxlF3g+G08WDSLrrpACDXJpUmBnP1uEawTyKmdzuV3XMR9CU
+         wYAYNW5BJ0VBJd3elo/QSO92HpDFI04bd/58Vx2jA2+245JyFkfNfANVGjCmBdaJGIHL
+         6vkdB4/Gk3Tu/A+nf6Mu22Qj2B1LigPUP1prF/jqGJhPU3W4v1JlClSSRqH57hbiQaEC
+         SG5AW/Bt1VJvK+7CgMKN5KosJkLEcmNXJfJDzBnQYFfPq06ec/S7GfK6Rj428S7QAlpH
+         6y5Q==
+X-Gm-Message-State: AOAM530RYpn7WE4xz42UF93QnwcoTjqjnSWvkCD4R8rzK9SX4eTtPo7x
+	PizHHhctVT/oy6ei5TWNXjpJiA90LWeBuZlnvDg=
+X-Google-Smtp-Source: ABdhPJwYBILZz8BX8EoH2+RUt58i+KMsSlH4tD1Gn2GDMfE9Gm0tTOVWIKv8iMtjl6LaEd6+nE5ZPwGrIquw4i5kSLo=
+X-Received: by 2002:a05:6512:ea9:b0:478:7f6b:5289 with SMTP id
+ bi41-20020a0565120ea900b004787f6b5289mr32132756lfb.87.1654076582449; Wed, 01
+ Jun 2022 02:43:02 -0700 (PDT)
+MIME-Version: 1.0
+References: <165404869855.21942.14779642481390967131-0@git.sr.ht>
+ <CAFVMu-qEJGEUdQSpzYegi+3Z8c1iEDagdd8a1Jv2JP-6+pBy8Q@mail.gmail.com>
+ <CAFuCWxsW2e8jXJsynoBw1TCts2UTrPjbRwEFyF6-bec_6ErsZw@mail.gmail.com> <CAFVMu-ryTs9=nO8-F2y88FPgr-TcrfCnKa-=tBC6A4ryc1TuMg@mail.gmail.com>
+In-Reply-To: <CAFVMu-ryTs9=nO8-F2y88FPgr-TcrfCnKa-=tBC6A4ryc1TuMg@mail.gmail.com>
+From: Jeremy Volkman <jeremy@jvolkman.com>
+Date: Wed, 1 Jun 2022 02:42:53 -0700
+Message-ID: <CAFuCWxtUpyZ2CETxdYct7J8sNOz2zknE2Ox4Z60qtQap8RrvQA@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc 0/2] Ignore undefined symbols when building
+ dynamic libraries on darwin
+To: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 859
+Lines: 26
+
+Sounds good. Thanks!
+
+-Jeremy
+
+On Wed, Jun 1, 2022 at 2:36 AM Motiejus Jak=C5=A1tys <motiejus@jakstys.lt> =
+wrote:
+>
+> On Wed, Jun 1, 2022 at 12:30 PM Jeremy Volkman <jeremy@jvolkman.com> wrot=
+e:
+> >
+> > Hi Motiejus,
+> >
+> > Thanks for accepting. I'm not sure if you saw, but I had submitted this=
+ patch a week ago (broken) with more discussion and links in the overview. =
+I forgot to increment the version number, so it wasn't obvious.
+>
+> I had a vague memory of looking into this, but wasn't sure where.
+> Turns out that wasn't that long ago. :)
+>
+> Anyhow, reason I am asking this: I try to apply patches as-is, so all
+> re-posts should be self-contained, as if earlier of them didn't
+> happen, because they are not going to the git history. Let's err on
+> the side of more verbosity than less, always.
+>
+> Thanks,
+> Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 39D5A11EEB5
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed,  1 Jun 2022 17:05:51 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1654103143;
+	bh=PFSoKnkCTJrJ+Uml/M6x2RBPoR4+Cz2ljB8Iw2xINIE=;
+	h=From:To:Cc:Subject:In-Reply-To:References;
+	b=nyP3Lv/Wv0F332eCz/w5rKbqCvYynxnH9j3+TiPdIhh1gINl+UtA3v0H2FbeWWLFm
+	 op3YjCfxg6FIQnxioFNltyJON24srPQU0/JrBPMZ64KsBQMqqdkDOROKRn+FdmIzrU
+	 4jDaLld/9xe3Ym/vJIMskxLDZ/zS223Z+K3LvnRw=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8;
+ format=flowed
+Content-Transfer-Encoding: 8bit
+Date: Wed, 01 Jun 2022 18:05:37 +0100
+From: fabian@hahn.graphics
+To: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: Re: [PATCH bazel-zig-cc v2 0/3] Windows support
+In-Reply-To: <CAFVMu-ps+Pt5DqSnUZ323sDcQB-MmjBg01nMfHK+kxtgr0Ew_g@mail.gmail.com>
+References: <20220529163518.182119-1-fabian@hahn.graphics>
+ <CAFVMu-ps+Pt5DqSnUZ323sDcQB-MmjBg01nMfHK+kxtgr0Ew_g@mail.gmail.com>
+Message-ID: <faee59d97f64ea7c368c583efe84db88@hahn.graphics>
+X-Sender: fabian@hahn.graphics
+Status: O
+Content-Length: 1577
+Lines: 32
+
+Hey Motiejus,
+
+On 2022-05-30 13:37, Motiejus Jakštys wrote:
+> As you may have noticed, the past patchset doesn't pass CI. If you
+> have a Linux machine, the tests are quite easy to execute manually[1].
+> Otherwise don't worry about sending multiple patch versions; I am
+> happy to ignore the patchsets (and the emails from the CI) until the
+> tests pass. That's what they are there for!
+
+I've actually been running the tests successfully on my Ubuntu box. I a
+bit confused at first looking at the failed build logs [1] until I
+I realized what the problem was: Even though I updated .build.yml in my
+patch, it actually uses the original baseline file in the repo to run
+the CI steps. This means that my addition of the wine-binfmt Debian
+package doesn't get picked up, which then causes the bazel test to fail
+that tries to run the actual Windows binary as it doesn't know how to
+interpret it. I now realized that there's further setup commands in the
+"setup" task. I will try to add the package there instead.
+
+> You can also use a transient docker environment[2] to isolate yourself
+> from the host OS. Let me know if that works for you.
+
+I just tried this and my tests passed, but only after I manually ran
+`update-binfmts --enable wine` inside the container. I'm a bit confused
+because this wasn't needed for qemu arm64 emulation, but maybe that's a
+wine-binfmt specific thing? Anyway, I will try to go with the setup
+step approach and add that extra command there too if needed.
+
+Best,
+Fabian
+
+[1] https://builds.sr.ht/~motiejus/job/769696
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oi1-f181.google.com (mail-oi1-f181.google.com [209.85.167.181])
+	by mail-b.sr.ht (Postfix) with ESMTPS id D313011EF41
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu,  2 Jun 2022 03:06:59 +0000 (UTC)
+Received: by mail-oi1-f181.google.com with SMTP id r206so5060045oib.8
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 01 Jun 2022 20:06:59 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=mime-version:references:in-reply-to:from:date:message-id:subject:to
+         :cc:content-transfer-encoding;
+        bh=rH/W4qS90Y/n0ND+RMRLeQWCKOp+ZcH5sX00mIWggjk=;
+        b=OxR/a19tDTaf7aF/K/PjfryRRICLvyw1sfNnHAD+MGk5JWWgb697MMjts6hkHetnDy
+         ocTVm1lziC8tZuEPLYLE/yigckDLwrnIN3Qjtq8yyLxfrB2TSkGICHPMGPjKaNqUADUf
+         ujZcZKpoIV9kARt771OGjHYt9c+c7cutC2PPkz/qqqInyJR3M3Pf4DSvT1kzA9h0KKSR
+         qMBZ7vDrKQQSL0AyiMxw1Af+1w+KinV/FMxzr/G42MkYdmgLuGDd2dTpZW2ZOCZ+A40v
+         sWTvC97cjehkejVTPs1/4u86PNg1JlUv6RrM+ldA4BG3cbHfMIKDnttv0Te3WgnB1pSC
+         ORDA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:references:in-reply-to:from:date
+         :message-id:subject:to:cc:content-transfer-encoding;
+        bh=rH/W4qS90Y/n0ND+RMRLeQWCKOp+ZcH5sX00mIWggjk=;
+        b=Ky9B1hsuzkUfrOpHX4/vIv0hPlGTor0KjBmkKWQ42NOahTfmecpb8IssQiq12jSL9o
+         3VyPsazmR9R9MOyuFiqE7j+YC4S5PaqA41YYtochyeJR21IA32ipRAMaGeGDPzAkKjq7
+         TDNOmJ+sFJ1mwmQ1gzxzpQhvtlOt3pca/KCAZFMvMu9QU4cImsb+qyA0AcnAzlGfS68U
+         itzTtGoxcWAUm3VtsCwoAJ+Ui2M2cFgAK24Ao3RJnz6Ce0ibiXnpsGfrbp76l/AHRd8I
+         s3ENcxo+azUcl6CiX9JeirQnwf50yMiFjwbec/DM3yFCatS9s9vxQ49ucSjmBfQbCkz+
+         t3Xg==
+X-Gm-Message-State: AOAM532y29DkcFli66S8/m29x2czbAGUiMcgLqJdt7TZqyQL06U5qRhV
+	KTCCs/tqjbtDTJFfFcilmCMZRjXEfaOsqk3SusEnqJvX2/4=
+X-Google-Smtp-Source: ABdhPJxlTNRJzquwFI8gXQAHB3spJJwoBSiQbJRwYhbYPKq1oC7kFefBP1j4kjRQktXMsTuZoyYRTaa6KfxjGOcicjU=
+X-Received: by 2002:a05:6808:171c:b0:2f9:c685:f4d9 with SMTP id
+ bc28-20020a056808171c00b002f9c685f4d9mr1518581oib.21.1654139217564; Wed, 01
+ Jun 2022 20:06:57 -0700 (PDT)
+MIME-Version: 1.0
+References: <20220529163518.182119-1-fabian@hahn.graphics> <CAFVMu-ps+Pt5DqSnUZ323sDcQB-MmjBg01nMfHK+kxtgr0Ew_g@mail.gmail.com>
+ <faee59d97f64ea7c368c583efe84db88@hahn.graphics>
+In-Reply-To: <faee59d97f64ea7c368c583efe84db88@hahn.graphics>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Thu, 2 Jun 2022 06:06:46 +0300
+Message-ID: <CAFVMu-pihCk8dj_MRrhqGhhoaAy1rOL7rx+pgMkEZFcOvVeWfw@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc v2 0/3] Windows support
+To: Fabian Hahn <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 1878
+Lines: 38
+
+On Wed, Jun 01, 2022 at 06:05:37PM +0100, fabian@hahn.graphics wrote:
+> Hey Motiejus,
+>
+> On 2022-05-30 13:37, Motiejus Jak=C5=A1tys wrote:
+> > As you may have noticed, the past patchset doesn't pass CI. If you
+> > have a Linux machine, the tests are quite easy to execute manually[1].
+> > Otherwise don't worry about sending multiple patch versions; I am
+> > happy to ignore the patchsets (and the emails from the CI) until the
+> > tests pass. That's what they are there for!
+>
+> I've actually been running the tests successfully on my Ubuntu box. I a
+> bit confused at first looking at the failed build logs [1] until I
+> I realized what the problem was: Even though I updated .build.yml in my
+> patch, it actually uses the original baseline file in the repo to run
+> the CI steps. This means that my addition of the wine-binfmt Debian
+> package doesn't get picked up, which then causes the bazel test to fail
+> that tries to run the actual Windows binary as it doesn't know how to
+> interpret it. I now realized that there's further setup commands in the
+> "setup" task. I will try to add the package there instead.
+>
+> > You can also use a transient docker environment[2] to isolate yourself
+> > from the host OS. Let me know if that works for you.
+>
+> I just tried this and my tests passed, but only after I manually ran
+> `update-binfmts --enable wine` inside the container. I'm a bit confused
+> because this wasn't needed for qemu arm64 emulation, but maybe that's a
+> wine-binfmt specific thing? Anyway, I will try to go with the setup
+> step approach and add that extra command there too if needed.
+
+That's fine. I pushed it to a branch, which kicked off CI[1]. That
+passed.
+
+I will review your patch in a short order. Sorry for the confusion and
+thank you for clarifying.
+
+Motiejus
+
+[1]: https://builds.sr.ht/~motiejus/job/772421
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oi1-f169.google.com (mail-oi1-f169.google.com [209.85.167.169])
+	by mail-b.sr.ht (Postfix) with ESMTPS id AA2D711EF01
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon,  6 Jun 2022 07:37:53 +0000 (UTC)
+Received: by mail-oi1-f169.google.com with SMTP id s8so13381534oib.6
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 06 Jun 2022 00:37:53 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=mime-version:references:in-reply-to:from:date:message-id:subject:to
+         :cc:content-transfer-encoding;
+        bh=d4gxM3P1SLz8KRgDn8hT4qEJRFlUsvvp87V+mZKND4Q=;
+        b=P97jhLDV+lJEbf21ZQlI0cjHw+GsrGzOwgshV66pp5d4kDbnk0iG9DMoZhZC+mEZqU
+         puOBkT+13SKxSAN8zfTmJ1jsHZtP5p+7fgQf6Rdy0Nc+/Jx8te+Lj3dSAQlj5Yz6ZKvj
+         Qx3H5TzLkOWPNCKmnlTNgLEwaUq3A9oUD049CO7q5Tc1H3cz6qBVfRG9KlnbP955ndX4
+         4bKYN+gOFGWock3oFihNxv0Kwwdp7rlyohAqi18UkPxLlhypyCFBqEWU9UpEUxBdsffq
+         AB+pC8V9dpu3Wl/zeuzYTw0tQO22Y9TeC0lQC9xOF2CDdhreIICUX8muLlbcd8WE0cUI
+         l8Bw==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:references:in-reply-to:from:date
+         :message-id:subject:to:cc:content-transfer-encoding;
+        bh=d4gxM3P1SLz8KRgDn8hT4qEJRFlUsvvp87V+mZKND4Q=;
+        b=OXzVoUNayUuWflUanRpVWFcv0n+5ZVH6eX8QsGDbx9k4V61gbRni6A0si7HnUTn8Hc
+         OwvrV0NBz/tjSVds22utqnkjfa3V3RbgM8CNRPuZvxB3cLHdBTZS5F0xlpwc9jCOH4h6
+         iE7yRz+9Brjb0mJOmFmUswJ45LtjaXNzGWk4iueBgCYQb5xTOKhjtxSp5ggybTGngEb5
+         dR3od/hbfPppCqXv3sBZ4JxUEDGP62pXolR7EEd5EM+byIGGaMCnNwV2gG2t8fKaGqnB
+         H3yMIemS2c3+qVJkROSLelw+5T9tqbJ+57rCwcnz90Q7zIPb3UFvWoqi5AS0stqBpuL2
+         QKdg==
+X-Gm-Message-State: AOAM5307Vw4PGjEX+NWZEUZcRw8lhJcHmm07q4EECp5dChCzMMxie9AW
+	ZpZ1UPsWDHQlU1Dt7d+VWCvh+NbMx0ZbdePdleI=
+X-Google-Smtp-Source: ABdhPJxJUfyRqukOO/ClY7IxiZ+Sl4Vesg9mtbgob2hZjv4kE9uMuYWMT1ExykMoKokjgakj36sLf5jnCv136p2V4aU=
+X-Received: by 2002:a05:6808:308e:b0:32b:20ef:15ff with SMTP id
+ bl14-20020a056808308e00b0032b20ef15ffmr29064055oib.216.1654501068924; Mon, 06
+ Jun 2022 00:37:48 -0700 (PDT)
+MIME-Version: 1.0
+References: <20220529163518.182119-1-fabian@hahn.graphics> <CAFVMu-ps+Pt5DqSnUZ323sDcQB-MmjBg01nMfHK+kxtgr0Ew_g@mail.gmail.com>
+ <faee59d97f64ea7c368c583efe84db88@hahn.graphics> <CAFVMu-pihCk8dj_MRrhqGhhoaAy1rOL7rx+pgMkEZFcOvVeWfw@mail.gmail.com>
+In-Reply-To: <CAFVMu-pihCk8dj_MRrhqGhhoaAy1rOL7rx+pgMkEZFcOvVeWfw@mail.gmail.com>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Mon, 6 Jun 2022 10:37:37 +0300
+Message-ID: <CAFVMu-o4DSj9H1qfJ8oBHGu6CXGszY79eERJRx6EXWeXPgtjKA@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc v2 0/3] Windows support
+To: Fabian Hahn <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 1126
+Lines: 29
+
+On Thu, Jun 2, 2022 at 6:06 AM Motiejus Jak=C5=A1tys <motiejus@jakstys.lt> =
+wrote:
+> I will review your patch in a short order. Sorry for the confusion and
+> thank you for clarifying.
+>
+
+Hi Fabian,
+
+I spent a couple of hours on this and published it to
+motiejus_windows[1] branch. Notable changes:
+- added test wrappers, so we no longer depend on wine-binfmt. Bazel
+does something unusual with sandboxing, so we still need this for
+linux-arm64.
+- side effect: `bazel test ...` remains the only command to run all
+tests by a mixture of "manual" and "no-sandbox" tags on some targets.
+- fixed linux-arm64.gnu tests. Until the changes those failed on all
+computers I've tried except CI. Now they work everywhere I've tried,
+assuming dependencies are installed.
+- trivial: renamed ext to _ext to convey "it's private", also updated
+release scripts.
+
+Please review my changes on top of yours in the branch[1] and let me
+know if I didn't mess up anything. Then I can release v0.8.0.
+
+As usual, thanks to Laurynas for tips.
+
+Motiejus
+
+[1]: https://git.sr.ht/~motiejus/bazel-zig-cc/tree/motiejus_windows
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 95D5511EF1B
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed,  8 Jun 2022 17:03:17 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1654707791;
+	bh=QLwRLhATaszHxFkSirsxI2L9B+cmVXrYQumrVloMFZw=;
+	h=From:To:Cc:Subject:In-Reply-To:References;
+	b=Jgj2/yhCtCsjjipoBAOB7wnZEeMn31FlMJH+akwWnl2aVQlDSCEF2Whzg+BoIeV00
+	 2hjLJAL//x7LyxTxTEqgwFLhgCud9KMe53gi1LBWBRsAjHiUx0kMnUvNwCef2RipEt
+	 R1XKv/g420hJcvNLtxzTIJglwADyaSn8uqG5wQ68=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8;
+ format=flowed
+Content-Transfer-Encoding: 8bit
+Date: Wed, 08 Jun 2022 18:03:05 +0100
+From: fabian@hahn.graphics
+To: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: Re: [PATCH bazel-zig-cc v2 0/3] Windows support
+In-Reply-To: <CAFVMu-o4DSj9H1qfJ8oBHGu6CXGszY79eERJRx6EXWeXPgtjKA@mail.gmail.com>
+References: <20220529163518.182119-1-fabian@hahn.graphics>
+ <CAFVMu-ps+Pt5DqSnUZ323sDcQB-MmjBg01nMfHK+kxtgr0Ew_g@mail.gmail.com>
+ <faee59d97f64ea7c368c583efe84db88@hahn.graphics>
+ <CAFVMu-pihCk8dj_MRrhqGhhoaAy1rOL7rx+pgMkEZFcOvVeWfw@mail.gmail.com>
+ <CAFVMu-o4DSj9H1qfJ8oBHGu6CXGszY79eERJRx6EXWeXPgtjKA@mail.gmail.com>
+Message-ID: <970d81eedf2eeed648ec06200b3d6567@hahn.graphics>
+X-Sender: fabian@hahn.graphics
+Status: O
+Content-Length: 1671
+Lines: 41
+
+Hey Motiejus,
+
+Thanks a lot for looking at my patches and adjusting them further.
+
+On 2022-06-06 08:37, Motiejus Jakštys wrote:
+> - added test wrappers, so we no longer depend on wine-binfmt. Bazel
+> does something unusual with sandboxing, so we still need this for
+> linux-arm64.
+
+I don't particularly mind, the run_under approach also looks fine to
+me.
+
+> - side effect: `bazel test ...` remains the only command to run all
+> tests by a mixture of "manual" and "no-sandbox" tags on some targets.
+
+I didn't know about the no-sandbox tag in bazel, so that's a great
+solution to make it work under `bazel test ...`!
+
+> - fixed linux-arm64.gnu tests. Until the changes those failed on all
+> computers I've tried except CI. Now they work everywhere I've tried,
+> assuming dependencies are installed.
+
+Right, I actually ended up passing QEMU_LD_PREFIX in --action_env and
+thought I had somehow messed up my qemu setup. Good to see this fixed!
+
+> Please review my changes on top of yours in the branch[1] and let me
+> know if I didn't mess up anything. Then I can release v0.8.0.
+
+The only thing I noticed is that since we no longer explicitly run
+bazel build in ci/test, we won't build the windows_arm64 test binary
+anymore. As far as I know bazel test ... won't build targets that are
+not required for running any tests, so unless we also put a command
+for bael build ... somewhere it won't be covered. This is a very
+minor point though, so feel free to ignore.
+
+I did run your branch against my project both on Linux and Windows
+machines and everything worked flawlessly. So from my point of view
+this is good to go.
+
+Best,
+Fabian
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f53.google.com (mail-oa1-f53.google.com [209.85.160.53])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 13D1B11EFD1
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed,  8 Jun 2022 19:51:20 +0000 (UTC)
+Received: by mail-oa1-f53.google.com with SMTP id 586e51a60fabf-f16a3e0529so28589001fac.2
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 08 Jun 2022 12:51:20 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=mime-version:references:in-reply-to:from:date:message-id:subject:to
+         :cc:content-transfer-encoding;
+        bh=CyqV+jkwMpm1LVOKc2MR4DBlPFo+Irj/WjUTMMyfSsc=;
+        b=PKpEpBKgk4akqzBK5fi/2KrXiQMUPZfFkUFEH0ItkuxePgh5urD1sPdGf4iSdyGmcu
+         Rw9RkKZ+pao0N4LasCwHUkFbv38tTlc0vqd9LbsAdgbdgApzBtLCaw7reHlPPZUdmt8o
+         +c4smH4wcM2QZLBm2h6v/sglOqdh9uIdU75o/XAROhYNwwx6+7/1Z/qg/mqu/qnIlYKL
+         XOynzSutYAmBIVf8gZUQ+5o4dPNfRmiX7EuSzXN3bVKa/qSf2cNPcon8YcW6Jcjwyoh7
+         u5mUOGec1i2dVAvqoRLFBwnasrNKDHCLCfakTiEqvlZcm1/RJL+Mnmhm95tacHtugXwI
+         jOPA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:references:in-reply-to:from:date
+         :message-id:subject:to:cc:content-transfer-encoding;
+        bh=CyqV+jkwMpm1LVOKc2MR4DBlPFo+Irj/WjUTMMyfSsc=;
+        b=SUmOgiyDkkeJYhFYnUGh5rvwoiF591Av6qbSjQhMZhOaefKW6OsMfoH6KdrYbZSHTV
+         KsmR0J1N800vigpOBCpV4P6OxRfhDH/NwrIr8NeXJQ/zlJX2E2eWZxXuVa6CNxRIs5Ig
+         HBA3WqkO+cVJIlr6ChGzJYp9c4BZeD/AEu+NLKdu0K1mRY83EHF6X/6dCjVDMLbl7SEM
+         lxA3SEbojMbi59XqxQMdJhWirZXei+Wq/cgpqVIduBN+UgKvC8V9wG4xYZ6SnNot14Gx
+         1C9sQz+8PrnwX5XFXwGYq1fc16NelC+/YvewUAnezpr2A1or1vkJOb7afz2ytIFtMZRK
+         tCmg==
+X-Gm-Message-State: AOAM531rbur7S3ArQn0211VcAzcEhWmjfuaSc0QfLSI7yqAwx7OqgRnb
+	9sNDPBLisZ0kCmKg9pwzxnRVQ+WZBJPivBG/jlFhAJ5JRms=
+X-Google-Smtp-Source: ABdhPJxnUyXrCT+vqt8X2rUgGvEIDitKlm2cRt9e19g8mkvoVYKBGdu92PN7dqxcCqGPPsjGy0MM4h8kvOy2NOk0WkU=
+X-Received: by 2002:a05:6870:f683:b0:f2:cc34:452a with SMTP id
+ el3-20020a056870f68300b000f2cc34452amr3424593oab.216.1654717879299; Wed, 08
+ Jun 2022 12:51:19 -0700 (PDT)
+MIME-Version: 1.0
+References: <20220529163518.182119-1-fabian@hahn.graphics> <CAFVMu-ps+Pt5DqSnUZ323sDcQB-MmjBg01nMfHK+kxtgr0Ew_g@mail.gmail.com>
+ <faee59d97f64ea7c368c583efe84db88@hahn.graphics> <CAFVMu-pihCk8dj_MRrhqGhhoaAy1rOL7rx+pgMkEZFcOvVeWfw@mail.gmail.com>
+ <CAFVMu-o4DSj9H1qfJ8oBHGu6CXGszY79eERJRx6EXWeXPgtjKA@mail.gmail.com> <970d81eedf2eeed648ec06200b3d6567@hahn.graphics>
+In-Reply-To: <970d81eedf2eeed648ec06200b3d6567@hahn.graphics>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Wed, 8 Jun 2022 22:51:08 +0300
+Message-ID: <CAFVMu-p=dPLrsCbMnR26MHj22rTk3LhE09_Ps2=cB_0sOZjPCA@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc v2 0/3] Windows support
+To: Fabian Hahn <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 1648
+Lines: 49
+
+On Wed, Jun 8, 2022 at 8:03 PM <fabian@hahn.graphics> wrote:
+>
+> On 2022-06-06 08:37, Motiejus Jak=C5=A1tys wrote:
+>
+> The only thing I noticed is that since we no longer explicitly run
+> bazel build in ci/test, we won't build the windows_arm64 test binary
+> anymore. As far as I know bazel test ... won't build targets that are
+> not required for running any tests, so unless we also put a command
+> for bael build ... somewhere it won't be covered. This is a very
+> minor point though, so feel free to ignore.
+
+Not in my experience: if an executable label doesn't have a "manual"
+tag, it will be built.
+
+Let's run a na=C3=AEve test. Apply this patch to the branch:
+
+diff --git a/test/windows/main.c b/test/windows/main.c
+index b5302af..5f94789 100644
+--- a/test/windows/main.c
++++ b/test/windows/main.c
+@@ -1,6 +1,10 @@
+ #include <stdio.h>
+ #include <windows.h>
+
++#ifdef _M_ARM64
++error
++#endif
++
+ int main() {
+     DWORD version =3D GetVersion();
+     DWORD majorVersion =3D (DWORD)(LOBYTE(LOWORD(version)));
+
+And then run the following:
+
+1) bazel test //test/windows:winver_windows_amd64  # OK
+2) bazel build //test/windows:winver_windows_arm64  # FAIL
+3) bazel test ...  # FAIL, the same way as above
+
+According to your earlier description, only (2) should fail. But 3
+fails too. I will not paste the full error message here, but suffice
+to say, it is what I expect it to be.
+
+> I did run your branch against my project both on Linux and Windows
+> machines and everything worked flawlessly. So from my point of view
+> this is good to go.
+
+Will merge. Thank you for your contribution!
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-oa1-f46.google.com (mail-oa1-f46.google.com [209.85.160.46])
+	by mail-b.sr.ht (Postfix) with ESMTPS id BAC0E11EFD1
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed,  8 Jun 2022 20:09:46 +0000 (UTC)
+Received: by mail-oa1-f46.google.com with SMTP id 586e51a60fabf-f2e0a41009so28622727fac.6
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 08 Jun 2022 13:09:46 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=mime-version:from:date:message-id:subject:to;
+        bh=39IC4EEdp6/ovd/eC9dHVL9//xW+pN9rq6f3dEDXLHA=;
+        b=cCENizUIUNvRsvbyfqWBv/N8LKExM+K1WE9dqrMWM2UxwJvbxNO37q2y9XsmDd5HfF
+         YZjTpqtPqYyHAsCCIF/Y01JoaKq8bnY3NaORxO/x94UgX0jsO/j2Mt25ykCkEVtzJX2r
+         MTldz0N903xF1z5evCrYQi2U7EtBHTuo2c6KjgGSEVm0oDxFsv6r83g4U2eYx/LeWcj0
+         9FJOiubhLfXjuZ4tFqXUZ5x0B3NWz0mlRo0V1klmIDEZh/rPvv3iGOjrd6q6Mbcopq24
+         vboOB3OwHigvJi75c9q3z5vb79TX/Psb+OdxbC7NQpaTJ6NyOynYUqyV5hn6L1buEInP
+         VZ8w==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:from:date:message-id:subject:to;
+        bh=39IC4EEdp6/ovd/eC9dHVL9//xW+pN9rq6f3dEDXLHA=;
+        b=gZGCjpV34JG/+KG0yLBqpAFLlS5z9dYv7IAcUbGETwjXcyM2R33OHjSwkUuG4WEmOP
+         0WN9/pVem5HMMLq4sNJn+9oTW4BclDcGKvPIY7LoZYctWoeP/ncPmsOxDHNP8ZpXjplk
+         1BpTX7gd58Y40q4xBKpsvzRcRQ9V5oTbAwx06rBXffUuqVVnbUY6uKWMx6LUX76X22a0
+         v13KFpvzxAU0nk3UJrcheW6Z4JACMF9AjokAHPEQhXgndj0LNCyqU28e6bIXHBNHHBCc
+         3ZAzceDspBAI0XX3EMg56bTXvVKk/8zzWnhPufzG1mH3wODC6vnmXTpl3j1ZCHqLQSyt
+         BFjA==
+X-Gm-Message-State: AOAM531d3U/8aTuWoeGBuu+o2I8YHR4QUnG4BffRhf31lMzabef+xM2L
+	3iI95pRQbsVaMxu7sv0hC1/utm+I30uit6vQteKYMbn7yTU=
+X-Google-Smtp-Source: ABdhPJz//vRXmZdtunfSfsETBthZC+rk966TxbKFBswzCoeInJ9b0dZQjf8RofBIIsVWd39AuRyoH9eEkPehGdUWuB0=
+X-Received: by 2002:a05:6870:899d:b0:f2:6a4a:ae03 with SMTP id
+ f29-20020a056870899d00b000f26a4aae03mr3270667oaq.116.1654718985982; Wed, 08
+ Jun 2022 13:09:45 -0700 (PDT)
+MIME-Version: 1.0
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus.jakstys@gmail.com>
+Date: Wed, 8 Jun 2022 23:09:34 +0300
+Message-ID: <CAFVMu-qLZP04KxO7iRsPd9TW5i0dgbB+kFM-YLjHgP+ZhgZL9Q@mail.gmail.com>
+Subject: bazel-zig-cc v0.8.0
+To: ~motiejus/bazel-zig-cc@lists.sr.ht, Fabian Hahn <fabian@hahn.graphics>, 
+	"~laurynasl" <laurynasl@uber.com>
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 668
+Lines: 22
+
+Hi all,
+
+bazel-zig-cc v0.8.0 is released. It adds windows (host and target)
+support and cleans up multiarch tests. All tests work on all machines
+I've tried, when previously it was CI-only.
+
+# Incompatible changes
+
+With `zig_toolchains` you add to your workspace: the "urls" parameter
+now needs "{_ext}" instead of "tar.xz". As usual, see USAGE[1] for an
+example.
+
+# Thanks
+
+Kudos to Fabian Hahn for contributing Windows support!
+The test organization was mostly guided by Laurynas. He mostly talked,
+I mostly wrote the code. As usual with every recent release, thank
+you, Laurynai!
+
+Motiejus
+
+[1]: https://git.sr.ht/~motiejus/bazel-zig-cc#usage
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 0BEFA11EFF7
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu,  9 Jun 2022 10:29:05 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1654770537;
+	bh=vmO9LC/tPaycUZY9fry2u9+5xWLd7xa7YCiJanGjoEU=;
+	h=From:To:Cc:Subject:In-Reply-To:References;
+	b=X2Qk/VjYCUSEdlMTS5L8YKwi1vEgCRkfR7JQugcvXRSkU2XY67Htnov3IxMOFwBEv
+	 xk+tk2X8ZyJzcG/ARgdCtvdbZFlo1P6NDCJlfgFD9Lzzfrt+82wEEGeCwdT64uv9Py
+	 zPVlQ75NnGUPwCgrCO3aPqbtuZESpDTdbjVRQg+Q=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8;
+ format=flowed
+Content-Transfer-Encoding: 8bit
+Date: Thu, 09 Jun 2022 11:28:57 +0100
+From: fabian@hahn.graphics
+To: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: Re: [PATCH bazel-zig-cc v2 0/3] Windows support
+In-Reply-To: <CAFVMu-p=dPLrsCbMnR26MHj22rTk3LhE09_Ps2=cB_0sOZjPCA@mail.gmail.com>
+References: <20220529163518.182119-1-fabian@hahn.graphics>
+ <CAFVMu-ps+Pt5DqSnUZ323sDcQB-MmjBg01nMfHK+kxtgr0Ew_g@mail.gmail.com>
+ <faee59d97f64ea7c368c583efe84db88@hahn.graphics>
+ <CAFVMu-pihCk8dj_MRrhqGhhoaAy1rOL7rx+pgMkEZFcOvVeWfw@mail.gmail.com>
+ <CAFVMu-o4DSj9H1qfJ8oBHGu6CXGszY79eERJRx6EXWeXPgtjKA@mail.gmail.com>
+ <970d81eedf2eeed648ec06200b3d6567@hahn.graphics>
+ <CAFVMu-p=dPLrsCbMnR26MHj22rTk3LhE09_Ps2=cB_0sOZjPCA@mail.gmail.com>
+Message-ID: <7b547394decea1653bb5b9b49cfcd3b8@hahn.graphics>
+X-Sender: fabian@hahn.graphics
+Status: O
+Content-Length: 439
+Lines: 13
+
+Hi Motiejus,
+
+On 2022-06-08 20:51, Motiejus Jakštys wrote:
+> According to your earlier description, only (2) should fail. But 3
+> fails too. I will not paste the full error message here, but suffice
+> to say, it is what I expect it to be.
+
+Wow, you're right. I've been using bazel for over 5 years now and
+never realized this. Thanks for the clarification, and thank you for
+merging my patches and the release!
+
+Best,
+Fabian
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f42.google.com (mail-oa1-f42.google.com [209.85.160.42])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 1AB2111EFF7
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu,  9 Jun 2022 11:49:05 +0000 (UTC)
+Received: by mail-oa1-f42.google.com with SMTP id 586e51a60fabf-fe15832ce5so4947938fac.8
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 09 Jun 2022 04:49:05 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=mime-version:references:in-reply-to:from:date:message-id:subject:to
+         :cc;
+        bh=88tl/iweb9vF2YBybDj+l6P5IpoSSf8ehlOB0sCBzZ0=;
+        b=jmlP46DdFlDMRaZr+nZG6tRb4kp2rTKd6rmvuqy+556oP0oePKfDmp4oPLB0SIvBXq
+         /MmBnDzAwoz/qFmdS4nwEw9iJt5h07ZBZvdrMFg/eC3jh2esGZYZGqSs/eWFaX9sDMLX
+         gLQ4mROPVH1ZSqucgVcHgTHgamU+STYfu3q4waNaiiIlOwpXOqSponpXkubkxmYf89gY
+         aDk29CFgc9PpSsjKh1+OYf17qFpw7eAYIDMt/Byztg9wIPnEowRj3D/+eLEIWNZXPVbF
+         S4PXlqIV+T9UFwVx3AcJeYVRF/YEWrnnfu4J3AQEfwNb6IyTm2noKg16qj0NoleMyVZ0
+         s/QQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:references:in-reply-to:from:date
+         :message-id:subject:to:cc;
+        bh=88tl/iweb9vF2YBybDj+l6P5IpoSSf8ehlOB0sCBzZ0=;
+        b=JDGgKVhN1JvBiXbjiL12vwsaG+q9dxbLln2TAqE/Q0Gf8OYeBuNdVI9OA8JHI+t/qL
+         N3NfE0Sqgqp21fZhy0oPSjXIW5HNRQxF+AbYXtyrH6upSokGFZLbzR7HYGJAYmYKsV30
+         pdMohnXUabe1+NVLKy2CGbSlgzPrV7htaUpsJ3ZtDhbf8I6DYmFIqdlhr8MGkndamCBB
+         iWl6beMwMRPIwqD4+QkaoyorSbciwDVtS5iRfxjqRvR1iHDGXxB2fbhf/VtfqYWmDbrd
+         o9bNeWg+G7w0jsIEW7IratrRJiuNSKKmbwBimsKQs5rMgCLJs033ZtQwYrNg7/y4EC94
+         tIJA==
+X-Gm-Message-State: AOAM530qCqQ/lnXZ+T4oIsHhvjgQDm8UEFfzxNnUp0dFlgNlf95AwOY6
+	h/Vm36PZt19qRMYqk1G/6mxb+8uFt/gcZMEMvVQ=
+X-Google-Smtp-Source: ABdhPJyUu4VrlzMEUfNLYZb+eyvSQKXTzmxxK3KzNYaA6Cj4gOsHH9xN9IM8uP1+LJwfj1uCwqdjPDmc/6F841+I9xY=
+X-Received: by 2002:a05:6870:f683:b0:f2:cc34:452a with SMTP id
+ el3-20020a056870f68300b000f2cc34452amr1486853oab.216.1654775344362; Thu, 09
+ Jun 2022 04:49:04 -0700 (PDT)
+MIME-Version: 1.0
+References: <20220529163518.182119-1-fabian@hahn.graphics> <CAFVMu-ps+Pt5DqSnUZ323sDcQB-MmjBg01nMfHK+kxtgr0Ew_g@mail.gmail.com>
+ <faee59d97f64ea7c368c583efe84db88@hahn.graphics> <CAFVMu-pihCk8dj_MRrhqGhhoaAy1rOL7rx+pgMkEZFcOvVeWfw@mail.gmail.com>
+ <CAFVMu-o4DSj9H1qfJ8oBHGu6CXGszY79eERJRx6EXWeXPgtjKA@mail.gmail.com>
+ <970d81eedf2eeed648ec06200b3d6567@hahn.graphics> <CAFVMu-p=dPLrsCbMnR26MHj22rTk3LhE09_Ps2=cB_0sOZjPCA@mail.gmail.com>
+ <7b547394decea1653bb5b9b49cfcd3b8@hahn.graphics>
+In-Reply-To: <7b547394decea1653bb5b9b49cfcd3b8@hahn.graphics>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Thu, 9 Jun 2022 14:48:53 +0300
+Message-ID: <CAFVMu-q9B2OD0+zery+8kytJpo6YTB0t7tOJivATLW4vF2x8JQ@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc v2 0/3] Windows support
+To: Fabian Hahn <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 298
+Lines: 10
+
+On Thu, Jun 9, 2022 at 1:29 PM <fabian@hahn.graphics> wrote:
+> <...> and thank you for merging my patches and the release!
+
+Hi Fabian,
+
+No problem! Note that your name is featured in the README[1] now.
+Please read it and make sure you understand what you have signed up
+for. :)
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-oi1-f181.google.com (mail-oi1-f181.google.com [209.85.167.181])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 6EACD11EEDB
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon,  4 Jul 2022 12:45:12 +0000 (UTC)
+Received: by mail-oi1-f181.google.com with SMTP id q11so12768339oih.10
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 04 Jul 2022 05:45:12 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=mime-version:from:date:message-id:subject:to;
+        bh=coxWmlQNSguWvjtrd+KL+nD1AvM9WoJ3raGAF1TinG8=;
+        b=R5QaDEumNaSIZKk+lhBC9akv7NshtLYDwi2O8FS3EP5Gbi7F+vWVZI2+/mK99v2UE1
+         QdZZr+6Uo+SrybyKZrtHgpTrNSwQxFxz7Q/nY7BC+94ohsOzrRQYljENIz4mBbtPSpDx
+         B/gMlcpsHJH7HOEt6DRTxP7tnl487LKGzwfp1wgilST2p27BaJqoIyMbkbDUAzu785bl
+         iQ1M1rk4mgxG0Oucbd7Hn/p0bx4JLChS4oswQwTpxMshZzZbSFR4UCTiPbrH2sGiaHII
+         dV5osp/XbSVR6nJB2WcrBvgaDY1FJkcCawz6jjVfAbMmxxRdfZunQIXuXlJt/kLJcuXF
+         SKkQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:from:date:message-id:subject:to;
+        bh=coxWmlQNSguWvjtrd+KL+nD1AvM9WoJ3raGAF1TinG8=;
+        b=TwyqsgOHKVB2c1slwd4xHXu3/hRdO5ae6XRnLq8dR831vYSvWi+EDrHgEegzrBhRl/
+         VYfhgL4POIho0nNQ4e7WpiGtdZRqGIK5I/6sziqLCT6ObNQMFQ2kccbnsFLidcQHMsSv
+         SlLvoI2Y/e+kszsYrQmusNTNUSt4r0bZ3rvGH+aGkeA0Eg/5fRHAwCoZ17INqRumeV88
+         t3UI+96uKvWOcQePizlTjIZ3O2SVLlEyZ7Z9EPRndZwQ0YL9tlxVdoTzt45gm8keSttb
+         /GMWI7NDnywTXaYXeAQtOcqsSI5PcJUG/QnqxXkCku7Hlk1K5BM/qq/+VzNlzKj6L/K/
+         XXLQ==
+X-Gm-Message-State: AJIora+fcX9Qc3oLa2DmA9G+ptPFauLnYRcFk+ZGnkm4bcR3v3u7JezZ
+	6IjwQ3mEY1C3jwLRDcyt7hKVlZkDwvT5hHfJvxJ02xV+w1I=
+X-Google-Smtp-Source: AGRyM1u39iRrqkkzeofLBF891K92mA26GQdl/CqMPqkGLnsrgdE2vQiEUat/BVghFfxGU5aNc+AVF3pPVH38mQHW4Xg=
+X-Received: by 2002:a05:6808:f03:b0:337:a7d2:4bb6 with SMTP id
+ m3-20020a0568080f0300b00337a7d24bb6mr6893861oiw.116.1656938710774; Mon, 04
+ Jul 2022 05:45:10 -0700 (PDT)
+MIME-Version: 1.0
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus.jakstys@gmail.com>
+Date: Mon, 4 Jul 2022 15:45:00 +0300
+Message-ID: <CAFVMu-rn=brG=37+bY2Zy6WPKUQYwbk5vz_yYJS6geEJApQ_Xw@mail.gmail.com>
+Subject: bazel-zig-cc v0.8.2
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 444
+Lines: 13
+
+Hi all,
+
+I released v0.8.3, which adds fastbuild, dbg and opt settings with
+defaults suitable for zig-cc:
+
+- zig by default adds `-flto`; fastbuild negates it.
+- add -O0, which now zig cc[1] interprets correctly.
+- also use today's zig sdk for tests.
+
+This v0.8.3 should have been v0.8.1; please ignore v0.8.1 and v0.8.2,
+these are caused by me trying to overly rush things today.
+
+[1]: https://github.com/ziglang/zig/issues/11921
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-ot1-f45.google.com (mail-ot1-f45.google.com [209.85.210.45])
+	by mail-b.sr.ht (Postfix) with ESMTPS id CDD8E11EF78
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 12 Jul 2022 07:19:38 +0000 (UTC)
+Received: by mail-ot1-f45.google.com with SMTP id e1-20020a05683013c100b0061c1a6b8d11so5564742otq.8
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 12 Jul 2022 00:19:38 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=mime-version:from:date:message-id:subject:to;
+        bh=GTzwRk1VzKiGp9a1uogPz+W/73KM/MT7lPNVKp+RGJs=;
+        b=T3r3PT6NDyTlGbcv0/XGzLrWrsLNtAp8TWlxQm3Kv4/VB9vW51TUK/PD0u9uASQLH8
+         mkHulABOeWsVxYblEYziS26jgLPZcMIT9HoIQTZzZepcBQWmJqg18xEDYiu+cHJSfb0x
+         pOvKoCrsHbB1/Jq131t/vz//7Wf2Ff2aGxFTuHRHbmjX4XmEUhiQabPYBg9gqSV6mwC0
+         AQoaCmJ9896a3ZYkstrMwT16klr7ScxvnwZEMhzYLCnefzXWcqu0w7zghsXtp21aWmgx
+         KSxQIAKAP8JvkhpxMR2O3dPgqSjBxYSSA5nHHOHXuPSO4D8eUjsGPaWt7aa0a+xbILGe
+         nTtQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:from:date:message-id:subject:to;
+        bh=GTzwRk1VzKiGp9a1uogPz+W/73KM/MT7lPNVKp+RGJs=;
+        b=0zCGKwp0rs79wOhy6Jr0OwqNZ8or26myERBkkmjHXBGq9UKsaRBLSG+VlbdZPZglMK
+         k3Nzpec9b6lgYyiYNOTfGL40krgUyqdTSO2rbm9103eiTWRWGvkHvaYILPp+3+xYIjl3
+         p0CEdlA0DD6QLbaEGED2lMfFUFfI4SOus7EwAQDRBbVlv6eRIwzitIa8tGzycKB6cnwv
+         krYhqhso9tETIkkDheXPlr09F7fOp9daW5jSMw4xy2ZpsuHRFpwEJeIKX4vZXNDAWz75
+         0B6Qi1dzLzPtMHig7yn74gS29cJX4/JJ9OCAIk4fsXq1Lu5o4a+7x97t2sUPnQHholCC
+         fudA==
+X-Gm-Message-State: AJIora+40prMpcc8dSICWQ9y6CUvIbcYLLk0Gpzmu8t+klu3EU2bvxwL
+	wX473DEyGArAZvPewH1QPUINRdISo7mQTI3QI5KAaXBPlzQ=
+X-Google-Smtp-Source: AGRyM1v2FLfJg8ErnpzxfDyxBaiYMw5gqAZyYga02Z+rK8KMpxIy9+aCu1Fhh5tv8fCdqM/FDAnZfkMCrh/OMho2XIo=
+X-Received: by 2002:a05:6830:59:b0:619:17f7:397d with SMTP id
+ d25-20020a056830005900b0061917f7397dmr8511801otp.60.1657610377972; Tue, 12
+ Jul 2022 00:19:37 -0700 (PDT)
+MIME-Version: 1.0
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus.jakstys@gmail.com>
+Date: Tue, 12 Jul 2022 10:19:27 +0300
+Message-ID: <CAFVMu-q9zJ7c7Us02ECHd-SfCBE+8UCjiADE9f03vYnVZhrt=A@mail.gmail.com>
+Subject: development tracks of bazel-zig-cc v0.9
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 2147
+Lines: 54
+
+Hi all,
+
+I will occasionally share some longer-term development updates. This is
+one of those. Now we have a couple of ongoing threads:
+- linker robustness
+- performance issues when using zig-cc.
+
+Linker robustness
+-----------------
+
+One of the biggest source of work when adopting zig-cc for our compiler
+needs was it's lack of support for various linker arguments. When
+compiling a program, you would often see something like this:
+
+    warning: unsupported linker arg: --sort-section
+    warning: unsupported linker arg: alignment
+    warning: unsupported linker arg: --exclude-libs
+    warning: unsupported linker arg: ALL
+
+Zig ignoring the flags was the right thing to do at the beginning, but
+this tends to break software in subtle ways during runtime. So I
+proposed failing hard on unsupported flags[1] and implemented (some
+still under review) the ones that I found in the wild[2]. Please +1.
+
+Performance issues
+------------------
+
+We have found non-deterministic performance degradations when building
+lots of code using bazel-zig-cc on a 96-core server. Usually our test
+shard takes 5-10 minutes to build, but with bazel-zig-cc some time out
+after 30 minutes. More about the CI infra here[4].
+
+So far we found:
+- zig was translating -Og to -O1, now fixed[5].
+- -fno-sanitize=undefined can decrease the build time by 30-50% for
+  non-optimized binaries.
+- -g0 (remove debug symbols) can reduce the build time by 30-50%.
+
+With these changes the baseline "zig cc" performance is similar to
+clang/gcc, but some shards still time out. We currently suspect there is
+some contention in zig's caching layer; the track is active, stay tuned.
+
+To be clear, we are not planning to remove the safety/debug features in
+bazel-zig-cc for the sake of speed; this is just data we've gathered so
+far.
+
+Regards,
+Motiejus
+
+[1]: https://github.com/ziglang/zig/pull/11906
+[2]: https://github.com/ziglang/zig/pulls?q=is%3Apr+author%3Amotiejus+
+[3]: https://github.com/ziglang/zig/pull/11863
+[4]: https://eng.uber.com/how-we-halved-go-monorepo-ci-build-time/
+[5]: https://github.com/ziglang/zig/pull/11949
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-ot1-f53.google.com (mail-ot1-f53.google.com [209.85.210.53])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 7112F11EEF7
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 27 Jul 2022 19:15:17 +0000 (UTC)
+Received: by mail-ot1-f53.google.com with SMTP id w6-20020a056830410600b0061c99652493so13515887ott.8
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 27 Jul 2022 12:15:17 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=from:to:cc:subject:date:message-id:mime-version
+         :content-transfer-encoding;
+        bh=QiBhGZyDsuGqfrVY4zUwonRcokOdh+ddzWujrxQlags=;
+        b=i+4CujBL1xDZlczbc6OdrXaX7fU+eiYeslDvZixt2JK9QJxKGhRdDCWgo3TYbIIQoC
+         Q/848FCUCfrV0CR/BDSbRpsM/Bj1N9fun1lj6biUbyLuQXrouGjG1xI1z9aBso5p2gno
+         RwUa0Cu/tJV13JCVhuEnpuV7siMU9oJ1tRCtRaG2qp1mQzlrPbky9QxRDBeQakXCnlSw
+         EZ+z7X5whmjUXw/DGsl4Ve37px7pgd6ErTvTjWfBzYXoZi+Yb9afDwDdLzREYzzJLc3t
+         qUsL2ESKYiLotr0nVnI9PTkDY2/HKnQ/nwIWmjLDayIK0UpDgVyNqsgPIOH6TFE0jhKM
+         hJwA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:from:to:cc:subject:date:message-id:mime-version
+         :content-transfer-encoding;
+        bh=QiBhGZyDsuGqfrVY4zUwonRcokOdh+ddzWujrxQlags=;
+        b=o+s9WZZJWYq6Xi+7bDlrnhoc0ViC0ftSHtZGlMURS6H3EEH7nxek56mJbj4mK4WIr/
+         CWaYsvTCjAMLYKzJRua76JPTQd4KNgBJilVJ1hX1AckEryLnXH3ZyAGvhOf/BalXnKcc
+         RB1Njeb15BI5bItIO2vvFApuMIaF3SuwR85tMpt08aPdULpq0EszPNpYRy/+IxVT/bEy
+         RXwcYnfpR0Tf7cxCoK1hA40lo2u9SRgA2b4cvr0TiB9zopEnp86fSWdmM6uAeF0w5Ryk
+         779abWmyG1Sf2zyCsjBhUOJiyebMnauwiAB4uHf5gfvQ6q8zTY5Wf0+oWGF8BShQtUjG
+         1bzw==
+X-Gm-Message-State: AJIora8ONN+9PvJgIr146L067vpZZrUCza/PEKKZO22DY2Z74H2cn0PO
+	kkqBItdy/lcXB9NB8lK+2ZYdA88pMcdHcg==
+X-Google-Smtp-Source: AGRyM1sq0IUerdKA8xSIW66KPXCA4IFzDK8e/cAyVTfoAs6bGrVXcoGRHsZDwCm738EPack0++qF7A==
+X-Received: by 2002:a9d:2782:0:b0:60b:1de:d89a with SMTP id c2-20020a9d2782000000b0060b01ded89amr9558101otb.304.1658949316242;
+        Wed, 27 Jul 2022 12:15:16 -0700 (PDT)
+Received: from localhost.localdomain ([201.75.167.67])
+        by smtp.googlemail.com with ESMTPSA id v15-20020a056870b50f00b0010d15f11512sm9543235oap.4.2022.07.27.12.15.13
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Wed, 27 Jul 2022 12:15:15 -0700 (PDT)
+From: Luis Holanda <luiscmholanda@gmail.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Luis Holanda <luiscmholanda@gmail.com>
+Subject: [PATCH] Add missing include path for MacOS platforms
+Date: Wed, 27 Jul 2022 16:13:06 -0300
+Message-Id: <20220727191305.1656332-1-luiscmholanda@gmail.com>
+X-Mailer: git-send-email 2.36.1
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Status: O
+Content-Length: 4892
+Lines: 87
+
+While integrating the project into our Bazel workspace, we had some
+problems while building protoc in an Intel MacBook.
+
+>From my testing, the issue seems to be caused by missing include path
+in the toolchain configuration to the `-none` variant of the headers.
+More details below.
+
+The issue can be reproduced directly inside `bazel-zig-cc` by including
+the protobuf workspace as a dependency:
+
++http_archive(
++    name = "com_google_protobuf",
++    sha256 = "2d9084d3dd13b86ca2e811d2331f780eb86f6d7cb02b405426e3c80dcbfabf25",
++    strip_prefix = "protobuf-3.21.1",
++    url = "https://github.com/protocolbuffers/protobuf/archive/v3.21.1.zip",
++)
++
++load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
++
++protobuf_deps()
+
+And then executing:
+
+bazel build --platforms @zig_sdk//platform:darwin_amd64 @com_google_protobuf//:protoc
+
+The command fails with the same error both in native compilation and
+cross-compiling from Linux. The error:
+
+ERROR: <output_base>/external/zlib/BUILD.bazel:37:11: Compiling compress.c failed: undeclared inclusion(s) in rule '@zlib//:zlib':
+this rule is missing dependency declarations for the following files included by 'compress.c':
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/sys/cdefs.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/sys/_symbol_aliasing.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/machine/limits.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/i386/limits.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/i386/_limits.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/sys/syslimits.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/machine/types.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/i386/types.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/i386/_types.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/sys/_types/_int8_t.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/sys/_types/_uintptr_t.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/machine/_types.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/sys/_pthread/_pthread_types.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/machine/endian.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/i386/endian.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/libkern/_OSByteOrder.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/libkern/i386/_OSByteOrder.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/sys/_types/_fd_def.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/Availability.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/AvailabilityInternal.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/sys/_pthread/_pthread_attr_t.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/sys/_pthread/_pthread_cond_t.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/sys/_pthread/_pthread_condattr_t.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/sys/_pthread/_pthread_rwlock_t.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/sys/_pthread/_pthread_rwlockattr_t.h'
+  '<output_base>/external/zig_sdk/lib/libc/include/x86_64-macos.10-none/sys/_pthread/_pthread_t.h'
+Target @com_google_protobuf//:protoc failed to build
+
+(<output_base> replaced manually to keep the description sane)
+
+Note that the specific rule included in the error message will vary due
+to parallelism, but the error is always the same and the missing paths
+always have the same prefix (up to `x86_64-macos.10-none`).
+
+After applying the patch, we confirmed that both native and cross compilations
+works as expected and can properly build protoc.
+
+Signed-off-by: Luis Holanda <luiscmholanda@gmail.com>
+---
+ toolchain/private/defs.bzl | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+index 4478947..6a536bc 100644
+--- a/toolchain/private/defs.bzl
++++ b/toolchain/private/defs.bzl
+@@ -57,6 +57,7 @@ def _target_darwin(gocpu, zigcpu):
+             "libunwind/include",
+             # TODO: Define a toolchain for each minimum OS version
+             "libc/include/{}-macos.{}-gnu".format(zigcpu, min_os),
++            "libc/include/{}-macos.{}-none".format(zigcpu, min_os),
+             "libc/include/any-macos.{}-any".format(min_os),
+             "libc/include/any-macos-any",
+         ],
+-- 
+2.36.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-oa1-f41.google.com (mail-oa1-f41.google.com [209.85.160.41])
+	by mail-b.sr.ht (Postfix) with ESMTPS id E327F11EF38
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 27 Jul 2022 20:35:20 +0000 (UTC)
+Received: by mail-oa1-f41.google.com with SMTP id 586e51a60fabf-10e3852b463so7414933fac.3
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 27 Jul 2022 13:35:20 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=from:to:cc:subject:date:message-id:mime-version
+         :content-transfer-encoding;
+        bh=C88X6Cj9dWF1UfbeaDb7Lz8haYXlZUq8pzHEB35felY=;
+        b=J4izNC0h/vZqpl3FAlojjaFPqJ//Xadzj+cCLqPK3c6UYv6BH1FXgLks5vmeR/Wn94
+         UCvQS2v1sHmCbZjhc9zRPolNCFGk/3JEHfP+TEa8hN5k3EsIdtcGx5v0leb3cbd9mXxA
+         hW9O6wsx0cDbnv9Y06OA3KsjtKqKzo9USu6dg6s6edQXUT551/9AqXROP2xjm+Xr0b8l
+         99olx20Ljdqu8C4b9CBjgGc8gwWHPj9XcELmR5jMLxrIEcP7bLKIIT82XV9lXM+hsgNd
+         Soy3clhWnhPlWyyKGc+f4EUu82+Hp0TfyhFA9fWVLQCpKQ4Dpyur1AzU8ug9CumV+R2Q
+         EZgA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:from:to:cc:subject:date:message-id:mime-version
+         :content-transfer-encoding;
+        bh=C88X6Cj9dWF1UfbeaDb7Lz8haYXlZUq8pzHEB35felY=;
+        b=G3V5XWEO5sHH2BSmEdZWoK/LYUHO70Cqu6e6ahFSQmLAuDyEZiGAQ1HH49NHi5Ew9z
+         VNZ+Bz/YCW3kGOBzv/a7pKR8Ot9Cm3u6xuxVz0sVBpnI/gOwqAXJimwpesAzkk0L86Lj
+         Knzpl8FZVPnIh6ZsSR16hnobi7rN+pO8zl5dMdMG2aYerOwiKKEWsiuay+nDUdq57hSW
+         WgmG6W9p/pNvGVXXvB4kiIN29mDD2QxMo91jPDNbDPiGR0yl4DDPFNcHJ9QmLlp9IXYV
+         UwlK54JOt6x+xrGH3+1ckhg6WCJCifi6pR6MjhNg1myy6w0lMLeuEgH7XdGyTpNZB//E
+         Py6g==
+X-Gm-Message-State: AJIora8pxEZ6ZjUirq6iBZsQTuulszyNke4IyP1SFAqtk2YtbOQe5VLI
+	65cydfydQrQIpnA4GTqPVcEi/hlrZ/WAvA==
+X-Google-Smtp-Source: AGRyM1u7ZF88lGev8gK4mNAj9+18k+2fagtQ46pH50N6cUFYYsa2cXMunbEEp2WD+Q4TuSsjjZUw8w==
+X-Received: by 2002:a05:6871:68d:b0:10d:a96f:16b9 with SMTP id l13-20020a056871068d00b0010da96f16b9mr3091137oao.230.1658954120053;
+        Wed, 27 Jul 2022 13:35:20 -0700 (PDT)
+Received: from localhost.localdomain ([201.75.167.67])
+        by smtp.googlemail.com with ESMTPSA id eq37-20020a056870a92500b0010d3438b20esm10306217oab.29.2022.07.27.13.35.18
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Wed, 27 Jul 2022 13:35:19 -0700 (PDT)
+From: Luis Holanda <luiscmholanda@gmail.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Luis Holanda <luiscmholanda@gmail.com>
+Subject: [PATCH 0/2] Support NixOS and others non-FHS Linux distributions
+Date: Wed, 27 Jul 2022 17:33:51 -0300
+Message-Id: <20220727203353.1672954-1-luiscmholanda@gmail.com>
+X-Mailer: git-send-email 2.36.1
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Status: O
+Content-Length: 1075
+Lines: 30
+
+Currently, the project expects Bash to be in /bin/bash, but in certains
+Linux distributions, namely NixOS, this path doesn't exist as all
+binaries are stored inside /nix/store. The only thing that exists in
+/bin in these distros is sh.
+
+This patchset changes all the shebangs to /usr/bin/env bash, which will
+work across all distributions.
+
+The first patch changes only what is necessary to have Bazel run
+correctly, while the second one changes the remaining scripts so that
+contributors using NixOS can execute them without much problem.
+
+Luis Holanda (2):
+  Support NixOS and others non-FHS Linux distros
+  misc: use /usr/bin/env in scripts
+
+ bin/mod-tidy                 | 2 +-
+ ci/lint                      | 4 ++--
+ ci/list_toolchains_platforms | 2 +-
+ ci/release                   | 2 +-
+ ci/test                      | 2 +-
+ contrib/makerel              | 2 +-
+ release                      | 2 +-
+ test/c/test.sh               | 2 +-
+ toolchain/defs.bzl           | 2 +-
+ 9 files changed, 10 insertions(+), 10 deletions(-)
+
+-- 
+2.36.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-oi1-f178.google.com (mail-oi1-f178.google.com [209.85.167.178])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 5DEA611EFBC
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 27 Jul 2022 20:35:22 +0000 (UTC)
+Received: by mail-oi1-f178.google.com with SMTP id r13so195125oie.1
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 27 Jul 2022 13:35:22 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=from:to:cc:subject:date:message-id:in-reply-to:references
+         :mime-version:content-transfer-encoding;
+        bh=tuD3wJBNj3NRAjCTlvFeCAf38S0xjPdk/GOQvmNdgIQ=;
+        b=k+CtfQuAJyUWYgmCMND7lFVDATS8Xiqu6xEOrvxalwSZKCuuRRPytRY4+KEURaps+U
+         xG1Kc2ZVsR3Jw50TLl4TfMhTzvZx9J0iFV5378cg8um20ljACTHjxj33sgWluHFDX9sr
+         mZ29jCKFkTc6SrqIR5xiLZ2Zq+UAJufJXLmIEk5HIdbZbCoKpecjh8oXNpq7zs97s8XW
+         QjOjwnQIzDMt3SoAAMCPwdOINPBofkF61ygCand4cuq9BjGliQb/Fq8NXzgFnpMQCVjt
+         31qfRgbVnHrrph3IHc3i8x8zO5fvQJkX8tPSTn1FTtz19l2VuqJqWkMFruJ6yoqN7NRi
+         0xxQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:from:to:cc:subject:date:message-id:in-reply-to
+         :references:mime-version:content-transfer-encoding;
+        bh=tuD3wJBNj3NRAjCTlvFeCAf38S0xjPdk/GOQvmNdgIQ=;
+        b=rGQWcKOpH+Ge6mZInKDddAQuxLb9uwqjcTW+/zV8uPtBFx6VuYp91vKJi1UiqKUGjb
+         +IcVX6u6acObpGSUAteT307n5SpelFfvIgZokhnmLk5tZ72MvZY/7g2RpitZAHfyyIZP
+         A6FC9T598PfQUhjoDcVqz/ADqoo7MFXGBaV0HCyOc2RYdyrGeD8TGtfbcBTMneLgk3oS
+         amg79rzv6woW5+gxcEz6LeD33J6CYIVKIzM+Dr7HG4r7yslOpqbnktHhbeTVco8J6HVO
+         JFXqhsavOAmYygm1fP2G3otF+UFbG1VGpMjL2yrHHoDdknHY6JEzAkPEN5RLCj0j3RU4
+         My6g==
+X-Gm-Message-State: AJIora9PTzZsk4zYwDoH+5PXgXhhsmrlvUq+/xanoO3gTzUuErLDQp50
+	9GeYkX5jKLxWpnd5TOYg3oqzup74D6E0IQ==
+X-Google-Smtp-Source: AGRyM1vSS6Eoa0cr6+TSJWPYZSJENpgkvtbWyiuj9p3OZr/eFutrL4OsEyd49AWqG6Pr18CiBY994g==
+X-Received: by 2002:aca:d946:0:b0:339:fcc1:5f03 with SMTP id q67-20020acad946000000b00339fcc15f03mr2665712oig.230.1658954121538;
+        Wed, 27 Jul 2022 13:35:21 -0700 (PDT)
+Received: from localhost.localdomain ([201.75.167.67])
+        by smtp.googlemail.com with ESMTPSA id eq37-20020a056870a92500b0010d3438b20esm10306217oab.29.2022.07.27.13.35.20
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Wed, 27 Jul 2022 13:35:21 -0700 (PDT)
+From: Luis Holanda <luiscmholanda@gmail.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Luis Holanda <luiscmholanda@gmail.com>
+Subject: [PATCH 1/2] Support NixOS and others non-FHS Linux distros
+Date: Wed, 27 Jul 2022 17:33:52 -0300
+Message-Id: <20220727203353.1672954-2-luiscmholanda@gmail.com>
+X-Mailer: git-send-email 2.36.1
+In-Reply-To: <20220727203353.1672954-1-luiscmholanda@gmail.com>
+References: <20220727203353.1672954-1-luiscmholanda@gmail.com>
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Status: O
+Content-Length: 1053
+Lines: 39
+
+As it expects Bash to be at `/bin/bash`, the current implementation
+fails to execute on NixOS, given that there bash is in a non-standard
+path (i.g. `/nix/store/<hash>-bash-interactive-<version>/bin/bash`).
+
+This patch specifically changes `/bin/bash` paths to use `/usr/bin/env bash`,
+which should give the correct path in every Unix system.
+
+Signed-off-by: Luis Holanda <luiscmholanda@gmail.com>
+---
+ test/c/test.sh     | 2 +-
+ toolchain/defs.bzl | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/test/c/test.sh b/test/c/test.sh
+index ee67dd3..7cfac79 100755
+--- a/test/c/test.sh
++++ b/test/c/test.sh
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!/usr/bin/env bash
+ 
+ set -euo pipefail
+ 
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index d200588..f640aa4 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -76,7 +76,7 @@ def toolchains(
+         },
+     )
+ 
+-ZIG_TOOL_WRAPPER = """#!/bin/bash
++ZIG_TOOL_WRAPPER = """#!/usr/bin/env bash
+ set -e
+ 
+ if [[ -n "$TMPDIR" ]]; then
+-- 
+2.36.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-oi1-f172.google.com (mail-oi1-f172.google.com [209.85.167.172])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 2FD7911EF38
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 27 Jul 2022 20:35:24 +0000 (UTC)
+Received: by mail-oi1-f172.google.com with SMTP id h125so158446oif.8
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 27 Jul 2022 13:35:24 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=from:to:cc:subject:date:message-id:in-reply-to:references
+         :mime-version:content-transfer-encoding;
+        bh=xSjtdXFC1UmYSLdEpH2vdwQuVCpgTiP5N5Ny/JpP95c=;
+        b=BspyOlKi0TASgVCkknqfzCDrviIkcb/FZZRv83zCKtblzTrMp2sDzDaeIJPEcjV6dC
+         gw5+0S5LXiGcVX/38bJ7R15aB8ouaTuA6i5Cg/SZDFBYl+yQGOYl8+fSu/EwFtNQ4T/0
+         3QeQNjPw178O1FEEzfLWJxKTSvcCs7gYRRONsyEXvTQYvWVs9KayDA6Nfz+sXH8YVK51
+         zJkhIpOJYeTZrlHcqm5OYIUEkRtR5244AnhlW4RSAumTpl4LSPZMMpT7HIF5+o6kNyYm
+         DQioNyFg7aU/1m+CJHpGVuN9Xf1zCQ6A1IZCdIVBOEgWrQS+61QyIJuxAH/tvbz1UKM+
+         DZmA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:from:to:cc:subject:date:message-id:in-reply-to
+         :references:mime-version:content-transfer-encoding;
+        bh=xSjtdXFC1UmYSLdEpH2vdwQuVCpgTiP5N5Ny/JpP95c=;
+        b=paKdcAFVye2BAtNFQzt/sO4LZe0afdTQWpPe8VtLby9fN5maOEbI8DcQtyi8YbE5AT
+         Rug0ymJB7/0rXIQ2XMR2Tz7Pi9DVjNhcu6qI+BgD5WfswUOj3kouIcq6DesssYkyzx+s
+         UsHrsAq++0T86IlwZW8uc7/5N+6r8xG1w3uqcdyAIJdmFPgefpoPYJsjcXN/VPOtbBFk
+         xcMrphcX8WVAeISnQrMj75egTVal7FZKPX4++r7X2H+86Fa7U76YbYpgUSg3KtHg3lKg
+         GdbNz1L3aATEV46W9e1Sju9jG4/jx0S73HaDu6Gf3S3bxbTZM7VMFfKADvExnITnv0eD
+         WhiA==
+X-Gm-Message-State: AJIora+b7sLcppGy80arrIeJOrOaIdyZKCeuoxqEMix0EslklmRoGKjO
+	spwhuPOcbO+BlhaDatkA7bMjhqMvfKKxsg==
+X-Google-Smtp-Source: AGRyM1tFzU5vsccWZskXpEYnhUKHf81gtd6jWhov81jmpBQCW1w3d6ouBHO6swcFyPfH9X8hkuVOvw==
+X-Received: by 2002:a05:6808:1a13:b0:33a:75de:233f with SMTP id bk19-20020a0568081a1300b0033a75de233fmr2716223oib.158.1658954123357;
+        Wed, 27 Jul 2022 13:35:23 -0700 (PDT)
+Received: from localhost.localdomain ([201.75.167.67])
+        by smtp.googlemail.com with ESMTPSA id eq37-20020a056870a92500b0010d3438b20esm10306217oab.29.2022.07.27.13.35.21
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Wed, 27 Jul 2022 13:35:22 -0700 (PDT)
+From: Luis Holanda <luiscmholanda@gmail.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Luis Holanda <luiscmholanda@gmail.com>
+Subject: [PATCH 2/2] misc: use /usr/bin/env in scripts
+Date: Wed, 27 Jul 2022 17:33:53 -0300
+Message-Id: <20220727203353.1672954-3-luiscmholanda@gmail.com>
+X-Mailer: git-send-email 2.36.1
+In-Reply-To: <20220727203353.1672954-1-luiscmholanda@gmail.com>
+References: <20220727203353.1672954-1-luiscmholanda@gmail.com>
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Status: O
+Content-Length: 2459
+Lines: 95
+
+This patch continues the work to support NixOS and others non-FHS
+distributions by replacing instances of `/bin/bash` with
+`/usr/bin/env bash`, which works correctly in more systems than the
+former.
+
+Signed-off-by: Luis Holanda <luiscmholanda@gmail.com>
+---
+ bin/mod-tidy                 | 2 +-
+ ci/lint                      | 4 ++--
+ ci/list_toolchains_platforms | 2 +-
+ ci/release                   | 2 +-
+ ci/test                      | 2 +-
+ contrib/makerel              | 2 +-
+ release                      | 2 +-
+ 7 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/bin/mod-tidy b/bin/mod-tidy
+index 0c66f25..b3d0971 100755
+--- a/bin/mod-tidy
++++ b/bin/mod-tidy
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!/usr/bin/env bash
+ 
+ set -xeuo pipefail
+ 
+diff --git a/ci/lint b/ci/lint
+index 8c52243..f84eaa1 100755
+--- a/ci/lint
++++ b/ci/lint
+@@ -1,9 +1,9 @@
+-#!/bin/bash
++#!/usr/bin/env bash
+ set -euo pipefail
+ 
+ REPO_ROOT=$(git rev-parse --show-toplevel)
+ cd "$REPO_ROOT"
+ 
+ # shellcheck disable=SC2046
+-shellcheck -x $(awk '/#!\/bin\/(ba)?sh/&&FNR==1{print FILENAME}' $(git ls-files))
++shellcheck -x $(awk '/#!\/usr\/bin\/env/&&FNR==1{print FILENAME}' $(git ls-files))
+ find . \( -name 'WORKSPACE' -o -name 'BUILD' -o -name '*.bzl' \) -exec buildifier {} +
+diff --git a/ci/list_toolchains_platforms b/ci/list_toolchains_platforms
+index a7d0342..fae9ab8 100755
+--- a/ci/list_toolchains_platforms
++++ b/ci/list_toolchains_platforms
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!/usr/bin/env bash
+ set -euo pipefail
+ 
+ indent() { sed 's/^/    /'; }
+diff --git a/ci/release b/ci/release
+index 5149c64..b166828 100755
+--- a/ci/release
++++ b/ci/release
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!/usr/bin/env bash
+ set -xeuo pipefail
+ 
+ cd "$(git rev-parse --show-toplevel)"
+diff --git a/ci/test b/ci/test
+index 269510d..5aaac7a 100755
+--- a/ci/test
++++ b/ci/test
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!/usr/bin/env bash
+ set -xeuo pipefail
+ 
+ bazel test ...
+diff --git a/contrib/makerel b/contrib/makerel
+index 045b422..de614db 100755
+--- a/contrib/makerel
++++ b/contrib/makerel
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!/usr/bin/env bash
+ set -euo pipefail
+ 
+ zigdir=out/zig-x86_64-linux-musl-x86_64_v3
+diff --git a/release b/release
+index c3a4976..d49de26 100755
+--- a/release
++++ b/release
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!/usr/bin/env bash
+ set -xeuo pipefail
+ 
+ sign=(-u motiejus@jakstys.lt)
+-- 
+2.36.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f44.google.com (mail-oa1-f44.google.com [209.85.160.44])
+	by mail-b.sr.ht (Postfix) with ESMTPS id C0C9A11EFC0
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 28 Jul 2022 19:47:17 +0000 (UTC)
+Received: by mail-oa1-f44.google.com with SMTP id 586e51a60fabf-10e3852b463so3586422fac.3
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 28 Jul 2022 12:47:17 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=mime-version:references:in-reply-to:from:date:message-id:subject:to
+         :cc;
+        bh=1X1kmZLyj4O7fbyQVYj0WvgfhXov5fohPzPdN2JcHlU=;
+        b=AER75cZ1cZcA4JkXpIrkJ9tvtLgltWuAzjymTMN+NDkvAbYOl7skEeIgAiOFAQMmFq
+         3EeQzHNKOHxo6tsE5pVkeYTZaI1+it49B3aPrGVGEeHvyX58sHqW9WFaeTTQ16Fkz6Sq
+         TO3aCBngShJa96HwjzEErzN8a4tLagcXJoT26pbd/aE4QdS+QyHBuXEOSwsoDkFmXpV4
+         hMSeF/s4T7XweqVImQ6vJkfBCNgETyYlhqbh4fmitgrsSvXhmOKLfDQcrB+Z5w2Dfy8n
+         HeSUPmJMw99mqnYxKFdjuAdJD3nJgK/8H4DZO+oU9WVbRrr087UeUMYlpvqbz1/J7hhO
+         WzhQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:mime-version:references:in-reply-to:from:date
+         :message-id:subject:to:cc;
+        bh=1X1kmZLyj4O7fbyQVYj0WvgfhXov5fohPzPdN2JcHlU=;
+        b=xoRL7sL0PVouUgNzDvkHFUZAeTO9BwePplFZZXYNeI3MP95iqB/k7hiEa7DJX2lBjM
+         rzwaprXx/1XiZ+A0teWUMxYq2cJy3RDcmyu9/Z/L6u0YKsH/OqkbAFbUdZeW6YCI4kFb
+         v0IXj5WqvCaXp5JwkLT9XRAbJmvOLgybT3FlXUDev8ulV+WYlx9KzmqmL0OuRuxMu4TA
+         mA0Muo1pUmMHDh46VxawINHllcFmL0K1P7SFd2ryCFMi8AWGR1w7Fza1iRFRJ2INUiWt
+         RGYuBvNXLi+TrTEhhGB0BWB2aBCOt5DKMwi6ryjV5F86bWf8DaS5oyb+ejBJNwKzaqgd
+         /Uiw==
+X-Gm-Message-State: AJIora83HOY+O9jkO5I/26gKLXl968jSn7EfVix19HoXkgHzJ+9zlAlQ
+	EyU4VZUxhXV05NQfkoXPwjYxSQ1/7hIT94edUIo=
+X-Google-Smtp-Source: AGRyM1ta7uAwtLddkUTA26k9NzRwJ8y8RYQUriPieT5iC7G9uqpNMFDAAAs0zwJlTq4LAI+ujenE5OqDJt2b8G0ekFY=
+X-Received: by 2002:a05:6870:a118:b0:10e:631c:5f3d with SMTP id
+ m24-20020a056870a11800b0010e631c5f3dmr110995oae.116.1659037636813; Thu, 28
+ Jul 2022 12:47:16 -0700 (PDT)
+MIME-Version: 1.0
+References: <20220727203353.1672954-1-luiscmholanda@gmail.com>
+In-Reply-To: <20220727203353.1672954-1-luiscmholanda@gmail.com>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Thu, 28 Jul 2022 12:47:05 -0700
+Message-ID: <CAFVMu-pRq0L35-7tV54WQWNT_6=ZLQwbc54P=zD9dNg-BBc=GA@mail.gmail.com>
+Subject: Re: [PATCH 0/2] Support NixOS and others non-FHS Linux distributions
+To: Luis Holanda <luiscmholanda@gmail.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 860
+Lines: 23
+
+On Wed, Jul 27, 2022 at 1:35 PM Luis Holanda <luiscmholanda@gmail.com> wrote:
+>
+> Currently, the project expects Bash to be in /bin/bash, but in certains
+> Linux distributions, namely NixOS, this path doesn't exist as all
+> binaries are stored inside /nix/store. The only thing that exists in
+> /bin in these distros is sh.
+>
+> This patchset changes all the shebangs to /usr/bin/env bash, which will
+> work across all distributions.
+>
+> The first patch changes only what is necessary to have Bazel run
+> correctly, while the second one changes the remaining scripts so that
+> contributors using NixOS can execute them without much problem.
+>
+> Luis Holanda (2):
+>   Support NixOS and others non-FHS Linux distros
+>   misc: use /usr/bin/env in scripts
+
+Thanks, applied.
+
+For next time don't sign-off -- that's unnecessary here.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-oa1-f43.google.com (mail-oa1-f43.google.com [209.85.160.43])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 726A011EFC0
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 28 Jul 2022 19:54:08 +0000 (UTC)
+Received: by mail-oa1-f43.google.com with SMTP id 586e51a60fabf-10cf9f5b500so3618201fac.2
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 28 Jul 2022 12:54:08 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=message-id:date:mime-version:user-agent:subject:content-language:to
+         :cc:references:from:in-reply-to:content-transfer-encoding;
+        bh=M3ZKMew3WW1+uBDJoQxk2d84eKMMvUxo8mlnKoDakpc=;
+        b=LOcdMVyNyFSxiYbPpivz7Z6MKEK7BGlpcItSPk+jfBByt5ZR9s9uRgScpZyCoJlEPQ
+         rNwID2ja8hhBOPK/uRhFy4ukUzgJKK7jCm/ItbJEMaKXu+/Zft7B1RSD1xwetfiSO8ip
+         vR9TNnmGBPZVsyGr6zhlJpLmFQ921JrQGDm8vWhYcde569j1UHQ8IdRjQSW0YswSh3W1
+         lJ3QiE1yYqFOzaUTC4NiCPNmLVkqPPmNVXkOJz1ykY+VHsh/oVzJ1UP8mZ45TF+Bq4kI
+         r1KGZUAeZnRMdjYqC5qrVdrystgB5KAI9V2zB0YlYdgiHZuIQo6evRsJKJiKZ/uddfKW
+         kNQw==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:message-id:date:mime-version:user-agent:subject
+         :content-language:to:cc:references:from:in-reply-to
+         :content-transfer-encoding;
+        bh=M3ZKMew3WW1+uBDJoQxk2d84eKMMvUxo8mlnKoDakpc=;
+        b=Mt/l5KtYVK6JjMb4xRehzy2n+BV6LczZ4gK7CeB/ouj1t32Es6jcvybAcb/I4sKYyi
+         zxHRc/6UfgYINfhjk5qcc685NFA3vTbJMTMwWMb/AejB0k5MpE/ymS56vNKW/YjKFhUK
+         GdzHSN7HcPtsSTfNI6RyVKdJXAgVNpqlOwFd+U5T0LkYpJmFtdFq+HCXkrZFWbqXxz5z
+         9nUb65qgQFXGJ3fvbRTanovAunjjjBNlHpHRtsJvjrfG9vXkhGzb3tffQphoAAqrvXvk
+         ruFuDaJOJdgSA5ebU1n/oU2t2Od5Q9gV2FeBRN3SeRXBdVqeU6qF9qhzld1RSCbhoHOZ
+         KrzA==
+X-Gm-Message-State: AJIora/Hw737Lq5KYb7S7Y2ka/kc1tybwolmSlXXKwFSypFW3NGNHSGS
+	+d5HaG0t+2KSfwEaCSq6uJhILbG0I7gkcg==
+X-Google-Smtp-Source: AGRyM1vnhn2Wu3z1qBQ8WSZ4qGlx7+SMqrLP+9laH5jK4mCWi9nmiRQQOGZ5o7eFAYAmkkzXaHfviw==
+X-Received: by 2002:a05:6870:4388:b0:10e:803e:5071 with SMTP id r8-20020a056870438800b0010e803e5071mr120170oah.62.1659038047709;
+        Thu, 28 Jul 2022 12:54:07 -0700 (PDT)
+Received: from [192.168.0.2] ([201.75.167.67])
+        by smtp.gmail.com with ESMTPSA id q22-20020a056870e61600b000f2455e26acsm883856oag.48.2022.07.28.12.54.05
+        (version=TLS1_3 cipher=TLS_AES_128_GCM_SHA256 bits=128/128);
+        Thu, 28 Jul 2022 12:54:06 -0700 (PDT)
+Message-ID: <c445d0d6-76e1-e025-f580-d3fe85277e9c@gmail.com>
+Date: Thu, 28 Jul 2022 16:54:01 -0300
+MIME-Version: 1.0
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:91.0) Gecko/20100101
+ Thunderbird/91.9.1
+Subject: Re: [PATCH 0/2] Support NixOS and others non-FHS Linux distributions
+Content-Language: en-US
+To: =?UTF-8?Q?Motiejus_Jak=c5=a1tys?= <motiejus@jakstys.lt>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+References: <20220727203353.1672954-1-luiscmholanda@gmail.com>
+ <CAFVMu-pRq0L35-7tV54WQWNT_6=ZLQwbc54P=zD9dNg-BBc=GA@mail.gmail.com>
+From: Luis Holanda <luiscmholanda@gmail.com>
+In-Reply-To: <CAFVMu-pRq0L35-7tV54WQWNT_6=ZLQwbc54P=zD9dNg-BBc=GA@mail.gmail.com>
+Content-Type: text/plain; charset=UTF-8; format=flowed
+Content-Transfer-Encoding: 8bit
+Status: O
+Content-Length: 166
+Lines: 5
+
+On 7/28/22 16:47, Motiejus Jakštys wrote:
+
+> For next time don't sign-off -- that's unnecessary here.
+
+Thanks for the advice, first contribution in Source Hut.
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-oa1-f53.google.com (mail-oa1-f53.google.com [209.85.160.53])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 50E4011EF0D
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 12 Aug 2022 03:10:51 +0000 (UTC)
+Received: by mail-oa1-f53.google.com with SMTP id 586e51a60fabf-10ea7d8fbf7so23716771fac.7
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 11 Aug 2022 20:10:51 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=to:subject:message-id:date:from:mime-version:from:to:cc;
+        bh=OvzaL/b2JIuLqdwq3IORh34Z1rM/m/uAXm6MNfTIKqw=;
+        b=Y1de+fXouMuRC+4OVwmKiUU85F8qIds7Ldy7HLZmv9FF+YMF4K+vwOhuKsLf18bnvw
+         tgRLXMEc3793BUsYsC0f7tuQDZ1i1p8Mv3EAse5t3Q2oFmSFspxnpfRIaeEPfuUasHbe
+         HbhnOWJhbvb8a69VFAXPkmtBmgu/xSXeQM5MOrfzMJkLbumTCwGGhcwTxWvqIlMuYgex
+         rttsAq4Yul9CjcrSHacD5XfLd8mbeKkhp1acVO1110Ukywy5IU3Czy63E1QYZLe3yk/g
+         vvUFKSYq/GrHdGMsLkkLtiMKbpDBDL3yUDSlVAm9zUnlxhogNLMluBmB/fUzEhdKnPND
+         AVRQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=to:subject:message-id:date:from:mime-version:x-gm-message-state
+         :from:to:cc;
+        bh=OvzaL/b2JIuLqdwq3IORh34Z1rM/m/uAXm6MNfTIKqw=;
+        b=lueMsA0iY6ThJVU310h4n6zjuZXSSup9G7ukjO0a3/GITJYu/vjfQxqSK6W2mkevvB
+         oZtnxQRLcBwaLBLcr2xZ0l3OduKYwuMLGm58e3QwFM525uM4sR7ihVE+hb190btkunCv
+         OkCs1cN+7o6y5JAJ/4dtz2RqoVCpPkFsbGqnKzYhX/5WGcGms5CVFsuVcBSqrfwxUbcA
+         O7YEx1VX0RyZ2SNvN9xh8CeXqoQuAZHmOVuWdAcyP+3libHz+bZlh6p6EaSXPpF8YM10
+         rP+NfEQDfWwRaLxAwu+WyzVJf6lPh33GkaK0eQCs6dLd6OepntrXsaJK0xH+DREqER9I
+         PYLw==
+X-Gm-Message-State: ACgBeo1whcPtaS8bUFhfBC8G1rs2Lk+mUxI4RJT7LhKXFfoBb2RmfKOV
+	+YLILXtQRgbKpWEkHxhQ9yu2KYbZK4jqlzA9Asmb/vibGok=
+X-Google-Smtp-Source: AA6agR73vYCQ2Cp2MweANst1nlNAZSL5aZ0VZWj5UGZ+zUx5eTckzAwyIcOtGIIaAMH9MGfK0niQDsV4bU2h35wap0Y=
+X-Received: by 2002:a05:6870:8904:b0:113:a785:b09f with SMTP id
+ i4-20020a056870890400b00113a785b09fmr4932714oao.216.1660273838844; Thu, 11
+ Aug 2022 20:10:38 -0700 (PDT)
+MIME-Version: 1.0
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus.jakstys@gmail.com>
+Date: Fri, 12 Aug 2022 06:10:27 +0300
+Message-ID: <CAFVMu-pEXFq8oDmny92hv1vsdO_0Cw4a33BsEY_RykeTZHZ35g@mail.gmail.com>
+Subject: bazel-zig-cc v0.9.0
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 620
+Lines: 17
+
+Hi all,
+
+Bazel-zig-cc was released. Backwards-incompatible changes:
+- Requires Go 1.19.
+
+Notable changes:
+- go 1.19 adds "--no-gc-sections" line [1], so we could clean up this
+from bazel-zig-cc. This is why it is incompatible with older Go
+versions.
+- go 1.19 uses `--compress-debug-sections=zlib`, which Zig understands
+since [2]. This results in significantly smaller binary sizes for
+debug builds.
+- support NixOS by Luis Holanda
+- upgrade zig 0.10.0-dev.3529+44a6172ed
+
+[1]: https://github.com/golang/go/commit/16e7613b2e1861b25c6549051337d1d8a850cf63
+[2]: https://github.com/ziglang/zig/pull/11863
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=tecton.ai header.i=@tecton.ai
+Received: from mail-qt1-f177.google.com (mail-qt1-f177.google.com [209.85.160.177])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 54FCD11EE5E
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 22 Aug 2022 14:28:16 +0000 (UTC)
+Received: by mail-qt1-f177.google.com with SMTP id x5so7973001qtv.9
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 22 Aug 2022 07:28:16 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=tecton.ai; s=google;
+        h=cc:to:subject:message-id:date:from:mime-version:from:to:cc;
+        bh=0FaUGogP99VFlV515qvsOttPexbmSEDINNNuiGcAFLQ=;
+        b=myRYmPEew/uqEMlLs+dya7upg+Ku8UAi5H/Ko7LRxKRiqxooWMBhX6qByl0cGj1BtH
+         7lSa4g0gDMOK3Nt6ETUCbQYQsCA9ZeGHdScdAp+0ksBUUfmp8Kg+AOTasukiNbure6OK
+         +5L4HIx99Jy5k/tDgy0j0rIosaaDosL2uOhPVEbJkLZim3t6Icb9HMLIw12uGXTM1bbk
+         gewyuJS4lsfm5MewPvzL4Jzv8UXC9cFYvPy3BcjPhwk/It8o2+LygxITDE0BN5HnH24I
+         jd5d1JShrirxfqznYrq9Cbc1EBQ7nmjFWJcbJsZEjiYMSzFPXodzkrPX+r7XYvFCxaqY
+         O8Ow==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:mime-version:x-gm-message-state
+         :from:to:cc;
+        bh=0FaUGogP99VFlV515qvsOttPexbmSEDINNNuiGcAFLQ=;
+        b=UR+/h2zXUo4XMcvDy6S0MWnGJBpo9ja8Lcr0B7eEFZ771q2l24Ea9jen2DEgxOD/Th
+         eKaUUlpJyzJWTulEQKT3jCTEdW+Jo6WLS0FY6JMYMN3L523i5zbCR8ZHFZdcsFupaP3U
+         DL1S2hQq1T2G3YaExRcm5Dd1oAMFIZe05rrWAAkCke3iIlmM3mZlIifrVSEdXPKQw4IN
+         TNDicvxR6zzPzovu16Ff2lz49PyIJ0CgaHKcadJR4XvIZRDpeuGIrZMB9s+1H2oGEbTI
+         TO8Q1PxjQIdCivMjc0hxaeAkst+7ywivFZ7SndMWBPHZvpTBy+kwrh73fW0tiZBlO6nk
+         73MA==
+X-Gm-Message-State: ACgBeo3HEbCDt5/I2VSixEWpwoIxHlUpNHs+ntByW+CmDryVdJkmpMza
+	C5e07jDx2kt263q0PJKhOfChMeUH6eR0THnUAva9yJTiF9266g==
+X-Google-Smtp-Source: AA6agR5KcFftNxZIzNkfGY3ZTIM3V4H2EQ2iFXdZndc4FXOPEFDHpvoqYI7yHjSVqy8XTtdjICtyljk3zDftTRhfaBo=
+X-Received: by 2002:ac8:5dd3:0:b0:344:94e6:d667 with SMTP id
+ e19-20020ac85dd3000000b0034494e6d667mr14471839qtx.409.1661178495743; Mon, 22
+ Aug 2022 07:28:15 -0700 (PDT)
+MIME-Version: 1.0
+From: Mike Eastham <meastham@tecton.ai>
+Date: Mon, 22 Aug 2022 10:28:05 -0400
+Message-ID: <CAMWUSyfthsE5Mk14K3Ly_EE10wcKB3eUA6MQib6Tgcv0ogAWPg@mail.gmail.com>
+Subject: Re: [PATCH] Add missing include path for MacOS platforms
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Luis Holanda <luiscmholanda@gmail.com>
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 786
+Lines: 18
+
+I found this thread while preparing to submit a patch for the very same
+issue.  Hopefully it can be merged!
+
+One nit is that I believe the "{}-macos.{}-none" path you added should
+be replacing "{}-macos.{}-gnu" instead of adding to it. If you look at
+the Zig distribution (zig-macos-aarch64-0.10.0-dev.3659+e5e6eb983 in my
+case) you can see there are no -gnu directories, so I believe that was
+just a typo:
+
+$ ls -d lib/zig/libc/include/*macos*
+lib/zig/libc/include/aarch64-macos.11-none
+lib/zig/libc/include/aarch64-macos.12-none
+lib/zig/libc/include/any-macos-any
+lib/zig/libc/include/any-macos.11-any
+lib/zig/libc/include/any-macos.12-any
+lib/zig/libc/include/x86_64-macos.10-none
+lib/zig/libc/include/x86_64-macos.11-none
+lib/zig/libc/include/x86_64-macos.12-none
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oi1-f178.google.com (mail-oi1-f178.google.com [209.85.167.178])
+	by mail-b.sr.ht (Postfix) with ESMTPS id A572611EF31
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 23 Aug 2022 07:19:47 +0000 (UTC)
+Received: by mail-oi1-f178.google.com with SMTP id n124so4128640oih.7
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 23 Aug 2022 00:19:47 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:from:to:cc;
+        bh=6zsEA5ROHIaWczJmUs9TIDq1H8FQUqtskW48jtXZh8U=;
+        b=WrIgsvXVSVE3sUOG3GBYAczzMKmmUiVCm+1e0Bbu/vPxOiK7d9C+zFL3pExX60pR9S
+         ytwYop74njTfEdiAQRcIu1d/ejQSZ0d3BRLMlGFdZoGDxcKwEvJgneCokYR+K5kLeNCL
+         iumvaJ3jk+NU1Kukujj2mRuLaKwMYZrdNtw8HDVvnKH+xqf/dvCj7004m+zx+pJdf3qQ
+         hJdhS/GNEy9tZGujeUL5WSYl2QGiW/G68lF/zks6992s4E8zTAoE2vQ/ckHW4RSs3NHT
+         loQq60MS+y3wNJNsC8zegbPdufs3VI2JJzg/9O217YdXWM13HzOKi0b2p56RTf23o78+
+         yQXQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:x-gm-message-state:from:to:cc;
+        bh=6zsEA5ROHIaWczJmUs9TIDq1H8FQUqtskW48jtXZh8U=;
+        b=0iwnUvjsk9pyixEGTNO7/k+CwiuXhjuPsp+aD7uLd6sxOnyhR1Rr9HZAKGeXM3L1NL
+         YHn6+fZ0N8ibCZgycIAdmZ2T8kdDFK13bIBoopon9GnyYcILSIRbhAWG3IL88c4Cb3DI
+         2mf/u2unyxwr5iPHCupymb+VOHloQkMEN9Tt5dfjTWrzStPkVzOCU2WqXM7V7hZyvB4m
+         zzDqetieUSGIbbYaKmOg/Lw4zCDAXROJpIyDd61o6ETqAt3LLrGkQ0b1o2BAud125aUw
+         pnHRqqbsNQw5qsyYntgnPLro7OltzWDLHEFzk7CFCrOCFDgf4XOhQJ1TdkTj5MRJh2KJ
+         VSnw==
+X-Gm-Message-State: ACgBeo086hb4XC/7Dvh2Virpw6nNfCoL4jBoPQnmHGgODeBo2rMKeLRZ
+	SdX90hyovoHT2c9ErqPrzWQl0qBitpsjeSXoL28=
+X-Google-Smtp-Source: AA6agR7WUdNw7VLbTkGnIeFhDKm7nlMyngIs6rt5xJJEJVJkXRNcMQGWAdgcK+vfqNkF9OQcxA3s8uUVwnD61A3H5P8=
+X-Received: by 2002:a05:6808:190f:b0:343:a58:d61d with SMTP id
+ bf15-20020a056808190f00b003430a58d61dmr782979oib.216.1661239186909; Tue, 23
+ Aug 2022 00:19:46 -0700 (PDT)
+MIME-Version: 1.0
+References: <CAMWUSyfthsE5Mk14K3Ly_EE10wcKB3eUA6MQib6Tgcv0ogAWPg@mail.gmail.com>
+In-Reply-To: <CAMWUSyfthsE5Mk14K3Ly_EE10wcKB3eUA6MQib6Tgcv0ogAWPg@mail.gmail.com>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Tue, 23 Aug 2022 10:19:35 +0300
+Message-ID: <CAFVMu-rbHhDWxb0kVi2zyPmU3JcXBc0ECOXQ+aytnGD2YOm8Tg@mail.gmail.com>
+Subject: Re: [PATCH] Add missing include path for MacOS platforms
+To: Mike Eastham <meastham@tecton.ai>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht, Luis Holanda <luiscmholanda@gmail.com>
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 312
+Lines: 12
+
+On Mon, Aug 22, 2022 at 5:28 PM Mike Eastham <meastham@tecton.ai> wrote:
+>
+> I found this thread while preparing to submit a patch for the very same
+> issue.  Hopefully it can be merged!
+
+Hi Mike,
+
+The subject like seems reasonable, but your submission is missing the
+patch itself.
+
+Thanks,
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=tecton.ai header.i=@tecton.ai
+Received: from mail-qt1-f172.google.com (mail-qt1-f172.google.com [209.85.160.172])
+	by mail-b.sr.ht (Postfix) with ESMTPS id AEC0E11EF83
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 23 Aug 2022 13:52:23 +0000 (UTC)
+Received: by mail-qt1-f172.google.com with SMTP id g14so809723qto.11
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 23 Aug 2022 06:52:23 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=tecton.ai; s=google;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:from:to:cc;
+        bh=7bXekKd7tvx/coptKr4cmDzXTJeOU8pK9pdf4IaDJxE=;
+        b=D5NGNff2j2PvRfFJ/LwlU4vC4vQCWsIv4uuvps6r2b9rcPtXRghKABU1t/l6tDS9th
+         sevm6uhIxWPrG+Xxlv5NI66WPNrslrLMoNrfGIXvxxUUKtkBP1AFn+P/6f0iYspklre6
+         58Wm+cEQqTOLwZq6aaxd6QAmpvU3AyAvofDMEh9nwlzX8jxk07kgPTjRxI6F572opaDU
+         /YHTaa0P1fH0f81hN3faGRY+v96OEg4PXX1pdi71Ars2qxN9wSh6U8iIMJTUJtKbV1Q3
+         m1+yI6rD0BxhOUWwHL8b6/gB40i0vHpgI6gKZACXqvZN8OK5kEeUtTeWnPcwgydkrCyk
+         Yr4A==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:x-gm-message-state:from:to:cc;
+        bh=7bXekKd7tvx/coptKr4cmDzXTJeOU8pK9pdf4IaDJxE=;
+        b=JEizfdgirIPfD1X2Xn3/2pJXhu/7gMTYck8d0FhL0p/CR1RYWPfgsaylmGfg7saIbZ
+         7iZMCbmAbbsXuobwb7dW3Etqz/JUI2kfaL8vnbDJnSMSxLicbn8GJMrBSa2MEoCFtrdV
+         Y9l91d4VXhJwU/XnBvQcVb6VljNMDqoeUbv/ZGJubkiYCM8rbdwvPGHe8/tEDQxDr8Vj
+         xSqKPrQ4bmxOHFIpRYN5WqndvN2ewSWl9qcQhaEYfxnSXh+wF1Nd5qk5Qyev6XzYAUNj
+         bbmd9ziZymPy9a+kujJr2WtJa6xCquXmgESpzImm3FkmM/RZs5wke5f4e0klvBiPP280
+         QD1g==
+X-Gm-Message-State: ACgBeo1Gqc4xx4nLA0Ol5cQ+UkwvTy2yQTdhWsRyc1+K2W6IJzcGxfy6
+	//ZWFpWHxl8dP6IoWWYg1k8ESYO5Bnk+L93VHd3pq2mbitRHHA==
+X-Google-Smtp-Source: AA6agR7Kf21QHF0pb+L+wpWo+wCOBg1pUhgFNRILndGzWlmPJTzpIlGWIh/eY5IcibUONlUdl1QeSHfGR5xX1vXcw7c=
+X-Received: by 2002:ac8:5dd3:0:b0:344:94e6:d667 with SMTP id
+ e19-20020ac85dd3000000b0034494e6d667mr18596305qtx.409.1661262742104; Tue, 23
+ Aug 2022 06:52:22 -0700 (PDT)
+MIME-Version: 1.0
+References: <CAMWUSyfthsE5Mk14K3Ly_EE10wcKB3eUA6MQib6Tgcv0ogAWPg@mail.gmail.com>
+ <CAFVMu-rbHhDWxb0kVi2zyPmU3JcXBc0ECOXQ+aytnGD2YOm8Tg@mail.gmail.com>
+In-Reply-To: <CAFVMu-rbHhDWxb0kVi2zyPmU3JcXBc0ECOXQ+aytnGD2YOm8Tg@mail.gmail.com>
+From: Mike Eastham <meastham@tecton.ai>
+Date: Tue, 23 Aug 2022 09:52:11 -0400
+Message-ID: <CAMWUSyfyLU+CR8mCznvAgopdX+JzJUniFWNRYrq8x3Xz4AA4fA@mail.gmail.com>
+Subject: Re: [PATCH] Add missing include path for MacOS platforms
+To: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht, Luis Holanda <luiscmholanda@gmail.com>
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 304
+Lines: 8
+
+Hey Motiejus,
+
+I was trying to reply to the patch submitted by Luis Holanda 26 days
+ago[0], but I suppose I did something incorrectly. Sorry about that!
+
+If it would be helpful for me to submit my own patch I would be happy to do so.
+
+[0] https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/34242
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oi1-f181.google.com (mail-oi1-f181.google.com [209.85.167.181])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 0CA6811EF83
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 23 Aug 2022 15:14:00 +0000 (UTC)
+Received: by mail-oi1-f181.google.com with SMTP id u14so16408944oie.2
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 23 Aug 2022 08:14:00 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:from:to:cc;
+        bh=UiBbGSUcRFrswlDf6dTZPvgknhWjlPB+Pss1mV60VCc=;
+        b=N6jjJ6h6JmEyxA+/5eKax7hkg3q3r8REAO5GXZUWNVhMPfpc/bXF74m8w2LhNfxdSd
+         hLjMlk2+1QYlrlQ3238JA6ap6CEpNuowZLU8jDtKaGoTDMSEQL0cX3cUu9+W/rLoWPl4
+         N0A89BhjKQF1r3iFY3kLtB6L5XfshMTayLS4d1quqcuOVCG1SF34xZsJXp0IpZPfScNd
+         iWwjKXjY1Ejnlnat/e4RPmjWND+7MnM8tP0xzpTefJqVUwX7YRujviUQ8ejWwUeu3uLm
+         il/OsndSfHTJOzbFOwGSu0IrJ1URoil7znqs2lZEOXev2RMCHgDJ1zB2nEPlEwZoH6Dx
+         jm6g==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:x-gm-message-state:from:to:cc;
+        bh=UiBbGSUcRFrswlDf6dTZPvgknhWjlPB+Pss1mV60VCc=;
+        b=nXkkocwHjS12hwEmRoCJEuDyEA5/Yfyc8rg/Hdw4U7HhKrFqxiBxgIQGDrc+036xgO
+         /3cYHviSRGVCuwYv4yzhKmT9OwV2HCeBAlQn1hK5wH0YuScVrqjYEY9PrfztXDEoGWzx
+         0hbgBpEV3Yd8FNV/QuFYtop7yOIcqJL8uDYZLqFBWsSLrBS5HwT7kIha/IkNXAM9sCOM
+         bqfvdk1N+UyC0gQVo+5h0KR0bmkmqJ8xRCKstlbfxB0vkp/WkYgsxU/4e3i4lcNzZT1n
+         L+EqzC5FH6dHZhYmV4WYNWKcKT+KvSta0nWv8roYmbHJvXHgVpu+8OHPdk70NQU0T3Th
+         4Otg==
+X-Gm-Message-State: ACgBeo2jw2zx+vpN5jWqlaJs4WCe9crw0+L5IQXWEJhZvx30LGi0r1Dd
+	ZSslqXzTW6GPl4YKCXcfZ8llj6STsY5nSucG2Ns=
+X-Google-Smtp-Source: AA6agR7EZXa3RFai+xgmpWX1+wBSiFO8yPakr89uSj1HUbwpRv9okSa+K4wmADtuNKXmmaCwN2c/4YUVFFwwB+dP20o=
+X-Received: by 2002:a54:4899:0:b0:343:3f7c:713d with SMTP id
+ r25-20020a544899000000b003433f7c713dmr1493575oic.116.1661267639367; Tue, 23
+ Aug 2022 08:13:59 -0700 (PDT)
+MIME-Version: 1.0
+References: <CAMWUSyfthsE5Mk14K3Ly_EE10wcKB3eUA6MQib6Tgcv0ogAWPg@mail.gmail.com>
+ <CAFVMu-rbHhDWxb0kVi2zyPmU3JcXBc0ECOXQ+aytnGD2YOm8Tg@mail.gmail.com> <CAMWUSyfyLU+CR8mCznvAgopdX+JzJUniFWNRYrq8x3Xz4AA4fA@mail.gmail.com>
+In-Reply-To: <CAMWUSyfyLU+CR8mCznvAgopdX+JzJUniFWNRYrq8x3Xz4AA4fA@mail.gmail.com>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Tue, 23 Aug 2022 18:13:48 +0300
+Message-ID: <CAFVMu-onW3K9cF3iS9YK7a6zQ+fi_OEvYskJfjxM1zaresZPRg@mail.gmail.com>
+Subject: Re: [PATCH] Add missing include path for MacOS platforms
+To: Mike Eastham <meastham@tecton.ai>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht, Luis Holanda <luiscmholanda@gmail.com>
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 459
+Lines: 13
+
+On Tue, Aug 23, 2022 at 4:52 PM Mike Eastham <meastham@tecton.ai> wrote:
+>
+> Hey Motiejus,
+>
+> I was trying to reply to the patch submitted by Luis Holanda 26 days
+> ago[0], but I suppose I did something incorrectly. Sorry about that!
+>
+> If it would be helpful for me to submit my own patch I would be happy to do so.
+
+Thanks, I didn't capture this first time. Applied Louis' patch and per
+your suggestion removed the darwin-gnu ones.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=tecton.ai header.i=@tecton.ai
+Received: from mail-qk1-f176.google.com (mail-qk1-f176.google.com [209.85.222.176])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 3B24E11EFF5
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 23 Aug 2022 17:10:24 +0000 (UTC)
+Received: by mail-qk1-f176.google.com with SMTP id g21so10786492qka.5
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 23 Aug 2022 10:10:24 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=tecton.ai; s=google;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:from:to:cc;
+        bh=rNJlO4/q80kk+PEPtW5ue8B+S2Qcu1i/6aKbO8a3aoI=;
+        b=ZC4OgnYZUU79FwXdoX76CN+40U8f4wDu0Psb5HuI/OdHa9++nSKj+j9iPP/lT3Hf2L
+         PbRie9tQHGfSDfovYbBGYEtrTbAqfCuTNa4Rjc+PUKBsNCavBuctA01BRIQab5lzGzyh
+         cTql61htQbUj17nxpjiKqEGJ7U0qE4itwuSMd3Ysbsxsto9curOzjHreN1IuRTlrpmCr
+         nOdJkGh//1GTP1eXO6OpOiEZ+GD48y+V5iWsF89H2aP7O95vc8DrzIxFZTU0LcsMLpBn
+         jOreDjZxYuyWhtMDrrQxXbSUMVR3rMISUWR/NG+7vK6jRiVq65F/5S1MV8VHX9LiE7g/
+         ISkw==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:x-gm-message-state:from:to:cc;
+        bh=rNJlO4/q80kk+PEPtW5ue8B+S2Qcu1i/6aKbO8a3aoI=;
+        b=v6BO8vSXIB9+WAEe+mbk7IMU/SCNUGRMHkgI2WbHOzfd98j1Y6/a3/a/YUOelxSIpz
+         O85Gp0u8azxGDG6gcygoq8elOcRNjvS11TNQDZDmtFsUbSfFtMII/PTss0EQdnDXu9u0
+         nh0pHf0lsbv39t5htMX6LWj4GMivbn/xFBbX5FKe6GaFylirGk0FlzvsaPck84/FXz0G
+         lBGn5j9GABWmTuOZ6A4EDh8ymEkaGn3arHVng+UtBmVx9279izVchHfecyto6TOH0a8x
+         38AtYfJ0NvodF/ytn0S2sN57UtSYRMJq2dQxWl4ukjMgnj8uk2EwMlGT3jAtCvek8Sfg
+         FxwQ==
+X-Gm-Message-State: ACgBeo25VjTDVduzxYBQeZiaxYsKHqe7DI/7flkFgnpfuwwkUsf8i0kl
+	pHM9WeRu5eCcNv3uB7d8kxHI0NdZ/ZgFNKb4UqPmVg==
+X-Google-Smtp-Source: AA6agR7lCoB9/y1yTlFbzgKSG6nBxE3xWn/5XsIZWIFm369jnjb5WxHYdTou1ZnbcRl1mAVDMltPLsYuiUwDGq1T4L8=
+X-Received: by 2002:a05:620a:4412:b0:6ba:e53e:3485 with SMTP id
+ v18-20020a05620a441200b006bae53e3485mr16752631qkp.461.1661274623761; Tue, 23
+ Aug 2022 10:10:23 -0700 (PDT)
+MIME-Version: 1.0
+References: <CAMWUSyfthsE5Mk14K3Ly_EE10wcKB3eUA6MQib6Tgcv0ogAWPg@mail.gmail.com>
+ <CAFVMu-rbHhDWxb0kVi2zyPmU3JcXBc0ECOXQ+aytnGD2YOm8Tg@mail.gmail.com>
+ <CAMWUSyfyLU+CR8mCznvAgopdX+JzJUniFWNRYrq8x3Xz4AA4fA@mail.gmail.com> <CAFVMu-onW3K9cF3iS9YK7a6zQ+fi_OEvYskJfjxM1zaresZPRg@mail.gmail.com>
+In-Reply-To: <CAFVMu-onW3K9cF3iS9YK7a6zQ+fi_OEvYskJfjxM1zaresZPRg@mail.gmail.com>
+From: Mike Eastham <meastham@tecton.ai>
+Date: Tue, 23 Aug 2022 13:10:13 -0400
+Message-ID: <CAMWUSyeBL-Vru+DjPvr5wiaOHLUNo90fHgnSk_sCVrJ09dXG9A@mail.gmail.com>
+Subject: Re: [PATCH] Add missing include path for MacOS platforms
+To: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht, Luis Holanda <luiscmholanda@gmail.com>
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 12
+Lines: 1
+
+Thank you!
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 2FA7811EEDB
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 26 Aug 2022 07:27:56 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Thu, 25 Aug 2022 19:24:38 +0100
+Subject: [PATCH bazel-zig-cc] Support configuring cache prefix with an
+ environment variable
+Message-ID: <166149887610.13477.8916629882571649449-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <git@kmicklas.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 1462
+Lines: 38
+
+From: Ken Micklas <kmicklas@uber.com>
+
+The user may want to build with `--sandbox_tmpfs_path=3D/tmp`, in which
+case the Zig cache will not be shared between sandboxes, massively
+slowing down the build. With this feature, the user can pass flags
+like `--repo_env=3DBAZEL_ZIG_CC_CACHE_PREFIX=3D$HOME/.cache/bazel-zig-cc`
+together with `--sandbox_writable_path=3D$HOME/.cache/bazel-zig-cc` to
+put the cache somewhere else which can be shared between sandboxes.
+---
+ toolchain/defs.bzl | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 965cf22..c8b5be0 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -79,7 +79,9 @@ def toolchains(
+ ZIG_TOOL_WRAPPER =3D """#!/usr/bin/env bash
+ set -e
+=20
+-if [[ -n "$TMPDIR" ]]; then
++if [[ -n "{cache_prefix}" ]]; then
++  _cache_prefix=3D"{cache_prefix}"
++elif [[ -n "$TMPDIR" ]]; then
+     _cache_prefix=3D$TMPDIR
+ elif [[ -n "$HOME" ]]; then
+     if [[ "$(uname)" =3D Darwin ]]; then
+@@ -149,6 +151,7 @@ def _zig_repository_impl(repository_ctx):
+         zig_tool_wrapper =3D ZIG_TOOL_WRAPPER.format(
+             zig =3D str(repository_ctx.path("zig")),
+             zig_tool =3D zig_tool,
++            cache_prefix =3D repository_ctx.os.environ.get("BAZEL_ZIG_CC_CAC=
+HE_PREFIX", ""),
+         )
+         if os =3D=3D "windows":
+             zig_tool_wrapper =3D ZIG_TOOL_WRAPPER_WINDOWS.format(
+--=20
+2.34.4
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=oJdQI8cGPBGSPfeNCNHqTUaYSI5F7OsizcNMwxO1CBc=;
+ c=simple/simple; d=sr.ht; h=Date:From:In-Reply-To:Subject:To:Cc;
+ q=dns/txt; s=srht; t=1661499911; v=1;
+ b=FKUvpqRZn48EuM1Clnn8smebPS97WzQbLOkOg8wIcLEIBANQpZ9+2cI+QFGpZn+p0kB4hp43
+ WRxr4O8CghhS4Ty/8rEuX2Mw0I7UJW0hLpoaktE5kp8ukyzylq7/NjlLqe6faPf7XGcBveG8e0P
+ OvtLuP/oFGH33g4NcokYJMrS/ndlYsT3cZHAkP8EIw/v81efpDBz9bHNnrK5/bjkA9epRbZIt/t
+ 9Jgh/3evWvhwLgFP70HESwNXbb0d5TbLdT13cCvFfZI6DkI5DTF9ezrIGL1AR5x0n1CpJAHKm8i
+ TqP5Ubmcpj+W8yHasex7qDNCfWoRnywWujeDvk7jgIkiA==
+Received: from localhost (unknown [173.195.146.249])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id 899C411EEDB;
+	Fri, 26 Aug 2022 07:45:11 +0000 (UTC)
+MIME-Version: 1.0
+Date: Fri, 26 Aug 2022 07:45:11 +0000
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CMFSKA1RSFMZ.2922PNT3HSAR6@cirno>
+In-Reply-To: <166149887610.13477.8916629882571649449-0@git.sr.ht>
+Subject: [bazel-zig-cc/patches/.build.yml] build success
+To: "~kmicklas" <git@kmicklas.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain; charset=UTF-8
+Status: O
+Content-Length: 346
+Lines: 10
+
+bazel-zig-cc/patches/.build.yml: SUCCESS in 17m14s
+
+[Support configuring cache prefix with an environment variable][0] from [~k=
+micklas][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/34941
+[1]: mailto:git@kmicklas.com
+
+=E2=9C=93 #831878 SUCCESS bazel-zig-cc/patches/.build.yml https://builds.sr=
+.ht/~motiejus/job/831878
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f46.google.com (mail-oa1-f46.google.com [209.85.160.46])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 3E7C811EF6A
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 26 Aug 2022 08:08:40 +0000 (UTC)
+Received: by mail-oa1-f46.google.com with SMTP id 586e51a60fabf-11ba6e79dd1so1144697fac.12
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 26 Aug 2022 01:08:40 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:from:to:cc;
+        bh=iOkmg5H8kC6sYToj5IN2l3Dx0MnC/eA4iGylZVpI+8U=;
+        b=juI1V+/7KoFUYCnp6qJsqHiqrggnyxOzleApuW80+dDeWg3U1e3/8GrdBsnN+Z2zDH
+         WKgYyG41aiCnB19lgl2UvyAPklUDBAEzBek6C+NDHxcE7s4hVyqhGjeW6KVTipaPnnul
+         EPGEU4Bca3hYjaFatlHrNm2aihtEc51g5/JAurf7MUyNQ+rS2Hq4V1nC9n3UbFke3kU8
+         lsw2ZufrcDOgMz2c+95qTORaUIe0HWSGvYRJkpiAbJ9E9awCeyK3nlOL3WTO/MUuTcR/
+         qzxf/FGIk+I3Bw2qdcXO+hd+TPUlylblp5JP2qUT7KbnaCsRq5zWL4Ek0z2CuE/XOVPr
+         pdxw==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:x-gm-message-state:from:to:cc;
+        bh=iOkmg5H8kC6sYToj5IN2l3Dx0MnC/eA4iGylZVpI+8U=;
+        b=QMV1l7PnqWEZAcrKkEi/heXhp9gXq+ydD0y1tWe66Dvrm//kdZFNgBM83pw4loXxBk
+         vb1NFmpRtVdi6Zds/BYPq8Uja8ih6KtNDV9Mc2iPBSmYTdR2jlXLxh+9MtqC1YlOVwK9
+         J7ae17qPljNC8a/3czJEjURMkeEU7sE5+UEYpGL94yWrHtAFQ4WIi2TtAwvOKWJIoMFl
+         jvzquOqcOlGaV4l5HMXB0832JKPDbeRs2ziIVoFtxTOcKYCXmkXXmp8aOojZstG47O82
+         ZgsmWr+qsEpqSYxSAkQsnqwdx0Yo/0H9xgc6u4Mg5lf/XxZ8TVStYWFa7hX1Djo3qmaI
+         3UjA==
+X-Gm-Message-State: ACgBeo2djEKtwyIXs6fHXZra+NWPHUOZYnbc4+CVw0uZeCctrXFu1GYG
+	HmbM/DZ5/KPJRGuN4v+SBaX4nD2cES9RodzU0Eoi2xwYmRM=
+X-Google-Smtp-Source: AA6agR49KCQy6GE5DZjvLSA9n41ys6JQMPc19xV1D6a3nfU7M/3p6wpPG82CRH33KzzI2CvDPj0/LIB7z+qzRkly/Kk=
+X-Received: by 2002:a05:6871:154:b0:11e:33b7:ddf7 with SMTP id
+ z20-20020a056871015400b0011e33b7ddf7mr1280671oab.116.1661501319573; Fri, 26
+ Aug 2022 01:08:39 -0700 (PDT)
+MIME-Version: 1.0
+References: <166149887610.13477.8916629882571649449-0@git.sr.ht>
+In-Reply-To: <166149887610.13477.8916629882571649449-0@git.sr.ht>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Fri, 26 Aug 2022 11:08:28 +0300
+Message-ID: <CAFVMu-oHOnGk7f3joqxPKcinZOR2C-PCrSc9C1dVz70a7Je8dQ@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc] Support configuring cache prefix with an
+ environment variable
+To: "~kmicklas" <git@kmicklas.com>, Fabian Hahn <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 741
+Lines: 16
+
+On Fri, Aug 26, 2022 at 10:28 AM ~kmicklas <kmicklas@git.sr.ht> wrote:
+>
+> From: Ken Micklas <kmicklas@uber.com>
+>
+> The user may want to build with `--sandbox_tmpfs_path=/tmp`, in which
+> case the Zig cache will not be shared between sandboxes, massively
+> slowing down the build. With this feature, the user can pass flags
+> like `--repo_env=BAZEL_ZIG_CC_CACHE_PREFIX=$HOME/.cache/bazel-zig-cc`
+> together with `--sandbox_writable_path=$HOME/.cache/bazel-zig-cc` to
+> put the cache somewhere else which can be shared between sandboxes.
+
+Thanks, applied.
+
+Fabian, would you like to keep compatibility and do this[1] for Windows?
+
+[1]: https://git.sr.ht/~motiejus/bazel-zig-cc/commit/15f957859146deaf524bbdf1a4b537124b305405
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-oa1-f52.google.com (mail-oa1-f52.google.com [209.85.160.52])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 9523611EF8C
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 26 Aug 2022 08:38:29 +0000 (UTC)
+Received: by mail-oa1-f52.google.com with SMTP id 586e51a60fabf-11c896b879bso1254063fac.3
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 26 Aug 2022 01:38:29 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=to:subject:message-id:date:from:mime-version:from:to:cc;
+        bh=cpK8UTVU08tIWKMrxkziALp2cye54mdoDIYGSuig7lI=;
+        b=BnyG+7/NibGRdwnEkKMA8Z24uCtX8KPI9AU+Iw0HSPaO5woiyoPB9+4kIEu88+Wyqp
+         dQnK1RoTj59q/a8XbleyDu0ED0h2LH1QiFG03wp24DKpdInMP/LB+M2sQRAwLmYdQtCZ
+         Oig4/mZYS2KBha5d4SiyOnOktXSgpGzsUzbYVS6xT19vr488bzyo8mKXaWO5qZ+sPqy9
+         3wssbsxJn39eF34wSTH0yxX1zNvPm0rRuUutk1vilIENocSupzAk+mxNEgW0Q5fvgpRo
+         EcPdhmr6aX1rrqg9Gw9uz3sW9THQODNLh3W9lS1qMtrS7hoOGvfeaMvXcF/VEdaK+zX9
+         3iTg==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=to:subject:message-id:date:from:mime-version:x-gm-message-state
+         :from:to:cc;
+        bh=cpK8UTVU08tIWKMrxkziALp2cye54mdoDIYGSuig7lI=;
+        b=j8vgK6xND5v0H3bGEtHiqnINbNTq9D+tecbIsIy7diiJ8o6QYuhcv24XnwV+6fD/AU
+         egtbi5ZuxuQY85QJQjFqUbgfQ8gQaZBYPP5D2yLCdmgZXw6puXQYI2jV3Qtt2qggI7Io
+         k9JjaF0Blqxs620plGICSrM/L7qVIMUGvCU0SjAnYSZuV+m0MTD2d+apXyRoI75tiCey
+         216Yeti1OPuxbP2Asf1SlKN89IYwuraE9NqmzBRbynUgwwxPUSI4TnBG4LQQa3vNvEjW
+         AuoohUL+pyegdRbOn6iVCmRncuPTbbVfxf0GMZD4Mx1oQK8CxeLMx7J3IJ5U8yOWzwL/
+         ZW2A==
+X-Gm-Message-State: ACgBeo33Be18p3r2ESaHUkqBqyfRXHON/gzItdvg2aq+D25tCgQYaoJQ
+	KaN/vmzRs/B8foB8OYjRK2KEVqCRFjwQQPupB88AeWHxE+4=
+X-Google-Smtp-Source: AA6agR4/8eK+uJyRNxbPftkvtMpuWfhReKcdn/P9AtMI5C6tsCd1wyWNGN7gNbKnAcNo6kzCc6jddC16pH+520xbyUk=
+X-Received: by 2002:a05:6871:154:b0:11e:33b7:ddf7 with SMTP id
+ z20-20020a056871015400b0011e33b7ddf7mr1318453oab.116.1661503108578; Fri, 26
+ Aug 2022 01:38:28 -0700 (PDT)
+MIME-Version: 1.0
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus.jakstys@gmail.com>
+Date: Fri, 26 Aug 2022 11:38:17 +0300
+Message-ID: <CAFVMu-rUhnfR3_86szyfw2XkOZfMo5zcDuexzzpyxinKH8sM8A@mail.gmail.com>
+Subject: bazel-zig-cc v0.9.1
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 629
+Lines: 17
+
+Hi all,
+
+I just released v0.9.1. Changes:
+
+- [Ken Micklas] Support configuring cache prefix with an environment variable
+- [Luis Holanda] Add missing include path for MacOS platforms
+
+This does no longer hardcode (on non-windows platforms at least) the
+/tmp/bazel-zig-cc; you can point the cache directory elsewhere.
+
+Zig landed two relevant changes to bazel-zig-cc:
+- https://github.com/ziglang/zig/pull/12629 : add some resolv stubs.
+- https://github.com/ziglang/zig/pull/12605 : artifacts of `zig cc`
+are no longer cached by zig. This avoids double-caching for most
+object files, saving disk space.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id B7DD711F00B
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 26 Aug 2022 09:07:05 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1661504822;
+	bh=9v0CfrUdSZh64OPu0b0vU8NJU5RI6W4mHvINxqb0E1c=;
+	h=From:To:Cc:Subject:In-Reply-To:References;
+	b=FJ/llJ4/xiM8AwdzNSNPCAInHcbZ6+ouTOzpC6sAIPU9H2NgkqGt9YcLBlyJYqXRY
+	 +6nvT5JKfdsXMUKGe2GFB2WgR3iFM1Ujoh/VhVhwJH+Cu59tuI0QPIabe7IbnO21vP
+	 iNAUaa8jMteY+eGdjfPCMqtm7N2He+lVwvOqS/QA=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8;
+ format=flowed
+Content-Transfer-Encoding: 8bit
+Date: Fri, 26 Aug 2022 10:06:56 +0100
+From: fabian@hahn.graphics
+To: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Cc: ~kmicklas <git@kmicklas.com>, ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: Re: [PATCH bazel-zig-cc] Support configuring cache prefix with an
+ environment variable
+In-Reply-To: <CAFVMu-oHOnGk7f3joqxPKcinZOR2C-PCrSc9C1dVz70a7Je8dQ@mail.gmail.com>
+References: <166149887610.13477.8916629882571649449-0@git.sr.ht>
+ <CAFVMu-oHOnGk7f3joqxPKcinZOR2C-PCrSc9C1dVz70a7Je8dQ@mail.gmail.com>
+Message-ID: <103137ae39e92e7032ed8b5998b5432e@hahn.graphics>
+X-Sender: fabian@hahn.graphics
+Status: O
+Content-Length: 173
+Lines: 5
+
+On 2022-08-26 09:08, Motiejus Jakštys wrote:
+> Fabian, would you like to keep compatibility and do this[1] for 
+> Windows?
+
+Sure, I'll take a look at it this weekend.
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 52F2F11EF56
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat, 27 Aug 2022 15:21:33 +0000 (UTC)
+From: Fabian Hahn <fabian@hahn.graphics>
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1661613689;
+	bh=lk7Ka7YTW3+XNx+V5QY2I3th4yFnM/VkEh+FTAcP0t4=;
+	h=From:To:Cc:Subject;
+	b=L3rCigC4XvEQUaC8R4ErzWSfYdrUmAOvlddz/hXGxRJz91s8nJmQs9lXWkydR0dxU
+	 VzOlZMR6ieOtdpKBqeLD508S5hdiR582WaE6GzCpi+C8tHjcAj9mCwqmXX1LdO6BLZ
+	 U4TTRH0/m2XKA3iq4suI8XDl12ZWQ08PXVMqYNxM=
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Fabian Hahn <fabian@hahn.graphics>
+Subject: [PATCH bazel-zig-cc] add cache prefix configuration for Windows
+Date: Sat, 27 Aug 2022 16:21:08 +0100
+Message-Id: <20220827152108.6422-1-fabian@hahn.graphics>
+Mime-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Status: O
+Content-Length: 2062
+Lines: 55
+
+---
+ toolchain/defs.bzl | 30 +++++++++++++++++++++++++-----
+ 1 file changed, 25 insertions(+), 5 deletions(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index a95f76e..53fd161 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -101,7 +101,20 @@ export ZIG_GLOBAL_CACHE_DIR=$ZIG_LOCAL_CACHE_DIR
+ exec "{zig}" "{zig_tool}" "$@"
+ """
+ 
+-ZIG_TOOL_WRAPPER_WINDOWS = """@echo off
++ZIG_TOOL_WRAPPER_WINDOWS_CACHE_KNOWN = """@echo off
++set ZIG_LOCAL_CACHE_DIR={cache_prefix}\\bazel-zig-cc
++set ZIG_GLOBAL_CACHE_DIR=%ZIG_LOCAL_CACHE_DIR%
++"{zig}" "{zig_tool}" %*
++"""
++
++ZIG_TOOL_WRAPPER_WINDOWS_CACHE_GUESS = """@echo off
++if exist "%TMP%\\*" goto :usertmp
++set ZIG_LOCAL_CACHE_DIR=C:\\Temp\\bazel-zig-cc
++goto zig
++:usertmp
++set ZIG_LOCAL_CACHE_DIR=%TMP%\\bazel-zig-cc
++:zig
++set ZIG_GLOBAL_CACHE_DIR=%ZIG_LOCAL_CACHE_DIR%
+ "{zig}" "{zig_tool}" %*
+ """
+ 
+@@ -152,10 +165,17 @@ def _zig_repository_impl(repository_ctx):
+     for zig_tool in _ZIG_TOOLS:
+         cache_prefix = repository_ctx.os.environ.get("BAZEL_ZIG_CC_CACHE_PREFIX", "")
+         if os == "windows":
+-            zig_tool_wrapper = ZIG_TOOL_WRAPPER_WINDOWS.format(
+-                zig = str(repository_ctx.path("zig")).replace("/", "\\") + ".exe",
+-                zig_tool = zig_tool,
+-            )
++            if cache_prefix:
++                zig_tool_wrapper = ZIG_TOOL_WRAPPER_WINDOWS_CACHE_KNOWN.format(
++                    zig = str(repository_ctx.path("zig")).replace("/", "\\") + ".exe",
++                    zig_tool = zig_tool,
++                    cache_prefix = cache_prefix,
++                )
++            else:
++                zig_tool_wrapper = ZIG_TOOL_WRAPPER_WINDOWS_CACHE_GUESS.format(
++                    zig = str(repository_ctx.path("zig")).replace("/", "\\") + ".exe",
++                    zig_tool = zig_tool,
++                )
+         elif cache_prefix:
+             zig_tool_wrapper = ZIG_TOOL_WRAPPER_CACHE_KNOWN.format(
+                 zig = str(repository_ctx.path("zig")),
+-- 
+2.25.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=5E6sxSf2ZXX1a2DrcA3hWyb5G48e8Oph2Nv321KR9mc=;
+ c=simple/simple; d=sr.ht; h=Date:From:In-Reply-To:Subject:To:Cc;
+ q=dns/txt; s=srht; t=1661614790; v=1;
+ b=O5riAorNq06QMAdbcpBR4oFYJ5fEQ5NgmTb1RVM4AVCoQ9we1LyL+FSilOPXC1pgix54A6u3
+ Bey7nRs4WQTBX9pIqcrfhhCQ7fFpZ07HG8dUoG2VmAMhknU+ojF1eajzEh98PPjw2PpPDW+gYhE
+ uQfUzL01Ibk9r123DFEA/1pBXaIjjayUcsHWfiiMejz4fR0e+cmDPxTRxrxhbZn/aqMjFT5IgTd
+ bVoAesVLCnPxHxbVpQ2iAAMkRY3uR6R4BbTVoZXFaDbPpcnfIeM811EmBYRqj0a2WJhbr3M89Bw
+ gu5rMALDRjqvbdXFxmS1AkmIMi+2kiBidvJtv39h9zcOw==
+Received: from localhost (unknown [173.195.146.244])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id F17B711EF56;
+	Sat, 27 Aug 2022 15:39:50 +0000 (UTC)
+MIME-Version: 1.0
+Date: Sat, 27 Aug 2022 15:39:50 +0000
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CMGXA8U8IWOU.KNKJDWHU9ZK9@cirno2>
+In-Reply-To: <20220827152108.6422-1-fabian@hahn.graphics>
+Subject: [bazel-zig-cc/patches/.build.yml] build success
+To: "Fabian Hahn" <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain; charset=UTF-8
+Status: O
+Content-Length: 330
+Lines: 9
+
+bazel-zig-cc/patches/.build.yml: SUCCESS in 18m16s
+
+[add cache prefix configuration for Windows][0] from [Fabian Hahn][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/34959
+[1]: mailto:fabian@hahn.graphics
+
+=E2=9C=93 #832843 SUCCESS bazel-zig-cc/patches/.build.yml https://builds.sr=
+.ht/~motiejus/job/832843
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-ot1-f53.google.com (mail-ot1-f53.google.com [209.85.210.53])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 6E23A11EF92
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 29 Aug 2022 11:46:50 +0000 (UTC)
+Received: by mail-ot1-f53.google.com with SMTP id h20-20020a056830165400b00638ac7ddba5so5696434otr.4
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 29 Aug 2022 04:46:50 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:from:to:cc;
+        bh=x0lFNpP5L+ObV4+f6IFR3E0AjaW8Z93zTXfDBDuTNWA=;
+        b=KiD91MhGDTZ3PmvYRaOPYw/l92xYiBTbmwWaAIo6pdL7kT8dtBkULVLqPhl05rXyT8
+         8mzyvXawwV6XJSKWR8IxnJI6CH42HLQtYKNkzT/ZHjEzdnWiu8dzcekqSWmJOvdKwx5Z
+         mTDyBIXdP5s4SLiXFZIGBP2hEVx6xc2BmsQQV8YaYUdHlDdfJ/zdz5Vwn1pAgB98rLX3
+         lq42KlUtEJTFypFzg/dx7S7nv40fYePFbVVWcZ4UXpNCE7q40AMOV/HTnXNJtKMW16fS
+         N+XtahcOSjOD4CN+jllyqFqC22yOEvjyq0iEN23c2B3otVU3ImwLS6954MF1I5Wa0T2Z
+         6vtg==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:x-gm-message-state:from:to:cc;
+        bh=x0lFNpP5L+ObV4+f6IFR3E0AjaW8Z93zTXfDBDuTNWA=;
+        b=hyj8QbDeF2MoHf3AK3q2N85zrt5YTygwRUPQmqSeImUVbLmdWE0pnP5DUI7xTWya3A
+         lfjsIB1Jt4quyklzZjhmFTd+qvf66i7Y5+GPHOBwIOOFbItZ1IuCOEmdQsq0Af+Zp9Tn
+         XfWwmNd/+nD8j5H5Xafxh0HrfxIiZDWgZ86oB7X9AEtMIZNLokyP/WRYW8ootGZWUmWA
+         oaaIDmGLoPpWlPkzJjfYOxsZCmmthCZOS5UTzJ0YnYTen8Q6mA2AvXtEvgGsjJ+U11nK
+         JJt5H2ay1ikjALfdPns7dgTDxZqzNMPozCcmSbcUDEEQKSNCBAGbgIZK9mxtxBleehjX
+         +Fiw==
+X-Gm-Message-State: ACgBeo3bpdst8L9ChlFwXJoeRiXReFVVWDpOJ9oWkOrTMynkeswlB9gi
+	WfbdGNMX3ZWlriOwcL0w6x65NDNoXSIrJm49aDk=
+X-Google-Smtp-Source: AA6agR7uTAmiG0/lWGZlTD1TXldy2nqE6VyscD8pIWS8rekNF7Pd201/NJu2wm2kS1Ma7vC2kJ7UEpzT2umsv5EQSO4=
+X-Received: by 2002:a9d:6452:0:b0:638:8437:cbb3 with SMTP id
+ m18-20020a9d6452000000b006388437cbb3mr6246491otl.194.1661773609610; Mon, 29
+ Aug 2022 04:46:49 -0700 (PDT)
+MIME-Version: 1.0
+References: <20220827152108.6422-1-fabian@hahn.graphics>
+In-Reply-To: <20220827152108.6422-1-fabian@hahn.graphics>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Mon, 29 Aug 2022 14:46:38 +0300
+Message-ID: <CAFVMu-qBY8E4DOCub_BVzrf=WbfAVq=fXVUHXLSJ4o506MiyRg@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc] add cache prefix configuration for Windows
+To: Fabian Hahn <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 621
+Lines: 18
+
+On Sat, Aug 27, 2022 at 6:21 PM Fabian Hahn <fabian@hahn.graphics> wrote:
+>
+> ---
+>  toolchain/defs.bzl | 30 +++++++++++++++++++++++++-----
+>  1 file changed, 25 insertions(+), 5 deletions(-)
+>
+
+Hi Fabian,
+
+I've applied your diff and cleaned up[1][2] the accumulated mess, then
+pushed to main. If I broke anything on Windows in the process, please
+ping me, preferably in the next couple of days.
+
+Thanks!
+Motiejus
+
+[1]: https://git.sr.ht/~motiejus/bazel-zig-cc/commit/e861c5b4bedb752adbdca9bfb863e9cc131c2a5c
+[2]: https://git.sr.ht/~motiejus/bazel-zig-cc/commit/342b239bb90e3bd8c35e64d6bc14924600e980c5
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f54.google.com (mail-oa1-f54.google.com [209.85.160.54])
+	by mail-b.sr.ht (Postfix) with ESMTPS id A21AB11EE64
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 30 Aug 2022 03:07:30 +0000 (UTC)
+Received: by mail-oa1-f54.google.com with SMTP id 586e51a60fabf-11c5505dba2so13797028fac.13
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 29 Aug 2022 20:07:30 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=content-transfer-encoding:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:from:to:cc;
+        bh=pmtODwdqQDwI78SnRc0bQ6YRA+jpVfC0v5H1ES+2g+Y=;
+        b=OF9SmF0rDDVH92ayCFnFGcwb9lR+7vXfkClxCgAh/+EiVZRmT0DkQw4QhbJ9vZX00+
+         jeaH1AOpH27VfD4q0EJ7KKwT7CV/Lx7R0i8MdZsq9ME9Hbg47QqiIeaIra/h5aVyM2fW
+         CCmRhsGqY5ib6cYe66JPfe87BPMiYkJ5FHSXal6mwg6kvDrzOEmIN/zn7epAfsh9sJQr
+         jGNVzj0Fm+mVwhHFKnyBpeANCaC1c7Mv8ioNB31OAqZHoxZQG+pNvJ9PwnlqguWdqYVW
+         705TUgAc1JUONkDqJ7GB+jZ/1yviKAgbCUDjGqXE4R4ulyzhHKdkKkQ5kIUHAgceMlRG
+         zdnw==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=content-transfer-encoding:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:x-gm-message-state:from:to:cc;
+        bh=pmtODwdqQDwI78SnRc0bQ6YRA+jpVfC0v5H1ES+2g+Y=;
+        b=x15/LvWFuYkKS7DM5dC40+iWd2xWUmdul6GLtzQQ64SwR5y+1s997UT+VxOoI5IhZR
+         9nVvA2HlQY3JTzFJ9On+ZAetAKaQ349+P5WTylpYeTbOqTWzynmb5G6RsdGs4WatyRv9
+         7cnCLsxg6Z3d+u+XSFVHFOzO2I6/DWL/53GqQn4CRHmZCKD4HyrFzubG+gnk9PHBKHCb
+         DWuuV0gLWXR8zeYSPq6+xzQe9hHsuyA0uU8quxF4kMoPEcUmKlLuuhlzjNYCvUxniwKh
+         Zgg8NY8E8AMZwoI98wyvG1JsS2Fonegh31+/Z4nF9NAI5W1/RJRDJz33xrZAWpQpPWEu
+         68ww==
+X-Gm-Message-State: ACgBeo2u5YIpP/GUyFqsspH710RWRoQszzeAEhwmL/1miHLq/5ylHZ3a
+	Z6FsI84YxrikYZ0AMRgJcrEafRR4tbcSA9iWAW4=
+X-Google-Smtp-Source: AA6agR55v3ScfR6sHQZpMvXk04tC0JAWONPI9kBI1sjrkln3tpvTDWi88xzzp++aj/yPpzLo7UzQxvokrxd1U2oTJPA=
+X-Received: by 2002:a54:4899:0:b0:343:3f7c:713d with SMTP id
+ r25-20020a544899000000b003433f7c713dmr8372804oic.116.1661828849905; Mon, 29
+ Aug 2022 20:07:29 -0700 (PDT)
+MIME-Version: 1.0
+References: <CAMqOJriRYL5XfvJy883Tdk7XYMeZyLDbAeRWBW-XPimy=_gy4w@mail.gmail.com>
+In-Reply-To: <CAMqOJriRYL5XfvJy883Tdk7XYMeZyLDbAeRWBW-XPimy=_gy4w@mail.gmail.com>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Tue, 30 Aug 2022 06:07:18 +0300
+Message-ID: <CAFVMu-o9PQqhA0tN_8qC8OhEu5Rh4_W+djkHibRBKnJHtz_z3A@mail.gmail.com>
+Subject: Re: bazel-zig-cc + rust
+To: Kevin King <4kevinking@gmail.com>, ~motiejus/bazel-zig-cc@lists.sr.ht, 
+	Luis Holanda <luiscmholanda@gmail.com>
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 1154
+Lines: 32
+
+On Tue, Aug 30, 2022 at 5:48 AM Kevin King <4kevinking@gmail.com> wrote:
+>
+> Hi Motiejus,
+
+Hi Kevin!
+
+> Thank you for the awesome bazel integration! I wasn't sure how to reach o=
+ut so let me know if there's a better way.
+
+Use the mailing list. :)
+
+> I am working on a bazel+rust+wasm project and was looking to use zig to c=
+ross-compile a rust web server to linux/{arm,amd}. The only problem I ran i=
+nto with bazel-zig-cc was that the rust does not pass its env down to the l=
+inker process, and so the #!/usr/bin/env sh line fails. I was able to fix i=
+t by changing it to #!/bin/sh (and then everything worked perfectly!), but =
+I understand that things like nix put sh elsewhere.
+
+That was /usr/bin/bash originally, then /usr/bin/env bash, then I
+removed the bashisms and changed to /usr/bin/env sh. Louis, does NixOS
+suppot /bin/sh?
+
+Kevin, why does /usr/bin/env sh fail? What is the error message?
+That's quite curious, since that would imply /usr/bin/env does not
+exist, or sh is not in $PATH.
+
+> Can you think of any potential solutions that would work for both rust an=
+d nix?
+
+Let's try to find out.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oo1-f44.google.com (mail-oo1-f44.google.com [209.85.161.44])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 85F4B11EEFB
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 30 Aug 2022 06:20:53 +0000 (UTC)
+Received: by mail-oo1-f44.google.com with SMTP id w39-20020a4a97aa000000b0044dfa1ddc67so779282ooi.6
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 29 Aug 2022 23:20:53 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:from:to:cc;
+        bh=BZXDXnigXy9sHdrMQGkAVengDkQWZdmf25cJiZ7tIeY=;
+        b=xhTaPw16KtnH6Ft4mPIvcJScavzgcgMX350ASeYIjsyr3xFDlQQrHKMohW/WSbeiVf
+         ZbcysrNUfrc+htbRRahRXkXHuEq73p5fJj9bwfeAaLrYrPE1LgWQHIC9LF84CqzJkvUL
+         tiNJM2TBqniy+MhwkYwKrZ76VoIyuAoJbb89oq/GVYKigcBsAkPFwi04EfGKqzfQR73E
+         Rhvn/69dSQKosQZn0q1cT+Vgf2I081LcFnJogiRqaeI02Z2eu9Q0BEpVDjUYiJgdr4M7
+         CgSxce9lQ4ckNflVlZDqeTiLCcNBdNpGP0glKPCmdl5TuV2/VSlygewNYxnjdTAx6D6f
+         ryxQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:x-gm-message-state:from:to:cc;
+        bh=BZXDXnigXy9sHdrMQGkAVengDkQWZdmf25cJiZ7tIeY=;
+        b=cjnd28vIJl9TairMh30cl+ggllwEWXZ3wMq6FNZEmkYjXpdI0v/a5pc6ja29Mv5g0c
+         1+9UW1eGKd/uJWXwwKdhXzncw8u329nCZ3fyLcTERT/nr4NUHLXpOaF7BwPUToOXorRj
+         K+buedzuX4gY2wVC4TyQQNkkKja0fNdieu5LrmtV6ApvejEOuE0Fmn3MQ493yhfMXS85
+         Ly4HASOynKFUg98L5xcT49wr6ytfCvYOdvTZjpMXo9zngIAXBrn7yK82MD6WOrudP/3L
+         YTsMFWm8sAyW4u85h4t5w8KJzrbPVFJwi8ee/7s9AGhIp8hHJLi68aeVsi5ZsByluHQo
+         GYRg==
+X-Gm-Message-State: ACgBeo0hJqcejYcQtsR0BhiLpohohqheud38RfRJd4IZxp2F/8t7nbbK
+	Xtqxi8mCAhC8RPBiKNP7i4XjZ6b8SALIy4H6ing=
+X-Google-Smtp-Source: AA6agR66jEAcTuGpCWkbdeKQkqv8tMlrFGuWNZUOaA+lKorOiWWURc3c/TeuHMyCj+je2MsT5gEKHd19vK2KgTMc8E8=
+X-Received: by 2002:a4a:ba95:0:b0:44b:499f:793d with SMTP id
+ d21-20020a4aba95000000b0044b499f793dmr6681165oop.68.1661840452852; Mon, 29
+ Aug 2022 23:20:52 -0700 (PDT)
+MIME-Version: 1.0
+References: <CAMqOJriRYL5XfvJy883Tdk7XYMeZyLDbAeRWBW-XPimy=_gy4w@mail.gmail.com>
+ <CAFVMu-o9PQqhA0tN_8qC8OhEu5Rh4_W+djkHibRBKnJHtz_z3A@mail.gmail.com> <CAMqOJrgjjF8rWZpca3YRrUM-j_wR_U-mmuZACN35wsvO6-hJKQ@mail.gmail.com>
+In-Reply-To: <CAMqOJrgjjF8rWZpca3YRrUM-j_wR_U-mmuZACN35wsvO6-hJKQ@mail.gmail.com>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Tue, 30 Aug 2022 09:20:41 +0300
+Message-ID: <CAFVMu-pvNx+peQYdge_fvmSGrHDmn78VmoYwTxkDgMjbzfVAwQ@mail.gmail.com>
+Subject: Re: bazel-zig-cc + rust
+To: Kevin King <4kevinking@gmail.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht, Luis Holanda <luiscmholanda@gmail.com>
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 826
+Lines: 18
+
+On Tue, Aug 30, 2022 at 6:58 AM Kevin King <4kevinking@gmail.com> wrote:
+>
+> The error I get is
+>
+> linking with `/private/var/tmp/_bazel_kevin/c782d9784982eee1866a2e1ae5f6f353/external/zig_sdk/tools/c++` failed: exit status: 127
+> [...]
+>  = note: env: sh: No such file or directory
+>
+> This appears to mean /usr/bin/env is executed correctly, but env itself can't find sh. Linking succeeds when I change the zig wrapper to use /bin/sh directly, leading me to believe rust does not pass PATH down to the linker.
+
+I asked in #zig:libera.chat, and Andrew pointed out that `/bin/sh` and
+`/usr/bin/env` are the only two files in `/bin` and `/usr/bin`
+respectively. So `#!/bin/sh` will work both NixOS and in your case,
+since it's an absolute path.
+
+I will make the change in bazel-zig-cc later today.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-ed1-f52.google.com (mail-ed1-f52.google.com [209.85.208.52])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 5855911EEFB
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 30 Aug 2022 06:22:49 +0000 (UTC)
+Received: by mail-ed1-f52.google.com with SMTP id z8so4025765edb.6
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 29 Aug 2022 23:22:49 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:from:to:cc;
+        bh=XooOH/gLGyV2e5XWgAs3frYuHQQeJNtnNXdT/SGMF9I=;
+        b=PPtO8/Sv5VZ8lhD8JW0GxmymEkrSfq1DuFPoCJgLQbfeoEKMfCfStcEz9EP8WZwN1+
+         OUZc2jHFhal9sE3eFMbFgbnh9tPIEXx63wqxFj5lcjp3JJKnCnFNFdziC2kVBvnxhgBC
+         WZLMkmB3ptUXilrvJWh3vff0lxrfaqiqr8koLUjCsivhBtZ3Qc6mlmlW2ELZpasm6utH
+         Yo/Op0tVH+hqXPjbouWBUEzUAmrQ+xj4fpy8WJTWyRq/OmUqOiPZwsdFr1plz3CcbKZ8
+         7oC2TbCs35m/brTZvvgbtOJxblbZ3SVCQAciRD0T0Mza7YSVJX+QD27m2NWazBvwdSHh
+         tSow==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:x-gm-message-state:from:to:cc;
+        bh=XooOH/gLGyV2e5XWgAs3frYuHQQeJNtnNXdT/SGMF9I=;
+        b=1cabWsKYFnHBcd1GTOz1sX8Wuk0sLPSwo1FyakSWglcakiicUKuyWeahm3e8u793BM
+         JeukRVPx6mvqxdM78i6Hmd3cuUD3YzTeA11fG/gNMT6lczTmEIGP94g2e9rL+gUfs+GO
+         cUEMS1f+N0ISpBm3CEuCrMJOT2aGN6UNTzeevgJFje+D4ISsDstQDD8HCxnkWGGeToDS
+         ahtiBpqtYdHi74b86/gkXBqABMnueLc/2kCc3PWhMO/2BTUx6pgkg9nEZ1dCvQlIfBFj
+         OF2ij1jvIYFWbXo3s5LJLQbZhOKEFmdpdS8/4EqUbQY2p8ni8ZFjKB/iuAai1NIfFAPY
+         jD9w==
+X-Gm-Message-State: ACgBeo1VRhSCKOAXqt7EgfvqnHVuvgEsDdMguwWv+mRNNq6Nt078f/B4
+	PNzG/DpaLGd8Paz8o8v8dwbesLvdoQV62BPrG/Q=
+X-Google-Smtp-Source: AA6agR6wgcjfMAclWe0wsDiBMKAo/xahWxNhKjmGBDD2p84jEgeKgSxwrbIfa1Q1ApMs04aL8satXp0rDwJL4yeveQk=
+X-Received: by 2002:a05:6402:1694:b0:447:fa04:367b with SMTP id
+ a20-20020a056402169400b00447fa04367bmr13825978edv.138.1661840568280; Mon, 29
+ Aug 2022 23:22:48 -0700 (PDT)
+MIME-Version: 1.0
+References: <CAMqOJriRYL5XfvJy883Tdk7XYMeZyLDbAeRWBW-XPimy=_gy4w@mail.gmail.com>
+ <CAFVMu-o9PQqhA0tN_8qC8OhEu5Rh4_W+djkHibRBKnJHtz_z3A@mail.gmail.com>
+ <CAMqOJrgjjF8rWZpca3YRrUM-j_wR_U-mmuZACN35wsvO6-hJKQ@mail.gmail.com> <CAFVMu-pvNx+peQYdge_fvmSGrHDmn78VmoYwTxkDgMjbzfVAwQ@mail.gmail.com>
+In-Reply-To: <CAFVMu-pvNx+peQYdge_fvmSGrHDmn78VmoYwTxkDgMjbzfVAwQ@mail.gmail.com>
+From: Kevin King <4kevinking@gmail.com>
+Date: Mon, 29 Aug 2022 23:22:37 -0700
+Message-ID: <CAMqOJrgjV8LLmJ8uLZNGN9NXhsSKhHR=b1_CsW_DRG9fGoOrdg@mail.gmail.com>
+Subject: Re: bazel-zig-cc + rust
+To: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht, Luis Holanda <luiscmholanda@gmail.com>
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 48
+Lines: 1
+
+Oh perfect! I'm glad there was a simple fix :)
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=avilabs-is.20210112.gappssmtp.com header.i=@avilabs-is.20210112.gappssmtp.com
+Received: from mail-lf1-f48.google.com (mail-lf1-f48.google.com [209.85.167.48])
+	by mail-b.sr.ht (Postfix) with ESMTPS id B2FDD11EF2F
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri,  9 Sep 2022 19:52:51 +0000 (UTC)
+Received: by mail-lf1-f48.google.com with SMTP id z25so4511554lfr.2
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 09 Sep 2022 12:52:51 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=avilabs-is.20210112.gappssmtp.com; s=20210112;
+        h=to:subject:message-id:date:from:mime-version:from:to:cc:subject
+         :date;
+        bh=k6q6Je/61wR2hy7UvCPDU+RUtdEWbu+6TDxSehTKHFM=;
+        b=J5Nc4Aw5EMDQuUVgC4b4MoOFeUxIMs91RjL7RqJQMJ0qIMzIs4v5+N41DW+oL0R99m
+         RcruqkrYSsuowwfxha0Hc4b255hLuTajksEpaw/6uUvBSFC5maZtQXKNm0h7pj2lnwiZ
+         6VSCo9EoHm64qgmZotg2RFNJO7FwRFwUWCEY2yNPnxHdeB1sWg+c7D/pDlaAntaVvzga
+         18ExK7p/hwf85L5RpWyQF5z2r+bLjEVYChYBbzvJDLAOSKs993JEdTYompxDi07SlH2D
+         hMxIK0PWa0rUM6VrDaGd14b91QyYKCdzbSovOJuU9woskctVb5Y4G/1iS8MaxxUvRcw3
+         1oMQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=to:subject:message-id:date:from:mime-version:x-gm-message-state
+         :from:to:cc:subject:date;
+        bh=k6q6Je/61wR2hy7UvCPDU+RUtdEWbu+6TDxSehTKHFM=;
+        b=US6aSzUU93bjMXRyKb2wPjah2ZBb+UfohNSYOiMFggxKsgZngijKgc2seJAkcvml4e
+         tmohhAjskpEE/1NGh6d/pFPACc9P1Qr/u5mE4bP+EElq3mpAT29SL/lcag2FHX62V8Ne
+         gWwDmTThv8/KMzqVVi+dw2eBP0ZlLSEu6jIy68gNv6h1DF+/PvaFz3TSWyOYLMhDKN9D
+         bawlpiiqpL0uM6v6zGf5efym4v3WVVi4P9tGsmQsQHQX/k5rqytu0ezAf/QAdJvHcyqO
+         o8mcPymzacVQRcn/a2N3s1fv4Sfqi6bUD/uN/eUnBDjBZ9mJTMsCvkxOlv4GVaeiGiCT
+         8zkA==
+X-Gm-Message-State: ACgBeo343XM4YwO9XVCrLC2otZsHPesSRbOwEi56GVcw+Jk8PFLNCZpd
+	qqKM7XElrphyTSVOTqimm6f4gTiS/ck/Va78RrUCYtay/gokkNYw
+X-Google-Smtp-Source: AA6agR5pF4K8tov2jp1OBxXHJR9+Yl00UbYc/kjXbNunQkTsYqxNFsMBOWTKqpZ8xwSRhbDwXPgCEQ/c/y3/hP3fUYI=
+X-Received: by 2002:a05:6512:e99:b0:492:cf19:875 with SMTP id
+ bi25-20020a0565120e9900b00492cf190875mr5124812lfb.690.1662753169952; Fri, 09
+ Sep 2022 12:52:49 -0700 (PDT)
+MIME-Version: 1.0
+From: =?UTF-8?B?RGFuw61lbCBQdXJraMO6cw==?= <danielp@avilabs.is>
+Date: Fri, 9 Sep 2022 19:52:39 +0000
+Message-ID: <CAOY-u7ZbrLf8fiwS=BQLN8D4V_qUVpJGNfThcKYaND8gA2n3Dw@mail.gmail.com>
+Subject: Using with rules_rust
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 740
+Lines: 15
+
+I've been trying to build our Rust code with these rules as the C/C++
+toolchain but I'm encountering an issue.
+When I try to build an project that depends on
+https://crates.io/crates/async-trait I get the following error:
+
+/workspace/bazel_output_base/execroot/monorepo/bazel-out/k8-opt-exec-2B5CBBC6/bin/external/cargo__async-stream-impl-0.3.3/libasync_stream_impl-1922333755.so:
+cannot allocate memory in static TLS block
+
+There is a similar issue posted here when using cargo-zig:
+
+https://github.com/messense/cargo-zigbuild/issues/4
+
+I'm having a hard time figuring out if it's possible to fix this using
+rules_rust and these rules. I was wondering if
+anybody in this mailing list had found a way to get past this issue?
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f50.google.com (mail-oa1-f50.google.com [209.85.160.50])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 3006F11EEC6
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat, 10 Sep 2022 04:52:37 +0000 (UTC)
+Received: by mail-oa1-f50.google.com with SMTP id 586e51a60fabf-127dca21a7dso9126500fac.12
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 09 Sep 2022 21:52:37 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=content-transfer-encoding:cc:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:from:to:cc:subject:date;
+        bh=9HFx1iNsEtN1WgL1Rmqux1snsjnyIzqx9MPUZhjlwp0=;
+        b=CzluCGkxLbwtAgeeM9V1YZ8vWMoe5g1w5F7T8hTQvpRBkeGZNJrVdJagkyYQXWoS3c
+         R1wEAxNP8RtPK6WYRHWpbx8mIo18ZMsIwSoveWnjcn+7TVxfl+cK/kcp+pXDZquFQrPT
+         CaHfS+p+xAAgmkgp8W1deJURMvg+wOa2Eg+4DvHvgxyjFayf3VwaZnML9iywJYTia1w9
+         qlKEflhGr4jwxFwtldQyCLiCIeiu26JhO/gmXdHfGnt/d3GifW+Pp5Kso1fO496vTvLr
+         ashhFgYchRNMcnTCk45v83Jl/GMaZ5q+jJHGqmz3zLD+iSJZxX8QJ5TNvmL/pR4OA6yE
+         gaEQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=content-transfer-encoding:cc:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:x-gm-message-state:from:to:cc
+         :subject:date;
+        bh=9HFx1iNsEtN1WgL1Rmqux1snsjnyIzqx9MPUZhjlwp0=;
+        b=CkyfJCTcQ9d5xTRBwuTqRYW+rQnAYzkECVyrMohECW2Ej8NacS75srZLef0Kb1qOpo
+         h+QQ2/+TT16/o3ZjxXGoUZ842ZsWGdksSuD1aLevx+rQkUNKVRCKIYWbU8TAz7ZFIsKn
+         yRj9gpsEPgrLw/GDcCKR+v+NyBYPNVfPmcpLQLndaf82FGsmbPabM24WXr6hiY04XREx
+         Kq5tb9/kROo+9PHgNaTbkikzmW4+yf9eyydxWKSg2usy8/F9jS6wunShuuB0Px7TJWI+
+         6IwI/br59WDHLFyT1smskDMUm6lP2gdNgxOz7O7Ux/Ndq9n14lFpe1XLQkvc1y/VRdMS
+         PX0w==
+X-Gm-Message-State: ACgBeo2KTT0mYnqV0e5xVgbgavQ3DNqAL/kAN11bzig399bsMsj5ZMjV
+	oiBIpxcupJ+ZXbtBWQ6AYngIBUJoQzvcrCu9ziyXOzEUYgU=
+X-Google-Smtp-Source: AA6agR4Xpn2N0vw+iHwycUodkZWakZqTWEzZkR6l1unqTYnAxZVxJWvDFyujPDQG2RgrmmJrQvYOMApDhDBswY6NwOE=
+X-Received: by 2002:a54:4899:0:b0:343:3f7c:713d with SMTP id
+ r25-20020a544899000000b003433f7c713dmr5001244oic.116.1662785556272; Fri, 09
+ Sep 2022 21:52:36 -0700 (PDT)
+MIME-Version: 1.0
+References: <CAOY-u7ZbrLf8fiwS=BQLN8D4V_qUVpJGNfThcKYaND8gA2n3Dw@mail.gmail.com>
+In-Reply-To: <CAOY-u7ZbrLf8fiwS=BQLN8D4V_qUVpJGNfThcKYaND8gA2n3Dw@mail.gmail.com>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Sat, 10 Sep 2022 07:52:25 +0300
+Message-ID: <CAFVMu-qx2RSRKRBM86BVukecjBE-K1KL5ooSRtLW7uGxzAMe1w@mail.gmail.com>
+Subject: Re: Using with rules_rust
+To: =?UTF-8?B?RGFuw61lbCBQdXJraMO6cw==?= <danielp@avilabs.is>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 1507
+Lines: 36
+
+On Fri, Sep 9, 2022 at 10:52 PM Dan=C3=ADel Purkh=C3=BAs <danielp@avilabs.i=
+s> wrote:
+>
+> I've been trying to build our Rust code with these rules as the C/C++
+> toolchain but I'm encountering an issue.
+> When I try to build an project that depends on
+> https://crates.io/crates/async-trait I get the following error:
+>
+> /workspace/bazel_output_base/execroot/monorepo/bazel-out/k8-opt-exec-2B5C=
+BBC6/bin/external/cargo__async-stream-impl-0.3.3/libasync_stream_impl-19223=
+33755.so:
+> cannot allocate memory in static TLS block
+>
+> There is a similar issue posted here when using cargo-zig:
+>
+> https://github.com/messense/cargo-zigbuild/issues/4
+>
+> I'm having a hard time figuring out if it's possible to fix this using
+> rules_rust and these rules. I was wondering if
+> anybody in this mailing list had found a way to get past this issue?
+
+Hi Dan=C3=ADel,
+
+Both cargo-zigbuild and bazel-zig-cc are thin wrappers on top of zig
+cc, so the underlying mechanism (zig cc) is the one to look out for.
+
+The best course of action would be to make a minimal example (e.g. a
+single test.rs) and peel off the build layers (bazel-zig-cc or
+cargo-zigbuild; whichever is easier) and file an issue in ziglang/zig.
+If you have a minimal rust example that exposes this problem, "rustc"
+and "zig cc" commands to reproduce it (no cargo or bazel), that will
+go a long way for whoever is interested in picking this up to
+understand what happened and fix this.
+
+Hope that helps,
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f47.google.com (mail-oa1-f47.google.com [209.85.160.47])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 3EFB511EF19
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 12 Sep 2022 10:53:05 +0000 (UTC)
+Received: by mail-oa1-f47.google.com with SMTP id 586e51a60fabf-11eab59db71so22216913fac.11
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 12 Sep 2022 03:53:05 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=to:subject:message-id:date:from:mime-version:from:to:cc:subject
+         :date;
+        bh=y7WyWF2RZq+b4qTej7JMdDJ7rSe1MtThqFCbkZDFbIc=;
+        b=iXA8gyCcbj7tRy8rKJtcgvrUoV2fVm9ly2XmKeMOfzR0haPxSF2pIXQjn+aM42RKo/
+         PKZfby9a3PS0Df6BttZdGccbU4Kln6WKNVvWnLfTjc/co4K+aSz1sWxcaxGCJTa8+pR0
+         IbM65+87CHjlYuAOxd6IeYLAIJ5SEIkmeALofCSpApcueC5/FK7U8Qjof8jyaa9PXNze
+         2K4GaXTeoYVu1R9l1xHEa6wP5JiAiMbmsiMsQpTBuQw6EOPwCW1SOURRvikEQw0e86a/
+         7ZN5nq4r/aLRvjIxeRiZ1wvzBQWW7W5kfirl9nmIvqU/3vZA/la6I1DwptAgar6NyhEz
+         epFw==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=to:subject:message-id:date:from:mime-version:x-gm-message-state
+         :from:to:cc:subject:date;
+        bh=y7WyWF2RZq+b4qTej7JMdDJ7rSe1MtThqFCbkZDFbIc=;
+        b=mNACTqZ44vMFX5n7RhI31sJDBug9jXT7WG80GHwawWZBzI/o7470wPfQcDNsdvdy5g
+         kFkIpe3bTo0evJ59ablMR1QYxsUD80Gr5OgDvpAAbiLbt31YXcgwY8nT8RK2vz16Hwpf
+         QWfozM+crFV4/mvn2j0FpOEwm4uSiPk1rPcmMYCHjlNC/wxzZ0ibKLTl08//8fN5WQwv
+         YhPJ91TelNnhtd9BV+GbcliyUkronpFrNI/utEqE68B8E2iD6mnkfPb3lc1B7ct0sZFo
+         9ZBCTD3Ns++KkP5OBz7EJ8s+tuOM2phBfic6UY6azNsVbcVHScEAvc6L1evZMDQtqwtv
+         TJXw==
+X-Gm-Message-State: ACgBeo3q+klR5NGQgrnqa8cx5RaUQ1WxTtKSZPMOeyzlc/Stk5r42mrY
+	BBTFH3xwWd+R+TYZT1JWsg8h4vIMlfuptpyjXct0eG08Cbw=
+X-Google-Smtp-Source: AA6agR45Jfu+x6EJ9u8wdc1QO+Kx1hzxyFC9/kxmvj+JJjfX4M5ZyJod16rHp73TKgB3tX4+I9d6rSLLmdVO6wowoNo=
+X-Received: by 2002:a05:6870:b14f:b0:127:d4f1:6a90 with SMTP id
+ a15-20020a056870b14f00b00127d4f16a90mr11274750oal.116.1662979984463; Mon, 12
+ Sep 2022 03:53:04 -0700 (PDT)
+MIME-Version: 1.0
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Mon, 12 Sep 2022 13:52:53 +0300
+Message-ID: <CAFVMu-qPoYBqA0UJofqmkeJ-D0ZU4P-rH8Rh8L78zhLRyJdNnQ@mail.gmail.com>
+Subject: bazel-zig-cc v0.9.2
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 331
+Lines: 11
+
+Hi all,
+
+v0.9.2 brings in some changes w.r.t. BAZEL_ZIG_CC_CACHE_PREFIX:
+- make it work on Windows: thanks Fabian Hahn.
+- make repository_rule depend on it, so artifacts that depend on it
+get invalidated. Thanks Laurynai.
+
+And makes bazel-zig-cc work on NixOS. For that I thank Luis Holanda
+and Andrew Kelley.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f51.google.com (mail-oa1-f51.google.com [209.85.160.51])
+	by mail-b.sr.ht (Postfix) with ESMTPS id EB5F911EF19
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 12 Sep 2022 10:56:50 +0000 (UTC)
+Received: by mail-oa1-f51.google.com with SMTP id 586e51a60fabf-11e9a7135easo22275719fac.6
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 12 Sep 2022 03:56:50 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=content-transfer-encoding:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:from:to:cc:subject:date;
+        bh=uMuUfBSSCorRcC5QjiCJo6Ia2ic2flgrpVRvIq8kKjc=;
+        b=VB+1hU0yZNXqxISFUf8zgbD6+lm0/Ti8ASDyS7ZzhYwIpQQBDZmjfGddt9wGx7jmyv
+         qFKkIJ/rst66/WBqNFdtaky1FevV6iNHmJ6vrI6u1H/HhIdk0mY5UmZsu57kQ3qFkCzh
+         Ke22B/iFc1W/JRntivIUq7og91pKuz/ZplPfzfXwIi6i3P52uG39ToxE7W4cXUMtZUqQ
+         HlJBsu3+sE2uBkC9OxV2JhJ/stqzw7jgoHOxFbxqzlhwMlwSSbGMPXLS0SfdZ2/hqqzS
+         NEpoRYBOL2Gy+W6j3zmBFTKmroIDHkZVRcDFybFt2EXHxaq+F133m+ZJ/AZc1p32ILMN
+         TaGA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=content-transfer-encoding:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:x-gm-message-state:from:to:cc
+         :subject:date;
+        bh=uMuUfBSSCorRcC5QjiCJo6Ia2ic2flgrpVRvIq8kKjc=;
+        b=p6Q1ti2pL4HiJM8h4sstjk80S0V3DWOIn2RF+xkfVIxVWcPl0aNXpm4lXxo+HAAP3x
+         bn06E8iUWc7YylyzVeEaf3WLtG4FB8nkIuEluKO863wrVSvDhD40/VD8bn5Nrf247Pgt
+         NCG2+SGY8MjQUL6W7T6A4Qo2AqgH1s/3rZlSNZQRvemsRkbYBprUkKisyfq7NCFaQ1Qe
+         p491MJEKSi/hP8qQ++UF+PPaJpCGP/EvCmnz1NULALCK0stqoFHtUW9slphVdinwjlve
+         AqNXAkaMWY9JKU+OflFCbaR69bdPP7Pej0qVCkVSL2MKK31TvMXKBfyJULPlthGIfM+L
+         d0DA==
+X-Gm-Message-State: ACgBeo2WfhCGxmr6U/POuvGcGsAQCh2M+CrX4CSJsbuuboYXYM30N1zn
+	Uzp1Yp3Mngmy1oB+MeFd0dn60Cbu1rhsmf9Mi73vDPzd9Xs=
+X-Google-Smtp-Source: AA6agR6Jbh4Va0PTc0LMi/JpiV6/lYECI44Yce3tWI+dilrKD/LWRYxDENjswmwBU9pC6Y/CzppyzHAFrDk/GJ2ILYM=
+X-Received: by 2002:a05:6870:b14f:b0:127:d4f1:6a90 with SMTP id
+ a15-20020a056870b14f00b00127d4f16a90mr11280348oal.116.1662980210247; Mon, 12
+ Sep 2022 03:56:50 -0700 (PDT)
+MIME-Version: 1.0
+References: <CAFVMu-qPoYBqA0UJofqmkeJ-D0ZU4P-rH8Rh8L78zhLRyJdNnQ@mail.gmail.com>
+In-Reply-To: <CAFVMu-qPoYBqA0UJofqmkeJ-D0ZU4P-rH8Rh8L78zhLRyJdNnQ@mail.gmail.com>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Mon, 12 Sep 2022 13:56:39 +0300
+Message-ID: <CAFVMu-p0GguWV_7g_DFHgTC27PgUSp7ayxtPda4LSLnY_3VU8Q@mail.gmail.com>
+Subject: Re: bazel-zig-cc v0.9.2
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 508
+Lines: 14
+
+On Mon, Sep 12, 2022 at 1:52 PM Motiejus Jak=C5=A1tys <motiejus@jakstys.lt>=
+ wrote:
+>
+> Hi all,
+>
+> v0.9.2 brings in <...>
+
+One thing I forgot: if you used musl, bazel-zig-cc used to add "-s -w"
+to LDFLAGS. That was wrong, added by me a while ago[1]. This is what
+happens when I don't get code reviews. Well, it's fixed now: the musl
+binaries produced by bazel-zig-cc will no longer be stripped.
+
+[1]: https://git.sr.ht/~motiejus/bazel-zig-cc/commit/58a04fbfec10d98ac5cd8e=
+e44df441146085b780
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 9504811EF24;
+	Thu, 15 Sep 2022 14:40:41 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Thu, 15 Sep 2022 14:40:41 +0000
+Subject: [PATCH bazel-zig-cc 0/1] Fix include root path for macos-aarch64
+MIME-Version: 1.0
+Message-ID: <166325284132.32481.3819031653685599117-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <git@kmicklas.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: kmicklas@uber.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+Status: O
+Content-Length: 254
+Lines: 11
+
+Despite the odd inconsistency between OS/arch, the others appear correct
+from a latest nightly.
+
+Ken Micklas (1):
+  Fix include root path for macos-aarch64
+
+ toolchain/defs.bzl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+-- 
+2.34.4
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id B11A311F88A;
+	Thu, 15 Sep 2022 14:40:41 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Thu, 15 Sep 2022 15:37:35 +0100
+Subject: [PATCH bazel-zig-cc 1/1] Fix include root path for macos-aarch64
+Message-ID: <166325284132.32481.3819031653685599117-1@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <git@kmicklas.com>
+In-Reply-To: <166325284132.32481.3819031653685599117-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: kmicklas@uber.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+MIME-Version: 1.0
+Status: O
+Content-Length: 608
+Lines: 21
+
+From: Ken Micklas <kmicklas@uber.com>
+
+---
+ toolchain/defs.bzl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 71214f6..f72412d 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -70,7 +70,7 @@ def toolchains(
+         host_platform_include_root = {
+             "linux-aarch64": "lib/zig/",
+             "linux-x86_64": "lib/",
+-            "macos-aarch64": "lib/zig/",
++            "macos-aarch64": "lib/",
+             "macos-x86_64": "lib/zig/",
+             "windows-x86_64": "lib/",
+         },
+-- 
+2.34.4
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=DlXGYPf+otWnejEClYXaLB1lSlI9vZSkseK4QiVLjAc=;
+ c=simple/simple; d=sr.ht; h=Date:From:In-Reply-To:Subject:To:Cc;
+ q=dns/txt; s=srht; t=1663253908; v=1;
+ b=K8cl/QZ97rhbTIO0JBn7X2bSeGAoSI7gfKUMBf7ufvfeEWPNxm8sAGkNABF2vA124Wk2lJHr
+ eBSNmFz/VElj1t25dGJEsayWT93HkToqMQteeUip1bEE0iOSlCZYrOBnwkEm50XtyCBZFiIlEbO
+ oZYpdgZ2lRGF6vpZhGnlBSKeSqm5kCaWXmIoRMH5l8lQLeoKb4PQTRCOGNI+Jybme8r6d/26OuO
+ QSKRvF8g8L93upEzaElPBmQDfItO8Of+30qpeIUEnGPq06Y/cXjMvYinluo6otDFTuztc49S7Kc
+ D7CQAdLJfoDPqBGrq6ovD3Jk8rsST5D4OKPa+pcuXGsCw==
+Received: from localhost (unknown [173.195.146.249])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id 0F9C111EF24;
+	Thu, 15 Sep 2022 14:58:28 +0000 (UTC)
+MIME-Version: 1.0
+Date: Thu, 15 Sep 2022 14:58:28 +0000
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CMX2AWW0QUR0.37NS5VEH6XEFC@cirno>
+In-Reply-To: <166325284132.32481.3819031653685599117-1@git.sr.ht>
+Subject: [bazel-zig-cc/patches/.build.yml] build success
+To: "~kmicklas" <git@kmicklas.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 321
+Lines: 9
+
+bazel-zig-cc/patches/.build.yml: SUCCESS in 17m45s
+
+[Fix include root path for macos-aarch64][0] from [~kmicklas][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/35334
+[1]: mailto:git@kmicklas.com
+
+=E2=9C=93 #845320 SUCCESS bazel-zig-cc/patches/.build.yml https://builds.sr=
+.ht/~motiejus/job/845320
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id C0EC011EEDB;
+	Thu, 15 Sep 2022 18:30:04 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Thu, 15 Sep 2022 18:30:04 +0000
+Subject: [PATCH bazel-zig-cc 0/1] Move Label dependencies above archive
+ fetching to reduce restarts
+MIME-Version: 1.0
+Message-ID: <166326660455.1440.4931108525708331193-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <git@kmicklas.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: kmicklas@uber.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+Status: O
+Content-Length: 579
+Lines: 14
+
+Before this, when running the repository rule, you might notice the
+Bazel output say it was extracting the SDK archive ~7 times. Each time a
+label dependency is used, it would restart the whole rule with the new
+dependency. Now, the restarts technically still happen, but are not
+noticeable since they occur before doing any substantial work.
+
+Ken Micklas (1):
+  Move Label dependencies above archive fetching to reduce restarts
+
+ toolchain/defs.bzl | 53 +++++++++++++++++++++++++---------------------
+ 1 file changed, 29 insertions(+), 24 deletions(-)
+
+-- 
+2.34.4
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id DE95911EF24;
+	Thu, 15 Sep 2022 18:30:04 +0000 (UTC)
+From: ~kmicklas <kmicklas@git.sr.ht>
+Date: Thu, 15 Sep 2022 19:20:21 +0100
+Subject: [PATCH bazel-zig-cc 1/1] Move Label dependencies above archive
+ fetching to reduce restarts
+Message-ID: <166326660455.1440.4931108525708331193-1@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~kmicklas <git@kmicklas.com>
+In-Reply-To: <166326660455.1440.4931108525708331193-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: kmicklas@uber.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 3069
+Lines: 83
+
+From: Ken Micklas <kmicklas@uber.com>
+
+---
+ toolchain/defs.bzl | 53 +++++++++++++++++++++++++---------------------
+ 1 file changed, 29 insertions(+), 24 deletions(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 71214f6..ceddb70 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -170,6 +170,35 @@ def _zig_repository_impl(repository_ctx):
+         "host_platform": host_platform,
+     }
+=20
++    # Fetch Label dependencies before doing download/extract.
++    # The Bazel docs are not very clear about this behavior but see:
++    # https://bazel.build/extending/repo#when_is_the_implementation_function=
+_executed
++    # and a related rules_go PR:
++    # https://github.com/bazelbuild/bazel-gazelle/pull/1206
++    for dest, src in {
++        "platform/BUILD": "//toolchain/platform:BUILD",
++        "toolchain/BUILD": "//toolchain/toolchain:BUILD",
++        "libc/BUILD": "//toolchain/libc:BUILD",
++        "libc_aware/platform/BUILD": "//toolchain/libc_aware/platform:BUILD",
++        "libc_aware/toolchain/BUILD": "//toolchain/libc_aware/toolchain:BUIL=
+D",
++    }.items():
++        repository_ctx.symlink(Label(src), dest)
++
++    for dest, src in {
++        "BUILD": "//toolchain:BUILD.sdk.bazel",
++        "private/BUILD": "//toolchain/private:BUILD.sdk.bazel",
++    }.items():
++        repository_ctx.template(
++            dest,
++            Label(src),
++            executable =3D False,
++            substitutions =3D {
++                "{absolute_path}": _quote(str(repository_ctx.path(""))),
++                "{os}": _quote(os),
++                "{zig_include_root}": _quote(zig_include_root),
++            },
++        )
++
+     urls =3D [uf.format(**format_vars) for uf in repository_ctx.attr.url_for=
+mats]
+     repository_ctx.download_and_extract(
+         auth =3D use_netrc(read_user_netrc(repository_ctx), urls, {}),
+@@ -200,30 +229,6 @@ def _zig_repository_impl(repository_ctx):
+         content =3D _fcntl_h,
+     )
+=20
+-    for dest, src in {
+-        "platform/BUILD": "//toolchain/platform:BUILD",
+-        "toolchain/BUILD": "//toolchain/toolchain:BUILD",
+-        "libc/BUILD": "//toolchain/libc:BUILD",
+-        "libc_aware/platform/BUILD": "//toolchain/libc_aware/platform:BUILD",
+-        "libc_aware/toolchain/BUILD": "//toolchain/libc_aware/toolchain:BUIL=
+D",
+-    }.items():
+-        repository_ctx.symlink(Label(src), dest)
+-
+-    for dest, src in {
+-        "BUILD": "//toolchain:BUILD.sdk.bazel",
+-        "private/BUILD": "//toolchain/private:BUILD.sdk.bazel",
+-    }.items():
+-        repository_ctx.template(
+-            dest,
+-            Label(src),
+-            executable =3D False,
+-            substitutions =3D {
+-                "{absolute_path}": _quote(str(repository_ctx.path(""))),
+-                "{os}": _quote(os),
+-                "{zig_include_root}": _quote(zig_include_root),
+-            },
+-        )
+-
+ zig_repository =3D repository_rule(
+     attrs =3D {
+         "version": attr.string(),
+--=20
+2.34.4
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=ByBs1FjHk1lGGcjd5gBmc72N92u3A0Qyh2mWYaae3Oc=;
+ c=simple/simple; d=sr.ht; h=Date:From:In-Reply-To:Subject:To:Cc;
+ q=dns/txt; s=srht; t=1663267619; v=1;
+ b=IL5AcdNK5WhcdRq495tuR+383OSpYDpc5gkuZ36a3pT0xdKmmKPGlevKY5pFcsxv8JK8gG/3
+ ZcgEEgdxOQSoZJD2CuTaBiHkIuKRmwNgFjiTyjgJWREMdtG158ncPcxZScJz9y06GttomneFdJt
+ Nsn3I4UKULj0n3ZhJiFyN+p9TPMkKUNgoglu9v5QtO77putQ3b/oi/osUUXPJcjiQProXKwT0Ag
+ SZgDiV5KYitEGx5qTv2V/XFxfF1nR4faZ1UHFXDlbmXEYnjljWpbNKWBT8TDpG/r0pO7bnKJJEz
+ SK/uafrDdYNEpPasImE1yNElrYSFy1F7MwjZq1BRBnpkQ==
+Received: from localhost (unknown [173.195.146.249])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id 4920011EEDB;
+	Thu, 15 Sep 2022 18:46:59 +0000 (UTC)
+MIME-Version: 1.0
+Date: Thu, 15 Sep 2022 18:46:59 +0000
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CMX75VTDNA40.2UGZNNDOW0UVW@cirno>
+In-Reply-To: <166326660455.1440.4931108525708331193-1@git.sr.ht>
+Subject: [bazel-zig-cc/patches/.build.yml] build success
+To: "~kmicklas" <git@kmicklas.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 350
+Lines: 10
+
+bazel-zig-cc/patches/.build.yml: SUCCESS in 16m52s
+
+[Move Label dependencies above archive fetching to reduce restarts][0] from=
+ [~kmicklas][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/35345
+[1]: mailto:git@kmicklas.com
+
+=E2=9C=93 #845473 SUCCESS bazel-zig-cc/patches/.build.yml https://builds.sr=
+.ht/~motiejus/job/845473
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oo1-f43.google.com (mail-oo1-f43.google.com [209.85.161.43])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 7666B11EEDB
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 15 Sep 2022 19:20:39 +0000 (UTC)
+Received: by mail-oo1-f43.google.com with SMTP id l40-20020a4a94eb000000b00472717928b5so3152400ooi.1
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 15 Sep 2022 12:20:39 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:from:to:cc:subject:date;
+        bh=cIrQy9EdHerBVaY7Dvc4XNQfhltLnbs0FHVFNRu23eM=;
+        b=1T1nysZ869dF1ANT3HcsxAOYKtoyROr7N1psifQ9SlLPA+cSvJz+ifbf56qdOZQ1yc
+         Km/R4eMYlifGrMDd76VikiiRbuIG30LNURWXS8L3EH8+U+A1Ob9M5cLlmvlJzNz33RxT
+         jU3yKRhpVMQF0LlCWlZRPxvNl3f5IT2dkC3mSPOAYzKv+BNa5/lNBVG1zn00h6kh0RdV
+         7H6bR6X4UUIN5Kg9TbVGpejRCk9MXMEhfs6xuX/ex+xcESCXUewYOHuXPjVJjqByMDxl
+         ioa1xcLI1j+HZHa+N5nNHMbzy62hWx9dPaqm2z5T0/VvJP0zQtmj9mPALBneduYyk5Y+
+         pHwQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:x-gm-message-state:from:to:cc:subject:date;
+        bh=cIrQy9EdHerBVaY7Dvc4XNQfhltLnbs0FHVFNRu23eM=;
+        b=S+tZImHAV/bTgE4PJsKS5gCTSBnUltknmV6XRw1x7N4IgSL/oXsSE+lflO1mN6QyNH
+         g3yltZZ6V1eNRpMSEB+kw51rzugVJk3H2OY64b77tRoFgk/+shPja7n/016pi1arD8/2
+         KG+0rXm7lX1c8bRXeWGBt5JQcb8hPXr0bEiM9/Ejs/Vgl+4cxcCBA4HQv3diExWGLO7t
+         Mk9JHsMJ89uFkPrpLmZQ9+mYLI1bj56cEUnmY6N/QGAO76T8ANfwRVqLxptTYodkuIv1
+         R0TX4z89/T4gPrXaxvKU3HzNcJe1pOZvusFzoBZlricumsn9Yq5tnQ42Jq3MW5NIoRr7
+         5Diw==
+X-Gm-Message-State: ACrzQf29AUKb+rNRu+DEkxOe6AbvWepSitQPfJuxNXhLzImXxxbGnCJ7
+	AjQ05MLxGW9EXOeG/x4LzmbEz1N9/XoVod8uJkA=
+X-Google-Smtp-Source: AMsMyM4vZhBMhSN2kpNqJx1evgIjbRUJkxPg4vHEZ00Ltfgt1EpaMjyj2BYKLM5A/FznCEo5afdxlk/3hHH+eVtJHjI=
+X-Received: by 2002:a4a:aa48:0:b0:475:2ead:9e35 with SMTP id
+ y8-20020a4aaa48000000b004752ead9e35mr654566oom.68.1663269638692; Thu, 15 Sep
+ 2022 12:20:38 -0700 (PDT)
+MIME-Version: 1.0
+References: <166326660455.1440.4931108525708331193-0@git.sr.ht> <166326660455.1440.4931108525708331193-1@git.sr.ht>
+In-Reply-To: <166326660455.1440.4931108525708331193-1@git.sr.ht>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Thu, 15 Sep 2022 22:20:27 +0300
+Message-ID: <CAFVMu-rBE6jZQWi0tjhrFqgL-ZjnsHnS9TjFv94JShaFOeVYiQ@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc 1/1] Move Label dependencies above archive
+ fetching to reduce restarts
+To: "~kmicklas" <git@kmicklas.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht, kmicklas@uber.com
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 286
+Lines: 11
+
+On Thu, Sep 15, 2022 at 9:30 PM ~kmicklas <kmicklas@git.sr.ht> wrote:
+>
+> From: Ken Micklas <kmicklas@uber.com>
+>
+> ---
+>  toolchain/defs.bzl | 53 +++++++++++++++++++++++++---------------------
+>  1 file changed, 29 insertions(+), 24 deletions(-)
+
+Applied, thanks!
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f51.google.com (mail-oa1-f51.google.com [209.85.160.51])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 0AE1B11EEDB
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 15 Sep 2022 19:23:53 +0000 (UTC)
+Received: by mail-oa1-f51.google.com with SMTP id 586e51a60fabf-1274ec87ad5so49012618fac.0
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 15 Sep 2022 12:23:53 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:from:to:cc:subject:date;
+        bh=3ZUSupMUH6E05gWVqE9yBfHWRhcg+RWdYQR0rqWPlKE=;
+        b=NlG7X7sAgkihr8jLH40LSPCowvP3DcK7dl/HlE56PNTt/7AYtvmrb6Uo+fKj90v58i
+         Z8JYtrE3frsPhcg2CN+Upc+SuSaLNVVs0Q4lVEVNXmU24F6RpWtx/eO9go/Q1TxFYoE7
+         yER+2xF8rL9onEJ8rukvZvgeciFJUPF04wJD50SZSTqeiUrpT0EB0CNLTWGwiVdpg/Ig
+         k95M8LwxZ/rYGG4jGd/aTCFu6a8Cb+DFUjlTS65J//U8jbTUk6suuFV47O20KvzwytM7
+         /7eeZ5Q7zTNVvSs8Po4Q5jBoJVaO9G+zAMGK9YhfFD6nzbsFmKRslP4aevtAqjtZ5Ip/
+         A+pA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:x-gm-message-state:from:to:cc:subject:date;
+        bh=3ZUSupMUH6E05gWVqE9yBfHWRhcg+RWdYQR0rqWPlKE=;
+        b=ad+7HmX3/Bk55NXV+l9bp9pqAloe4fhT+sTZTag48DFD5G5oCFiteaPAztrhbD+imb
+         9NgLVy6lzh7ZeG+ZarlGLeao+183VHvIkgZRXEXI8g4j6Icak9QOlAhpwRd/dKgDUwlG
+         gE9hNqYkxQE+nyvj64TpVkEbtWfNZVk1aiUB07sYZwOOK7DvrVquGP4RRCra60gmQxWK
+         dTS3MJeHfCgtOpN/zIZIucWSgMpcn2cskBCta97WdcBETXHVhK96ApLJwHh7qEY31eR/
+         v1mr27+cFuyaejbhq/amjA80QFdx9xXZ+fp0Etc3qCvVv83oAs50qpnqy7Wa8hsXxB7c
+         GACg==
+X-Gm-Message-State: ACgBeo3X6OJjo8jAkmpi8xv1T+hIia2GdFvMLsZF2ZXA1Ia0zmKJCyeo
+	gYsMVQxUJA//2NyiCm8iiv9u2rToxVN7VlUPqjY=
+X-Google-Smtp-Source: AA6agR6JEj+JU288Tt4plRsVDzZTfLUQvjSeoreUySv8gLa8vz3h1eFeMqigehU624QVLMUJokkNG3rhp5eiZ4X0SRk=
+X-Received: by 2002:a05:6870:14c8:b0:127:8b50:198b with SMTP id
+ l8-20020a05687014c800b001278b50198bmr6209532oab.216.1663269832350; Thu, 15
+ Sep 2022 12:23:52 -0700 (PDT)
+MIME-Version: 1.0
+References: <166325284132.32481.3819031653685599117-0@git.sr.ht> <166325284132.32481.3819031653685599117-1@git.sr.ht>
+In-Reply-To: <166325284132.32481.3819031653685599117-1@git.sr.ht>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Thu, 15 Sep 2022 22:23:41 +0300
+Message-ID: <CAFVMu-oZSaxLey689rL80RvwPd0VNH7SOFKaQ0A5ccefVUBsTg@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc 1/1] Fix include root path for macos-aarch64
+To: "~kmicklas" <git@kmicklas.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht, kmicklas@uber.com
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 423
+Lines: 13
+
+On Thu, Sep 15, 2022 at 5:40 PM ~kmicklas <kmicklas@git.sr.ht> wrote:
+>
+> From: Ken Micklas <kmicklas@uber.com>
+>
+> ---
+>  toolchain/defs.bzl | 2 +-
+>  1 file changed, 1 insertion(+), 1 deletion(-)
+
+Thanks, applied. Though those will likely need to be revised soon -- I
+remember reading somewhere that those prefixes will be made consistent
+at some point. It's either landed, or there is an open PR.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id A8BE811EE04;
+	Tue, 27 Sep 2022 07:24:28 +0000 (UTC)
+From: ~motiejus <motiejus@git.sr.ht>
+Date: Tue, 27 Sep 2022 07:24:28 +0000
+MIME-Version: 1.0
+Subject: [PATCH bazel-zig-cc 0/2] use relative paths
+Message-ID: <166426346839.12781.6953968828011257615-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~motiejus <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht, fabian@hahn.graphics
+Cc: laurynasl@uber.com, mail@kmicklas.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 1174
+Lines: 31
+
+This patchset changes absolute paths to tools to relative paths. Work
+was started by @kmicklas and completed by myself and @laurynasl. Please
+review.
+
+Currently, with absolute paths, bazel's remote cache keys are different
+between two workspaces, busting our remote cache. We hope (did not try
+yet) that this will normalize them and fix our cache hit ratios.
+
+Fabian, this does not work on Windows yet; if you want to chime in, I
+will wait a couple of days for your patch before I cut a release.
+
+1.0 is coming soon.
+
+Ken Micklas (1):
+  WIP: use relative paths for tools
+
+Motiejus Jak=C5=A1tys (1):
+  defs: fix import paths
+
+ README.md                           |  2 +-
+ toolchain/BUILD.sdk.bazel           |  9 +++++++--
+ toolchain/defs.bzl                  | 29 +++++++++++++++++++++++++----
+ toolchain/private/BUILD.sdk.bazel   |  7 -------
+ toolchain/private/cc_toolchains.bzl | 17 ++++++++---------
+ toolchain/private/defs.bzl          | 29 ++++++++++++++---------------
+ toolchain/toolchain/defs.bzl        |  4 ++--
+ 7 files changed, 57 insertions(+), 40 deletions(-)
+ delete mode 100644 toolchain/private/BUILD.sdk.bazel
+
+--=20
+2.34.4
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id CC64611EE05;
+	Tue, 27 Sep 2022 07:24:28 +0000 (UTC)
+From: ~motiejus <motiejus@git.sr.ht>
+Date: Wed, 21 Sep 2022 11:14:29 +0100
+Subject: [PATCH bazel-zig-cc 1/2] WIP: use relative paths for tools
+Message-ID: <166426346839.12781.6953968828011257615-1@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~motiejus <motiejus@jakstys.lt>
+In-Reply-To: <166426346839.12781.6953968828011257615-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht, fabian@hahn.graphics
+Cc: laurynasl@uber.com, mail@kmicklas.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 6211
+Lines: 167
+
+From: Ken Micklas <kmicklas@uber.com>
+
+---
+ README.md                           |  2 +-
+ toolchain/BUILD.sdk.bazel           |  9 +++++++--
+ toolchain/defs.bzl                  |  5 +++--
+ toolchain/private/BUILD.sdk.bazel   |  7 -------
+ toolchain/private/cc_toolchains.bzl | 12 +++++++-----
+ toolchain/toolchain/defs.bzl        |  4 ++--
+ 6 files changed, 20 insertions(+), 19 deletions(-)
+ delete mode 100644 toolchain/private/BUILD.sdk.bazel
+
+diff --git a/README.md b/README.md
+index 262b88b..266952f 100644
+--- a/README.md
++++ b/README.md
+@@ -110,7 +110,7 @@ toolchain(
+   generator_location =3D "toolchain/BUILD:7:19",
+   toolchain_type =3D "@bazel_tools//tools/cpp:toolchain_type",
+   target_compatible_with =3D ["@platforms//os:linux", "@platforms//cpu:aarch=
+64", "@zig_sdk//libc:unconstrained"],
+-  toolchain =3D "@zig_sdk//private:aarch64-linux-musl_cc",
++  toolchain =3D "@zig_sdk//:aarch64-linux-musl_cc",
+ )
+ ```
+=20
+diff --git a/toolchain/BUILD.sdk.bazel b/toolchain/BUILD.sdk.bazel
+index e1505b1..ef5fd5f 100644
+--- a/toolchain/BUILD.sdk.bazel
++++ b/toolchain/BUILD.sdk.bazel
+@@ -1,11 +1,10 @@
+ load("@bazel-zig-cc//toolchain:defs.bzl", "declare_files")
++load("@bazel-zig-cc//toolchain/private:cc_toolchains.bzl", "declare_cc_toolc=
+hains")
+=20
+ package(
+     default_visibility =3D ["//visibility:public"],
+ )
+=20
+-
+-
+ declare_files(
+     os =3D {os},
+     zig_include_root =3D {zig_include_root},
+@@ -15,3 +14,9 @@ exports_files([
+     "glibc-hacks/fcntl.map",
+     "glibc-hacks/glibchack-fcntl.h",
+ ])
++
++declare_cc_toolchains(
++    os =3D {os},
++    absolute_path =3D {absolute_path},
++    zig_include_root =3D {zig_include_root},
++)
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 797e4fe..f0e6a72 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -186,14 +186,14 @@ def _zig_repository_impl(repository_ctx):
+=20
+     for dest, src in {
+         "BUILD": "//toolchain:BUILD.sdk.bazel",
+-        "private/BUILD": "//toolchain/private:BUILD.sdk.bazel",
++        # "private/BUILD": "//toolchain/private:BUILD.sdk.bazel",
+     }.items():
+         repository_ctx.template(
+             dest,
+             Label(src),
+             executable =3D False,
+             substitutions =3D {
+-                "{absolute_path}": _quote(str(repository_ctx.path(""))),
++                "{absolute_path}": _quote("external/zig_sdk"),
+                 "{os}": _quote(os),
+                 "{zig_include_root}": _quote(zig_include_root),
+             },
+@@ -246,6 +246,7 @@ def filegroup(name, **kwargs):
+     return ":" + name
+=20
+ def declare_files(os, zig_include_root):
++    filegroup(name =3D "all", srcs =3D native.glob(["**"]))
+     filegroup(name =3D "empty")
+     if os =3D=3D "windows":
+         native.exports_files(["zig.exe"], visibility =3D ["//visibility:publ=
+ic"])
+diff --git a/toolchain/private/BUILD.sdk.bazel b/toolchain/private/BUILD.sdk.=
+bazel
+deleted file mode 100644
+index 3e7c23e..0000000
+--- a/toolchain/private/BUILD.sdk.bazel
++++ /dev/null
+@@ -1,7 +0,0 @@
+-load("@bazel-zig-cc//toolchain/private:cc_toolchains.bzl", "declare_cc_toolc=
+hains")
+-
+-declare_cc_toolchains(
+-    os =3D {os},
+-    absolute_path =3D {absolute_path},
+-    zig_include_root =3D {zig_include_root},
+-)
+diff --git a/toolchain/private/cc_toolchains.bzl b/toolchain/private/cc_toolc=
+hains.bzl
+index 724cbda..6b8b3e6 100644
+--- a/toolchain/private/cc_toolchains.bzl
++++ b/toolchain/private/cc_toolchains.bzl
+@@ -29,7 +29,7 @@ def declare_cc_toolchains(os, absolute_path, zig_include_ro=
+ot):
+                 absolute_tool_paths[name] =3D path
+                 continue
+             tool_path =3D zig_tool_path(os).format(zig_tool =3D path)
+-            absolute_tool_paths[name] =3D "%s/%s" % (absolute_path, tool_pat=
+h)
++            absolute_tool_paths[name] =3D tool_path
+=20
+         linkopts =3D target_config.linkopts
+         dynamic_library_linkopts =3D target_config.dynamic_library_linkopts
+@@ -53,18 +53,20 @@ def declare_cc_toolchains(os, absolute_path, zig_include_=
+root):
+             compiler =3D "clang",
+             abi_version =3D "unknown",
+             abi_libc_version =3D "unknown",
++            # visibility =3D ["//visibility:private"],
+         )
+=20
+         native.cc_toolchain(
+             name =3D zigtarget + "_cc",
+             toolchain_identifier =3D zigtarget + "-toolchain",
+             toolchain_config =3D ":%s_cc_config" % zigtarget,
+-            all_files =3D "@zig_sdk//:zig",
+-            ar_files =3D "@zig_sdk//:zig",
+-            compiler_files =3D "@zig_sdk//:zig",
+-            linker_files =3D "@zig_sdk//:zig",
++            all_files =3D "@zig_sdk//:all",
++            ar_files =3D "@zig_sdk//:all",
++            compiler_files =3D "@zig_sdk//:all",
++            linker_files =3D "@zig_sdk//:all",
+             dwp_files =3D "@zig_sdk//:empty",
+             objcopy_files =3D "@zig_sdk//:empty",
+             strip_files =3D "@zig_sdk//:empty",
+             supports_param_files =3D 0,
++            # visibility =3D ["//visibility:private"],
+         )
+diff --git a/toolchain/toolchain/defs.bzl b/toolchain/toolchain/defs.bzl
+index 1d99a61..24a90cc 100644
+--- a/toolchain/toolchain/defs.bzl
++++ b/toolchain/toolchain/defs.bzl
+@@ -32,7 +32,7 @@ def _declare_toolchain(gotarget, zigtarget, target_compatib=
+le_with):
+         name =3D gotarget,
+         exec_compatible_with =3D None,
+         target_compatible_with =3D target_compatible_with,
+-        toolchain =3D "@zig_sdk//private:%s_cc" % zigtarget,
++        toolchain =3D "@zig_sdk//:%s_cc" % zigtarget,
+         toolchain_type =3D "@bazel_tools//tools/cpp:toolchain_type",
+     )
+=20
+@@ -41,6 +41,6 @@ def _declare_toolchain(gotarget, zigtarget, target_compatib=
+le_with):
+         name =3D zigtarget,
+         exec_compatible_with =3D None,
+         target_compatible_with =3D target_compatible_with,
+-        toolchain =3D "@zig_sdk//private:%s_cc" % zigtarget,
++        toolchain =3D "@zig_sdk//:%s_cc" % zigtarget,
+         toolchain_type =3D "@bazel_tools//tools/cpp:toolchain_type",
+     )
+--=20
+2.34.4
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id EAD5C11EF5B;
+	Tue, 27 Sep 2022 07:24:28 +0000 (UTC)
+From: ~motiejus <motiejus@git.sr.ht>
+Date: Mon, 26 Sep 2022 10:14:08 +0300
+Subject: [PATCH bazel-zig-cc 2/2] defs: fix import paths
+MIME-Version: 1.0
+Message-ID: <166426346839.12781.6953968828011257615-2@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~motiejus <motiejus@jakstys.lt>
+In-Reply-To: <166426346839.12781.6953968828011257615-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht, fabian@hahn.graphics
+Cc: laurynasl@uber.com, mail@kmicklas.com
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 9326
+Lines: 238
+
+From: Motiejus Jak=C5=A1tys <motiejus@uber.com>
+
+Empirically these need to come from most specfic to least specific.
+
+The error message is as follows:
+
+    In file included from test/c/main.c:1:
+    In file included from external/zig_sdk/lib/libcxx/include/stdio.h:107:
+    In file included from external/zig_sdk/lib/libc/include/generic-glibc/std=
+io.h:38:
+    external/zig_sdk/lib/libc/include/generic-glibc/bits/types.h:139:3: error:
+    # error
+      ^
+    external/zig_sdk/lib/libc/include/generic-glibc/bits/types.h:145:1: error=
+: unknown type name '__STD_TYPE'
+    __STD_TYPE __DEV_T_TYPE __dev_t;        /* Type of device numbers.  */
+
+Dissected `generic-glibc/bits/types.h:#error`:
+
+    #if __WORDSIZE =3D=3D 32
+    <...>
+    # define __STD_TYPE		__extension__ typedef
+    #elif __WORDSIZE =3D=3D 64
+    <...>
+    # define __STD_TYPE		typedef
+    #else
+    # error
+    #endif
+
+So we do not have the `__WORDSIZE`. Where does that come from? Probably from a
+directory that has an `x86_64` in it. How does that get included? Let's start
+with `lib/libcxx/include/stdio.h`:
+
+	16 #include_next <stdio.h>
+
+Now previously our `c++` command line looked like this:
+    external/zig_sdk/tools/c++ \
+    <...>
+    -Iexternal/zig_sdk/lib/include \
+    -Iexternal/zig_sdk/lib/libcxx/include \
+    -Iexternal/zig_sdk/lib/libcxxabi/include \
+    -Iexternal/zig_sdk/lib/libunwind/include \
+    -Iexternal/zig_sdk/lib/libc/include/generic-glibc \
+    -Iexternal/zig_sdk/lib/libc/include/any-linux-any \
+    -Iexternal/zig_sdk/lib/libc/include/x86_64-linux-gnu \
+    -Iexternal/zig_sdk/lib/libc/include/x86_64-linux-any \
+    -Iexternal/zig_sdk/lib/libc/include/x86-linux-any \
+    -Iexternal/zig_sdk/glibc-hacks \
+    <...>
+
+So the next place it will find `stdio.h` is in `generic-glibc`, which already
+uses the `__WORDSIZE`. If we make the "next" include to be the arch-specific
+one instead of the generic-glibc, things start compiling again.
+
+Fix the same fo musl.
+---
+ toolchain/defs.bzl                  | 24 ++++++++++++++++++++++--
+ toolchain/private/cc_toolchains.bzl |  9 +++------
+ toolchain/private/defs.bzl          | 29 ++++++++++++++---------------
+ 3 files changed, 39 insertions(+), 23 deletions(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index f0e6a72..25ca20a 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -1,6 +1,13 @@
+ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_user_netrc", "us=
+e_netrc")
+-load("@bazel-zig-cc//toolchain/private:defs.bzl", "DEFAULT_INCLUDE_DIRECTORI=
+ES", "target_structs", "zig_tool_path")
++load("@bazel-zig-cc//toolchain/private:defs.bzl", "target_structs", "zig_too=
+l_path")
++
++# Directories that `zig c++` includes behind the scenes.
++_DEFAULT_INCLUDE_DIRECTORIES =3D [
++    "libcxx/include",
++    "libcxxabi/include",
++    "libunwind/include",
++]
+=20
+ _fcntl_map =3D """
+ GLIBC_2.2.5 {
+@@ -86,12 +93,14 @@ _ZIG_TOOLS =3D [
+     "wasm-ld",  # WebAssembly
+ ]
+=20
++# TODO: ZIG_LIB_DIR equivalent in powershell?
+ _ZIG_TOOL_WRAPPER_WINDOWS_CACHE_KNOWN =3D """@echo off
+ set ZIG_LOCAL_CACHE_DIR=3D{cache_prefix}\\bazel-zig-cc
+ set ZIG_GLOBAL_CACHE_DIR=3D%ZIG_LOCAL_CACHE_DIR%
+ "{zig}" "{zig_tool}" %*
+ """
+=20
++# TODO: ZIG_LIB_DIR equivalent in powershell?
+ _ZIG_TOOL_WRAPPER_WINDOWS_CACHE_GUESS =3D """@echo off
+ if exist "%TMP%\\*" goto :usertmp
+ set ZIG_LOCAL_CACHE_DIR=3DC:\\Temp\\bazel-zig-cc
+@@ -104,6 +113,12 @@ set ZIG_GLOBAL_CACHE_DIR=3D%ZIG_LOCAL_CACHE_DIR%
+ """
+=20
+ _ZIG_TOOL_WRAPPER_CACHE_KNOWN =3D """#!/bin/sh
++set -e
++if [ -d external/zig_sdk/lib ]; then
++    export ZIG_LIB_DIR=3Dexternal/zig_sdk/lib
++else
++    export ZIG_LIB_DIR=3D"$(dirname "$0")/../lib"
++fi
+ export ZIG_LOCAL_CACHE_DIR=3D"{cache_prefix}/bazel-zig-cc"
+ export ZIG_GLOBAL_CACHE_DIR=3D"{cache_prefix}/bazel-zig-cc"
+ exec "{zig}" "{zig_tool}" "$@"
+@@ -111,6 +126,11 @@ exec "{zig}" "{zig_tool}" "$@"
+=20
+ _ZIG_TOOL_WRAPPER_CACHE_GUESS =3D """#!/bin/sh
+ set -e
++if [ -d external/zig_sdk/lib ]; then
++    export ZIG_LIB_DIR=3Dexternal/zig_sdk/lib
++else
++    export ZIG_LIB_DIR=3D"$(dirname "$0")/../lib"
++fi
+ if [ -n "$TMPDIR" ]; then
+     _cache_prefix=3D$TMPDIR
+ elif [ -n "$HOME" ]; then
+@@ -258,7 +278,7 @@ def declare_files(os, zig_include_root):
+     lazy_filegroups =3D {}
+=20
+     for target_config in target_structs():
+-        for d in DEFAULT_INCLUDE_DIRECTORIES + target_config.includes:
++        for d in _DEFAULT_INCLUDE_DIRECTORIES + target_config.includes:
+             d =3D zig_include_root + d
+             if d not in lazy_filegroups:
+                 lazy_filegroups[d] =3D filegroup(name =3D d, srcs =3D native=
+.glob([d + "/**"]))
+diff --git a/toolchain/private/cc_toolchains.bzl b/toolchain/private/cc_toolc=
+hains.bzl
+index 6b8b3e6..a5b4b5e 100644
+--- a/toolchain/private/cc_toolchains.bzl
++++ b/toolchain/private/cc_toolchains.bzl
+@@ -1,4 +1,4 @@
+-load(":defs.bzl", "DEFAULT_INCLUDE_DIRECTORIES", "target_structs", "zig_tool=
+_path")
++load(":defs.bzl", "target_structs", "zig_tool_path")
+ load("@bazel-zig-cc//toolchain:zig_toolchain.bzl", "zig_cc_toolchain_config")
+=20
+ DEFAULT_TOOL_PATHS =3D {
+@@ -17,9 +17,6 @@ def declare_cc_toolchains(os, absolute_path, zig_include_ro=
+ot):
+         zigtarget =3D target_config.zigtarget
+=20
+         cxx_builtin_include_directories =3D []
+-        for d in DEFAULT_INCLUDE_DIRECTORIES + target_config.includes:
+-            d =3D zig_include_root + d
+-            cxx_builtin_include_directories.append(absolute_path + "/" + d)
+         for d in getattr(target_config, "toplevel_include", []):
+             cxx_builtin_include_directories.append(absolute_path + "/" + d)
+=20
+@@ -53,7 +50,7 @@ def declare_cc_toolchains(os, absolute_path, zig_include_ro=
+ot):
+             compiler =3D "clang",
+             abi_version =3D "unknown",
+             abi_libc_version =3D "unknown",
+-            # visibility =3D ["//visibility:private"],
++            visibility =3D ["//visibility:private"],
+         )
+=20
+         native.cc_toolchain(
+@@ -68,5 +65,5 @@ def declare_cc_toolchains(os, absolute_path, zig_include_ro=
+ot):
+             objcopy_files =3D "@zig_sdk//:empty",
+             strip_files =3D "@zig_sdk//:empty",
+             supports_param_files =3D 0,
+-            # visibility =3D ["//visibility:private"],
++            visibility =3D ["//visibility:private"],
+         )
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+index 8a8b4f5..2e939fd 100644
+--- a/toolchain/private/defs.bzl
++++ b/toolchain/private/defs.bzl
+@@ -1,9 +1,3 @@
+-DEFAULT_INCLUDE_DIRECTORIES =3D [
+-    "include",
+-    "libcxx/include",
+-    "libcxxabi/include",
+-]
+-
+ _ZIG_TOOL_PATH =3D "tools/{zig_tool}"
+=20
+ # Zig supports even older glibcs than defined below, but we have tested only
+@@ -101,12 +95,14 @@ def _target_linux_gnu(gocpu, zigcpu, glibc_version):
+         gotarget =3D "linux_{}_{}".format(gocpu, glibc_suffix),
+         zigtarget =3D "{}-linux-{}".format(zigcpu, glibc_suffix),
+         includes =3D [
+-            "libunwind/include",
+-            "libc/include/generic-glibc",
++                       "libc/include/{}-linux-gnu".format(zigcpu),
++                       "libc/include/generic-glibc",
++                   ] +
++                   # x86_64-linux-any is x86_64-linux and x86-linux combined.
++                   (["libc/include/x86-linux-any"] if zigcpu =3D=3D "x86_64"=
+ else []) +
++                   (["libc/include/{}-linux-any".format(zigcpu)] if zigcpu !=
+=3D "x86_64" else []) + [
+             "libc/include/any-linux-any",
+-            "libc/include/{}-linux-gnu".format(zigcpu),
+-            "libc/include/{}-linux-any".format(zigcpu),
+-        ] + (["libc/include/x86-linux-any"] if zigcpu =3D=3D "x86_64" else [=
+]),
++        ],
+         toplevel_include =3D ["glibc-hacks"] if fcntl_hack else [],
+         compiler_extra_includes =3D ["glibc-hacks/glibchack-fcntl.h"] if fcn=
+tl_hack else [],
+         linker_version_scripts =3D ["glibc-hacks/fcntl.map"] if fcntl_hack e=
+lse [],
+@@ -127,11 +123,14 @@ def _target_linux_musl(gocpu, zigcpu):
+         gotarget =3D "linux_{}_musl".format(gocpu),
+         zigtarget =3D "{}-linux-musl".format(zigcpu),
+         includes =3D [
+-            "libc/include/generic-musl",
++                       "libc/include/{}-linux-musl".format(zigcpu),
++                       "libc/include/generic-musl",
++                   ] +
++                   # x86_64-linux-any is x86_64-linux and x86-linux combined.
++                   (["libc/include/x86-linux-any"] if zigcpu =3D=3D "x86_64"=
+ else []) +
++                   (["libc/include/{}-linux-any".format(zigcpu)] if zigcpu !=
+=3D "x86_64" else []) + [
+             "libc/include/any-linux-any",
+-            "libc/include/{}-linux-musl".format(zigcpu),
+-            "libc/include/{}-linux-any".format(zigcpu),
+-        ] + (["libc/include/x86-linux-any"] if zigcpu =3D=3D "x86_64" else [=
+]),
++        ],
+         linkopts =3D [],
+         dynamic_library_linkopts =3D [],
+         copts =3D ["-D_LIBCPP_HAS_MUSL_LIBC", "-D_LIBCPP_HAS_THREAD_API_PTHR=
+EAD"],
+--=20
+2.34.4
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=W7KlZflNVFjgKd628RF6PaVUJubT+rUOy4Q+3rHrpxM=;
+ c=simple/simple; d=sr.ht; h=Date:Subject:To:Cc:From:In-Reply-To;
+ q=dns/txt; s=srht; t=1664266328; v=1;
+ b=NCYXfvN9GoTiM384oIMvv0Zysk1gDxQiDQHIqwGA2NBS/5ESsWVndRdHWnLPeTKNDJ6hZipK
+ nRGGRix+3HVrumdnhXQoo2OaT1az2Xsj/IdIOgKcjUuOrLY51JDiFFEZl+RlC+unoN2AXg2vUI/
+ urwhxb19FXVu97UVnTJ01EIp+AJWjBxBFP/SBazSOKBX0c0GG6gZlpsvWbI6BhFfN/a2cNmN94E
+ 3GjhqyDfH5ng3siBZJUVl5qsi7qupHMP0N0pFCdcdGYpIvkMpwkc86HbtgQbzls0/vhOsvmLtf7
+ 9pLHhXmhIFKaRVTLsRZWXWYTYF3vyFnm60FhBETgyghsQ==
+Received: from localhost (unknown [173.195.146.244])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id C3F2F11EE04;
+	Tue, 27 Sep 2022 08:12:08 +0000 (UTC)
+MIME-Version: 1.0
+Date: Tue, 27 Sep 2022 08:12:08 +0000
+Subject: [bazel-zig-cc/patches/.build.yml] build success
+To: "~motiejus" <motiejus@jakstys.lt>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CN716CKQL8QI.2KTA9DW8RGJVO@cirno2>
+In-Reply-To: <166426346839.12781.6953968828011257615-2@git.sr.ht>
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 303
+Lines: 9
+
+bazel-zig-cc/patches/.build.yml: SUCCESS in 47m37s
+
+[use relative paths][0] from [~motiejus][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/35627
+[1]: mailto:motiejus@jakstys.lt
+
+=E2=9C=93 #851368 SUCCESS bazel-zig-cc/patches/.build.yml https://builds.sr=
+.ht/~motiejus/job/851368
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=uber.com header.i=@uber.com
+Received: from mail-qk1-f170.google.com (mail-qk1-f170.google.com [209.85.222.170])
+	by mail-b.sr.ht (Postfix) with ESMTPS id A049611EE05
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 27 Sep 2022 09:44:45 +0000 (UTC)
+Received: by mail-qk1-f170.google.com with SMTP id d17so5651016qko.13
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 27 Sep 2022 02:44:45 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=uber.com; s=google;
+        h=content-transfer-encoding:cc:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:from:to:cc:subject:date;
+        bh=r5VFyX1uT1BFLnwrXt3uLx3lRhBc+ITbuN6f4nth1Gg=;
+        b=vvbnJZEiuJt4m2ffffQyXu+Y8naonBmKxxIMgkii/lWQ6X21TnQmhRYDUeWf8vyN5U
+         LnB/FRDXykuT2/Jw2WwvXWtTA3RzpLQ8SerPeR3Vqh1Nqa1A0iRcwwrn+gMukMPip/FV
+         n/Ko4qOfW65WIq2C2WZspGwgfdsw4CFDAHFOs=
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=content-transfer-encoding:cc:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:x-gm-message-state:from:to:cc
+         :subject:date;
+        bh=r5VFyX1uT1BFLnwrXt3uLx3lRhBc+ITbuN6f4nth1Gg=;
+        b=VDBpQSk57bs2YO9HT3E4l7sJK6P64dF5Qbe5zBVL0cJhStzPUSo+fNJe+r7eXacNmc
+         UeMAeOyJMUEAK/uym+PLTOvruaNsprC96YKWFjPEemuPUSnwAVHyiYd+90BrMicTCDUV
+         0LExWrmsyn6hr9/WLwh4sKsFUGBpPFAxBmaACGVjA/ihTBWwiUF6weFuDuLIAUR9qZfU
+         Qq2cWpfBNpsfsA6VBjBz3o3DD6Md0DGtCSC7oPlp3SuUJzBuAleO80nfzWOg0JY9S88W
+         8yyNY3knobuft6mbxLxkKvhwgiIw4n6hlK+yuXfHOunCfDqnMHIyBJpM45rgSqSUoGMY
+         taTQ==
+X-Gm-Message-State: ACrzQf1cX1aBsmkgNoAchdOUMGdFpv9CQtAkamC84YQzjchqeb6YJ47R
+	TzsaFpTjgUkkdRq9jIUMmEVLubytMZPifn3LXktR
+X-Google-Smtp-Source: AMsMyM5YfFW5pOEuSYW2BGOZGw7sBOW82OY5UKDobg0Kx32YmdjDydMkfReEwBnQW6MOUNb1ME/cW7Do1qJzHRHEzx4=
+X-Received: by 2002:a05:620a:1239:b0:6ce:24c1:12d7 with SMTP id
+ v25-20020a05620a123900b006ce24c112d7mr16841011qkj.496.1664271885023; Tue, 27
+ Sep 2022 02:44:45 -0700 (PDT)
+MIME-Version: 1.0
+References: <166426346839.12781.6953968828011257615-0@git.sr.ht>
+In-Reply-To: <166426346839.12781.6953968828011257615-0@git.sr.ht>
+From: Laurynas Lubys <laurynasl@uber.com>
+Date: Tue, 27 Sep 2022 12:44:34 +0300
+Message-ID: <CAG09j48HjG7DQ9a7pxgniwNS6Yik7ZEVVo52XsmpfVLtmzoB-A@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc 0/2] use relative paths
+To: "~motiejus" <motiejus@jakstys.lt>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht, fabian@hahn.graphics, 
+	mail@kmicklas.com
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 1543
+Lines: 40
+
+Mostly looks good.
+The `absolute_path` parameter can be inlined to avoid confusion.
+I don't see a good way to keep the `private` package. It has to go, so
+that all the generated files are available under the `zig_sdk//:all`
+fileset.
+
+
+On Tue, Sep 27, 2022 at 10:24 AM ~motiejus <motiejus@git.sr.ht> wrote:
+>
+> This patchset changes absolute paths to tools to relative paths. Work
+> was started by @kmicklas and completed by myself and @laurynasl. Please
+> review.
+>
+> Currently, with absolute paths, bazel's remote cache keys are different
+> between two workspaces, busting our remote cache. We hope (did not try
+> yet) that this will normalize them and fix our cache hit ratios.
+>
+> Fabian, this does not work on Windows yet; if you want to chime in, I
+> will wait a couple of days for your patch before I cut a release.
+>
+> 1.0 is coming soon.
+>
+> Ken Micklas (1):
+>   WIP: use relative paths for tools
+>
+> Motiejus Jak=C5=A1tys (1):
+>   defs: fix import paths
+>
+>  README.md                           |  2 +-
+>  toolchain/BUILD.sdk.bazel           |  9 +++++++--
+>  toolchain/defs.bzl                  | 29 +++++++++++++++++++++++++----
+>  toolchain/private/BUILD.sdk.bazel   |  7 -------
+>  toolchain/private/cc_toolchains.bzl | 17 ++++++++---------
+>  toolchain/private/defs.bzl          | 29 ++++++++++++++---------------
+>  toolchain/toolchain/defs.bzl        |  4 ++--
+>  7 files changed, 57 insertions(+), 40 deletions(-)
+>  delete mode 100644 toolchain/private/BUILD.sdk.bazel
+>
+> --
+> 2.34.4
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oi1-f178.google.com (mail-oi1-f178.google.com [209.85.167.178])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 1B25911EE05
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 27 Sep 2022 13:10:04 +0000 (UTC)
+Received: by mail-oi1-f178.google.com with SMTP id m81so11839896oia.1
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 27 Sep 2022 06:10:04 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=content-transfer-encoding:to:subject:message-id:date:from
+         :mime-version:from:to:cc:subject:date;
+        bh=cBNiw8zybrgk0hg558e2v5hQQ5OHEb48r745rdZ9+Tk=;
+        b=dbDdpk2p6sLSVmDD4hEh4NZLYV0zQZ0lcwNwnCi4DWYLKaxD5cQPz5vwudAr7AMvwC
+         PgohWaiWFBhKc/VVAe81iS2irKoWClxZzn1XqzNyXhFRsUd0Gt0xezj1c5V57UGJnGpc
+         8J/pcMreo6CiIMEuRWvuLPWDdDSoSkGD18yAElnI8lilyNL+46BM+s/Ah4NhrnVtC1jx
+         CxTAcWcunoyxwh3NotR9zI91C0ksiCayZBGU6yVai6PYhw2DzSSM/JjfYfEoeIcUbY7P
+         t/swYzL6PmGjEyUjonp48koVRAErTes40JHpVdGAcdP5QAHtGzXs5l8iXV028G5Ax+QP
+         hB+Q==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=content-transfer-encoding:to:subject:message-id:date:from
+         :mime-version:x-gm-message-state:from:to:cc:subject:date;
+        bh=cBNiw8zybrgk0hg558e2v5hQQ5OHEb48r745rdZ9+Tk=;
+        b=b/F2LU+u3InyGfvmHPoLT24MQdlnSFkDljgxWqZa8/8d8vxcMLTtNtYuX3aneEEwNK
+         AsG6uVN2bbdq+xUAI1Ei5G8n3B2xWFgxDHUmkyvSfntTfFEofQ9nWsj4B2f0OiBBLvVN
+         NBkRKsUsJ/dSwMayohHMdIHKORqpXze9beq5iSJu1NlTtUEgQjAqcPSfmQWzMbWhmKEd
+         D/SkrQnebqTkv0HfSBWGM1WWPVARxw3j6+JRpFmA0VW2/c5RaZogqr1sLFp32D9Os6mM
+         ApfzQLxs33ij1sH4oay7FSuDwU5BXjlZtKb7Ss5onF62nnSzBERHokwKBxvskgB2VyTs
+         vtzA==
+X-Gm-Message-State: ACrzQf1prgnmbVCNta7dvBQoUIy3Y734OGhKu3UTtdauzZRm8VUVg3t0
+	k32pbaVrjrb7WHnN3oROj0QyfU4ycDlMBwhzwc6WgRPITMY=
+X-Google-Smtp-Source: AMsMyM5Kyq9LAyyIJZZsagbDl/3R1Ng5ZwWZkDauCpP6FlNXoh5oCFQTzFWwIUPEWMOT9ToiRQMYc7AYRqKS0PXGVic=
+X-Received: by 2002:a05:6808:a0a:b0:350:aae9:3c7 with SMTP id
+ n10-20020a0568080a0a00b00350aae903c7mr1764209oij.216.1664284203295; Tue, 27
+ Sep 2022 06:10:03 -0700 (PDT)
+MIME-Version: 1.0
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Tue, 27 Sep 2022 16:09:52 +0300
+Message-ID: <CAFVMu-rJk0fyAMpvWRN60r38bELu5Oq1orM6-8aARKY0zyOvBQ@mail.gmail.com>
+Subject: bazel-zig-cc v1.0.0-rc1
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 744
+Lines: 19
+
+Hi all,
+
+I just cut bazel-zig-cc v1.0.0-rc1. Big release:
+
+- use relative paths for tools. We hope this will make builds (more)
+reproducible and un-bust our remote cache hit rates.
+- you may have noticed zig_sdk is being "downloaded" ~10 times on some
+occasions. No longer.
+
+We are in final testing & acceptance phase to use bazel-zig-cc for all
+CGo at Uber's Go Monorepo. We may have a couple more RCs.
+
+Note: this release temporarily breaks Windows support; I will wait for
+a couple of days for Fabian's patch to port [1] before cutting v1.0.0.
+
+This release includes code from Motiejus Jak=C5=A1tys and Ken Micklas with
+close collaboration of Laurynas Lubys.
+
+[1]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/35627
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f51.google.com (mail-oa1-f51.google.com [209.85.160.51])
+	by mail-b.sr.ht (Postfix) with ESMTPS id B00F111EE05
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 27 Sep 2022 13:59:55 +0000 (UTC)
+Received: by mail-oa1-f51.google.com with SMTP id 586e51a60fabf-1319573379eso516462fac.0
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 27 Sep 2022 06:59:55 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=content-transfer-encoding:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:from:to:cc:subject:date;
+        bh=NWWaL96khLWrFeuHEpCKFpO9Uk7PENGUdwLiys4kvek=;
+        b=MZk/b8eFw/uDRuWxXvOvxAc7wzeE/Zs0s7ACPE3TfGR+F/ysSOwL0W6PbQrJEQn5Cp
+         mV5CG+Tpp6slfXS+MDStcdYcSJ0o3Smd3m1r1k6tQbmLuUI0v8Mp03i8t8isekhl1DGJ
+         Bighdzoi0hANgz/IQuQfII7m3qVvgM9ab+O2Bw448FLkaczQTSWkRriGQc9HsQNvlFWR
+         QoWCcMgsrDCsUqutAMh2CowNUE4souwv5Z2ITaj7YRm1RJsBOs4IfDKqvxDTp4oRTGUL
+         8B0FLvnBcAXG+ItvvRL167CJ8TiaL8/w6LqIqqJ4/Ji5cEZV6lAvzvXwqw/wTM1BmECB
+         24QQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=content-transfer-encoding:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:x-gm-message-state:from:to:cc
+         :subject:date;
+        bh=NWWaL96khLWrFeuHEpCKFpO9Uk7PENGUdwLiys4kvek=;
+        b=qcj4YYjQA6EjwQeaSnBhtC+vJx2CTmBRBLsHJFQQf2xZKiA0uF8yTCMbl9hIuSxEdZ
+         WcUic5zYj6X+TZcTUVsfwgewlM8ehhVTYYPe19vC3R9fetHMKToDTuWQP5rwd7Najkjn
+         sj+wM7cZ4L4QHOfdsexzbwhHRwdLnNJkKihyv0RYhfPxuG2WrOX+bez3SCeXSzvQGn8Y
+         hOiI3E5FqvvGAPYtSkwzxdj9kmCzUWlbFw6JGk6AxJDcc/DTv6FSLpSh0LaXes/f4bqp
+         wXw2Syew50khtOtMPqWpBLnqZEqUXJUGmDPNj/BWdgwGyCWvcsdXByNmBx2GES0j28H9
+         fVoA==
+X-Gm-Message-State: ACrzQf3rG+rHO88wr+NcwkJMcIpvcon18JYSH5DqhutT6SkLjebVw1iI
+	eAkpQ4fpNScDOdxyc9/Y3OF6nAtxGbJOLbylBYnN9gdU
+X-Google-Smtp-Source: AMsMyM7YB6TQn8UidRWDQ3wNHSOyeN7PEOLcW+39BBYx7LP28r1Fqxpuxp4VmkbVCABa073pkEiJHusiDEddl9cePOU=
+X-Received: by 2002:a05:6870:b14f:b0:127:d4f1:6a90 with SMTP id
+ a15-20020a056870b14f00b00127d4f16a90mr2276361oal.116.1664287195035; Tue, 27
+ Sep 2022 06:59:55 -0700 (PDT)
+MIME-Version: 1.0
+References: <CAFVMu-rJk0fyAMpvWRN60r38bELu5Oq1orM6-8aARKY0zyOvBQ@mail.gmail.com>
+In-Reply-To: <CAFVMu-rJk0fyAMpvWRN60r38bELu5Oq1orM6-8aARKY0zyOvBQ@mail.gmail.com>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Tue, 27 Sep 2022 16:59:43 +0300
+Message-ID: <CAFVMu-oQC8e=7cJJLvdM5q8WtnDEChogsX3coJPvUoi7d3pbCg@mail.gmail.com>
+Subject: Re: bazel-zig-cc v1.0.0-rc1
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 318
+Lines: 9
+
+On Tue, Sep 27, 2022 at 4:09 PM Motiejus Jak=C5=A1tys <motiejus@jakstys.lt>=
+ wrote:
+> - use relative paths for tools. We hope this will make builds (more)
+> reproducible and un-bust our remote cache hit rates.
+
+Quick update: bazel-zig-cc v1.0.0-rc1 does not mess up the remote
+cache keys. Jackpot!
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 5F91511EEE2
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 28 Sep 2022 16:38:28 +0000 (UTC)
+From: Fabian Hahn <fabian@hahn.graphics>
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1664383103;
+	bh=nZiSsi4a3L6utKl+cvx5mUU11oQlCVQAM3bzccuOFVo=;
+	h=From:To:Cc:Subject;
+	b=M687vJMugshPLNlJ3uk9sTKN0OjwjA4V9RxcfwWFLVMMo3XRBWvvLJD9tvvXY5ion
+	 ngnILZc79nqqiNkdB7IribEbiFRBjWL8xxDgExPzMlHXEK90Lv2V+sWbN/dXgs0jq0
+	 P51I+qtrArEKXAk2PiFDkl6vIjiW9vHATxwuB0o0=
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Fabian Hahn <fabian@hahn.graphics>
+Subject: [PATCH bazel-zig-cc] fix Windows host support with relative paths
+Date: Wed, 28 Sep 2022 17:38:11 +0100
+Message-Id: <20220928163811.4756-1-fabian@hahn.graphics>
+Mime-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Status: O
+Content-Length: 1450
+Lines: 43
+
+v1.0.0-rc1 indeed broke Windows host support, but it was trivial to fix.
+Also, the massive speedups gained from bazel not redownloading zig
+multiple times more than made up for it, this was actually way worse on
+Windows than I've ever experienced it to be on Linux (could take up to
+10 minutes on first bazel run...). Also very cool to see that we're now
+friendly to remote caches. Fantastic work everyone!
+
+I've tested v1.0.0-rc1 with my minimal patch below on Windows and
+everything is working fine. If we can add this then from my side v1.0.0
+is good to go. Nice milestone indeed.
+
+Best,
+Fabian
+
+---
+ toolchain/defs.bzl | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 0aba0fb..487271f 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -93,15 +93,15 @@ _ZIG_TOOLS = [
+     "wasm-ld",  # WebAssembly
+ ]
+ 
+-# TODO: ZIG_LIB_DIR equivalent in powershell?
+ _ZIG_TOOL_WRAPPER_WINDOWS_CACHE_KNOWN = """@echo off
++set ZIG_LIB_DIR=external\\zig_sdk\\lib
+ set ZIG_LOCAL_CACHE_DIR={cache_prefix}\\bazel-zig-cc
+ set ZIG_GLOBAL_CACHE_DIR=%ZIG_LOCAL_CACHE_DIR%
+ "{zig}" "{zig_tool}" %*
+ """
+ 
+-# TODO: ZIG_LIB_DIR equivalent in powershell?
+ _ZIG_TOOL_WRAPPER_WINDOWS_CACHE_GUESS = """@echo off
++set ZIG_LIB_DIR=external\\zig_sdk\\lib
+ if exist "%TMP%\\*" goto :usertmp
+ set ZIG_LOCAL_CACHE_DIR=C:\\Temp\\bazel-zig-cc
+ goto zig
+-- 
+2.25.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=zczVT4eRYBkbCSg5ecsE3BwZfMagCqVvV0rebt+AFo8=;
+ c=simple/simple; d=sr.ht; h=Date:From:In-Reply-To:Subject:To:Cc;
+ q=dns/txt; s=srht; t=1664386011; v=1;
+ b=f+i6LUFuTw2PexTQo+vzq4G4ddTeyzGRGicT2E6Yx8OhjuDvjAHLt6NZl6ccv/E0Y+ZTM4Lb
+ AwAGJvQLwobFb3uvIAPriSI29NlMQ6QvuzefnApcbw32xK8vUmNMJNClpjaELU+JPai8TtudRPk
+ emwPtEdXOSo04vyDt46XQ73L5EZw2PYzXmSalATPCRR++p1Ocl2Z5NWOmmGGLmCWrrZsPIybWZi
+ y3uAFuyrd+RMWYPWBoM5z+Y+EnNI1LjPaorU5Gfhrewi66iW+CmwdRB2jJQn2MAIQH7kuIkGQs3
+ cVhjfR4A3dlYJce3AFeiG6A2fkTm5B/Zd6qcRvje8LXLg==
+Received: from localhost (unknown [173.195.146.244])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id 9F85C11EEE2;
+	Wed, 28 Sep 2022 17:26:51 +0000 (UTC)
+MIME-Version: 1.0
+Date: Wed, 28 Sep 2022 17:26:51 +0000
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CN87LM5GVCV9.1WLSUUR9B74UH@cirno2>
+In-Reply-To: <20220928163811.4756-1-fabian@hahn.graphics>
+Subject: [bazel-zig-cc/patches/.build.yml] build success
+To: "Fabian Hahn" <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 332
+Lines: 9
+
+bazel-zig-cc/patches/.build.yml: SUCCESS in 48m21s
+
+[fix Windows host support with relative paths][0] from [Fabian Hahn][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/35663
+[1]: mailto:fabian@hahn.graphics
+
+=E2=9C=93 #852370 SUCCESS bazel-zig-cc/patches/.build.yml https://builds.sr=
+.ht/~motiejus/job/852370
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f43.google.com (mail-oa1-f43.google.com [209.85.160.43])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 88C0911F04E
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 28 Sep 2022 17:39:05 +0000 (UTC)
+Received: by mail-oa1-f43.google.com with SMTP id 586e51a60fabf-12803ac8113so18209645fac.8
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 28 Sep 2022 10:39:05 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:from:to:cc:subject:date;
+        bh=qaL7GGgrR6+LcB0nMfuv/XEGqUKAHZzfsHSfMqGiWXE=;
+        b=eXrwPluflVBoDQ8RN8qoNycAWWLxip4VFTn3nNdg3RhcH32QxcPIfN+OpDpoEIn7hL
+         lrWggIdq+JKQtcEKD6lF4ohCRWR94919NDrkDcuKDrnQBBTjn+fEXDkai477DWYELmo0
+         FHcvcyxo/oERnWirkpdNVZL6W0x4k5BYmMTrplBlMcUz1DWUKimbXUunM1zE5U4aYRkG
+         rtqDlFJJ4fZUZz5QucmGwrrIzDEdhw66qvBknSWGW50tpTqhkYsjcvwJZ7MqLA7osROc
+         EBUkXRADzN4VNke/T/9AlSW73IiCDplJsXxltuUe4VBVFG09WTeIKfhR6HxU6AmzcOfm
+         qcFg==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:x-gm-message-state:from:to:cc:subject:date;
+        bh=qaL7GGgrR6+LcB0nMfuv/XEGqUKAHZzfsHSfMqGiWXE=;
+        b=iEJeq4KuP50j9+Ijpgj1x5mTQPmhvCofRHB0trc6HrEtakvTcIL8M9+oPgszHaXUik
+         d0tUCnm1b2lDhq1C4uQcYAxbY5/XPJfRvyNZi3e0gD8C+30X6ywSvAkf47o8Ffu0AwSK
+         tzUWSKWNhnuF+PBRixPCCPLx4yYUYIYfZYROydL05geGAJ8yHlJB8ki/VZvygn5+Wu61
+         muBB7HMY4kdX+xAdGGhOvQPHox6wdM9iVk6Y2bHKlvKhmswqbaHov3WfvzaM4lvlJW+a
+         +vL7JrezdUU/gV+elrGD31w+gEk0M870NPa35GHwU4vgf2t/bcev5UNWavEQmX2VsXb/
+         nRmw==
+X-Gm-Message-State: ACrzQf1GU4gH+Sqq9tffb/lJvnChsHF16rmZb6Ewr65mXRXqPAYvcLnR
+	VYVQ5oIdAF0otitS1gkgHcJXxqhhGK5G6O+7Pe9PnRR0Nc0=
+X-Google-Smtp-Source: AMsMyM7EB2jI2qFrXCD1EBpbBcLzGml3gRTiF9f+ChdDLkQsDlvXCh/8E5lZL+Z9HmR4KQjEPTFtjK3W3sXngLkkD9I=
+X-Received: by 2002:a05:6870:b14f:b0:127:d4f1:6a90 with SMTP id
+ a15-20020a056870b14f00b00127d4f16a90mr5958396oal.116.1664386744779; Wed, 28
+ Sep 2022 10:39:04 -0700 (PDT)
+MIME-Version: 1.0
+References: <20220928163811.4756-1-fabian@hahn.graphics>
+In-Reply-To: <20220928163811.4756-1-fabian@hahn.graphics>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Wed, 28 Sep 2022 20:38:53 +0300
+Message-ID: <CAFVMu-q_du=CzkUKd_0-Wufh6WiU4+mSBBG7g=F-i_5p1XqOwg@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc] fix Windows host support with relative paths
+To: Fabian Hahn <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 997
+Lines: 33
+
+Hi Fabian,
+
+On Wed, Sep 28, 2022 at 7:38 PM Fabian Hahn <fabian@hahn.graphics> wrote:
+> diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+> index 0aba0fb..487271f 100644
+> --- a/toolchain/defs.bzl
+> +++ b/toolchain/defs.bzl
+> @@ -93,15 +93,15 @@ _ZIG_TOOLS = [
+>      "wasm-ld",  # WebAssembly
+>  ]
+>
+> -# TODO: ZIG_LIB_DIR equivalent in powershell?
+>  _ZIG_TOOL_WRAPPER_WINDOWS_CACHE_KNOWN = """@echo off
+> +set ZIG_LIB_DIR=external\\zig_sdk\\lib
+>  set ZIG_LOCAL_CACHE_DIR={cache_prefix}\\bazel-zig-cc
+>  set ZIG_GLOBAL_CACHE_DIR=%ZIG_LOCAL_CACHE_DIR%
+>  "{zig}" "{zig_tool}" %*
+
+See the logic of Linux:
+
+if [ -d external/zig_sdk/lib ]; then
+    export ZIG_LIB_DIR=external/zig_sdk/lib
+else
+    export ZIG_LIB_DIR="$(dirname "$0")/../lib"
+fi
+
+It should set ZIG_LIB_DIR to external/zig_sdk/lib iff the directory
+exists. It may not exist if build tools change working directory
+before invoking zig cc. Hello Go!
+
+Can you update the patch to add this?
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 6588111F050
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 28 Sep 2022 18:58:29 +0000 (UTC)
+From: Fabian Hahn <fabian@hahn.graphics>
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1664391505;
+	bh=59+Xlj3WvqBwGrjjA1jXOHljOQCjh53DEv6XJpf5vPk=;
+	h=From:To:Cc:Subject;
+	b=GDy89IkCKUV/lFMnjtwZMdxoPWh5IkGPLMBFGcEgYSAcJxpexWxBbFQW2pPZqZdeN
+	 bspQgpbHeQCfsVz2tw6AmwfFO39bAjJUEL9DFeSkmBt4MOVVhSlIOuPoKU+6015sO4
+	 hNOPRu7U8s4OengLZV5V47oxDHrvTcgF0JKfQ+zo=
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Fabian Hahn <fabian@hahn.graphics>
+Subject: [PATCH bazel-zig-cc v2] fix Windows host support with relative paths
+Date: Wed, 28 Sep 2022 19:58:17 +0100
+Message-Id: <20220928185817.4406-1-fabian@hahn.graphics>
+Mime-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Status: O
+Content-Length: 1493
+Lines: 47
+
+---
+Fixed the Windows scripts to support changing working directories.
+Apologies for missing this, it didn't come up in my testing so I wasn't
+sure if would be needed and skipped it. It's a bit more complicated now
+than just adding a single line, but should still be fine.
+
+Best,
+Fabian
+
+ toolchain/defs.bzl | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 0aba0fb..284d2fe 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -93,15 +93,25 @@ _ZIG_TOOLS = [
+     "wasm-ld",  # WebAssembly
+ ]
+ 
+-# TODO: ZIG_LIB_DIR equivalent in powershell?
+ _ZIG_TOOL_WRAPPER_WINDOWS_CACHE_KNOWN = """@echo off
++if exist "external\\zig_sdk\\lib\\*" goto :have_external_zig_sdk_lib
++set ZIG_LIB_DIR=%~dp0\\..\\lib
++goto :set_zig_lib_dir
++:have_external_zig_sdk_lib
++set ZIG_LIB_DIR=external\\zig_sdk\\lib
++:set_zig_lib_dir
+ set ZIG_LOCAL_CACHE_DIR={cache_prefix}\\bazel-zig-cc
+ set ZIG_GLOBAL_CACHE_DIR=%ZIG_LOCAL_CACHE_DIR%
+ "{zig}" "{zig_tool}" %*
+ """
+ 
+-# TODO: ZIG_LIB_DIR equivalent in powershell?
+ _ZIG_TOOL_WRAPPER_WINDOWS_CACHE_GUESS = """@echo off
++if exist "external\\zig_sdk\\lib\\*" goto :have_external_zig_sdk_lib
++set ZIG_LIB_DIR=%~dp0\\..\\lib
++goto :set_zig_lib_dir
++:have_external_zig_sdk_lib
++set ZIG_LIB_DIR=external\\zig_sdk\\lib
++:set_zig_lib_dir
+ if exist "%TMP%\\*" goto :usertmp
+ set ZIG_LOCAL_CACHE_DIR=C:\\Temp\\bazel-zig-cc
+ goto zig
+-- 
+2.25.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=um/H94u9uG3jiKqtK6opec6OVER4+3uYUPAM2kq5ODw=;
+ c=simple/simple; d=sr.ht; h=Date:Subject:To:Cc:From:In-Reply-To;
+ q=dns/txt; s=srht; t=1664394340; v=1;
+ b=jEz6APX7utEsOBPp/her0yUMV08BU8gMARGXiM8M3NDCfZ6uBEINLca0xz96FxajKcFIKGUB
+ 0GD65sDJb3X42LDaBOImfDq9/TKcroDs+4+a2EZJD1e7vn/mG2qWq9SHVGcQfXqlX/CYfalTS0l
+ 6Vpwrbo0u2wn1VMWEDGpCMen94GyQq9L+MIbh2oGUWcn/xJzfX7b3VxIq1u4aw9xWHOhqId8KXR
+ 7hYPySwIFlpII/MrS0Cho3tTzrAGH2B46uNkPPetHJNNs0i5Z/6XVl78asFEy/AGaBnCb8vZWNN
+ LZCETsLwpCU7/MBqbGqQt4KgrTSepTGxcXWvQX/hLmilA==
+Received: from localhost (unknown [173.195.146.249])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id 490A011F050;
+	Wed, 28 Sep 2022 19:45:40 +0000 (UTC)
+MIME-Version: 1.0
+Date: Wed, 28 Sep 2022 19:45:40 +0000
+Subject: [bazel-zig-cc/patches/.build.yml] build success
+To: "Fabian Hahn" <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CN8AJW90THKD.PFIGC78CGNGR@cirno>
+In-Reply-To: <20220928185817.4406-1-fabian@hahn.graphics>
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 334
+Lines: 9
+
+bazel-zig-cc/patches/.build.yml: SUCCESS in 47m9s
+
+[fix Windows host support with relative paths][0] v2 from [Fabian Hahn][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/35674
+[1]: mailto:fabian@hahn.graphics
+
+=E2=9C=93 #852447 SUCCESS bazel-zig-cc/patches/.build.yml https://builds.sr=
+.ht/~motiejus/job/852447
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oi1-f170.google.com (mail-oi1-f170.google.com [209.85.167.170])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 1A38711F0DA
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 29 Sep 2022 08:33:40 +0000 (UTC)
+Received: by mail-oi1-f170.google.com with SMTP id d64so889810oia.9
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 29 Sep 2022 01:33:40 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:from:to:cc:subject:date;
+        bh=k7f3v35257wecXHbrge3h66zdPnddoPFCoZyYUDOQ1k=;
+        b=oO4xAYm6SaxOJgUtCA93CRdnbs8ChGaXjMhWgV4pCxN0Om0960N26OcnzmN/OYlSOE
+         CMcBE75sKFrQFSDH1JDHmIhGJE1H7mo39A1FmMCGa6sSkl+KmUvgJi001Fp8P2hgTYJh
+         hj7cPJ/1PlBWgqjijx1F1dICLtDhC6vmkw/y6wOipGy1hO2RTTTYDvekd2mzeRZBGgYD
+         p3w/w8tfbbh0rPnM2M86o4pBfy9sTEtxb4K4DSZRYTihrF2i68J6wzH2tfJz99kiBfUD
+         UO+WlHP6w7KAzau5+exqOUuI60dj+QrpHfIa9t1Gf2bRvPYahi0cPqPK89gncHGp3WD9
+         nRqA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:x-gm-message-state:from:to:cc:subject:date;
+        bh=k7f3v35257wecXHbrge3h66zdPnddoPFCoZyYUDOQ1k=;
+        b=WdVqoLIn3o9yV1kfcz0GWlVao2nbzYJiHlKDQyMBoXfvbE25If+/boS0/Av/ADZSTb
+         /i+YV12/F+eKPP9BbmeZGxZqvIUrespDSJpH0TXtY8yrUvC+k60m8/E3gtCTPh+suace
+         735Y4xOXmSQLT+rgwD6q+jhqdXmVuUDMJGQWk85Ym+qrR1Nsjrl5MoFVXU2j7nWOKjyh
+         wBm/NUXKns0fvK9JTtK6RNo66RnmfJvJnYdRczMQvJ0ZOpkRXROx/KHHZMRTfUanrIlS
+         HkdmT4TFdy6C0wG0O8VT/3r5dLBIQSEP9UluRkpWvUGJZPfmlLR16kaf1dcQFmmdmmTf
+         7J/A==
+X-Gm-Message-State: ACrzQf0FHA8iDvttJTHFqSMc7YH74QX2b7jfUnUKEIAyL6Eb1dXROkwQ
+	tyr23T0VtCUPecwsXNxhiRuyBGKNRlUNcdTqID9F9eS5
+X-Google-Smtp-Source: AMsMyM61D9h+aah20DtTQqLfSoKZsIYE8ReLUtOWgG+nolYSqPdkD11wuDCN1t1K4b/bnSCVmkNRpvB2zYsgLcGyiJo=
+X-Received: by 2002:a05:6808:a0a:b0:350:aae9:3c7 with SMTP id
+ n10-20020a0568080a0a00b00350aae903c7mr6316454oij.216.1664440419323; Thu, 29
+ Sep 2022 01:33:39 -0700 (PDT)
+MIME-Version: 1.0
+References: <20220928185817.4406-1-fabian@hahn.graphics>
+In-Reply-To: <20220928185817.4406-1-fabian@hahn.graphics>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Thu, 29 Sep 2022 11:33:28 +0300
+Message-ID: <CAFVMu-rRSm9cm1o-h2V-=U53tDAaaV6TOzrRTPw5bkwCDB+H1A@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc v2] fix Windows host support with relative paths
+To: Fabian Hahn <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 445
+Lines: 15
+
+On Wed, Sep 28, 2022 at 9:58 PM Fabian Hahn <fabian@hahn.graphics> wrote:
+>
+> ---
+> Fixed the Windows scripts to support changing working directories.
+> Apologies for missing this, it didn't come up in my testing so I wasn't
+> sure if would be needed and skipped it. It's a bit more complicated now
+> than just adding a single line, but should still be fine.
+>
+> Best,
+> Fabian
+>
+
+Thanks! Applied and tagged v1.0.0-rc2.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f44.google.com (mail-oa1-f44.google.com [209.85.160.44])
+	by mail-b.sr.ht (Postfix) with ESMTPS id C420311EE64
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 25 Oct 2022 06:59:41 +0000 (UTC)
+Received: by mail-oa1-f44.google.com with SMTP id 586e51a60fabf-13b103a3e5dso14554672fac.2
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 24 Oct 2022 23:59:41 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=to:subject:message-id:date:from:mime-version:from:to:cc:subject
+         :date:message-id:reply-to;
+        bh=jf6+1+G0zOxE1rzJSq3uMSkjpwIdg2Fm/ARuAuCiiE4=;
+        b=sj+jKesr7+howUfNeubxE0bB9IUFuQxxluTnWHzeff0o+08+UCnMNLmWG72+sXVmkP
+         +MlRNCLIEXSSVxMKE4iIjPGeR0zHth7UdB4PBDUvkXht4aWV4F0k+gfTu/p8zIsUEBYQ
+         7vXg8z2ThTCvTouw18mWXi3cpz6BkNFEIwFueg7RTjJVMJis3tEkFlrAPaYc1s+ZvJqA
+         4FE6qyBOUsSRkwtW2ZCXy1sjoUjucLaa70BC0wgm8FOUifJsOzwbqi/7OgQVgBDMkOvc
+         OaTjqT9JUykT2iQwgE0guL4IgXVo38VU7IzLp9kqH9g0lCXwEKMuImwaeyxWd/sK44dq
+         Y6Hw==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=to:subject:message-id:date:from:mime-version:x-gm-message-state
+         :from:to:cc:subject:date:message-id:reply-to;
+        bh=jf6+1+G0zOxE1rzJSq3uMSkjpwIdg2Fm/ARuAuCiiE4=;
+        b=cj6+CZKAZkYDaXF9QCvhKKMPkfANCO7DBTOX0yI3naboW2N4+fBx3cLrkWCXC1LwAC
+         a/qCrgSBLJ0Rpz3ZH3YPjORgAdRgeCYpv9bA4GqoLXQetsrJdMIRWRu3zqbGsc3a7fDL
+         o51u7QxBJ6LoHjyImAN0OBh427553i8FBbIJQJHq8bYeLmjOfrzZroAwgzTsI9u63dTh
+         8Bk/Pq/+gKFtkP6Z/LNk2jzc+6ZDq9pwA5PvOQZMxRJcWMVwuz8k8NZirgwvTnkZ7gGx
+         gwDHnRMLC1i9SZ3CxzelkpAzkF8JzGOHUnMo8G4Aa9dUZP7JUxp4bKCzGwnX3ehQbxYD
+         Xelw==
+X-Gm-Message-State: ACrzQf0srv2JBlgd64+0eajB/2X28AvJjRCEPn8rttmla0CWzwei/ato
+	caiTAsXgy0FC0t7IMtLLTyFajDTdqgNGb+oForkiFKiLBcM=
+X-Google-Smtp-Source: AMsMyM5TjyvBNtJz9Ax7S9fwoo7wObkMbBFsB/CFIikXxDEGL7H3GyUMcavLzcmP/sjYDQRKi9enj8H241LqPOwyStI=
+X-Received: by 2002:a05:6870:6189:b0:13b:9640:6ed7 with SMTP id
+ a9-20020a056870618900b0013b96406ed7mr6496049oah.216.1666681180845; Mon, 24
+ Oct 2022 23:59:40 -0700 (PDT)
+MIME-Version: 1.0
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Tue, 25 Oct 2022 09:59:29 +0300
+Message-ID: <CAFVMu-oZUxT8fXH_JBFbmW+7yZDD3a4NiAZHHyZab4i6vKjGnQ@mail.gmail.com>
+Subject: what's cooking in bazel-zig-cc
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 941
+Lines: 24
+
+Hi folks,
+
+I made a few -rc releases and things went silent. Well, they are
+silent publicly, but I am very much working on v1.0.
+
+A few open tracks:
+- bazel-zig-cc is much slower than gcc/clang when building many small
+binaries. https://git.sr.ht/~motiejus/test-zigcc reproduces it whlist
+comparing to grailbio/bazel-toolchain.
+- relative ZIG_LIB_DIR does not work correctly in zig, tracked in
+https://github.com/ziglang/zig/issues/13050 ; currently bazel-zig-cc
+ships a forked version which includes #13051 (created using
+https://git.sr.ht/~motiejus/bazel-zig-cc/tree/main/item/contrib/README-patched.md
+).
+- rare race in zig when building glibc stubs:
+https://github.com/ziglang/zig/issues/13160
+
+I am currently narrowing down (1), so I can remove Bazel out of the
+picture and engage ZSF. The other two have been escalated to ZSF under
+Uber's support contract and we are awaiting resolution.
+
+Hold tight!
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=mobileink-com.20210112.gappssmtp.com header.i=@mobileink-com.20210112.gappssmtp.com
+Received: from mail-qt1-f178.google.com (mail-qt1-f178.google.com [209.85.160.178])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 1A22211EE04
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu,  3 Nov 2022 14:40:48 +0000 (UTC)
+Received: by mail-qt1-f178.google.com with SMTP id l2so1307345qtq.11
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Thu, 03 Nov 2022 07:40:48 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=mobileink-com.20210112.gappssmtp.com; s=20210112;
+        h=to:subject:message-id:date:from:mime-version:from:to:cc:subject
+         :date:message-id:reply-to;
+        bh=jMlACLQlu7KNgsKUE+rAK6IghqNSJfYH0RjdLmrVNwc=;
+        b=F2ymHMAxYPTHHVkddf1RkYcUru30i438IKnogOhgx2PGeka9QhYCwxcKE3yvRLIRKr
+         bfvND/PoBnF4w7K/abneF32frSEikuiZOt+6JUhGEqu+2pd1xdjth9QRyJn0NvqVd3/Z
+         jJXRgVGUWi5gCU10aUN36Jps4fCYsm/3v1q6X+FAcUopVc1JEdmEurJ/WKisCHb6Fo8m
+         JAV51wEL3FMzcpEtpDAf9b2iuBtz7I09fcNWKws8zmGpr1Mfy8QG3wN1prlxvs17Tp15
+         zJOh54um2C/Si1tenjoB9ihvN1F9kyIWfYb7LFAludP+PYwzRYKieW28cT6zjMETFxzC
+         uy8g==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=to:subject:message-id:date:from:mime-version:x-gm-message-state
+         :from:to:cc:subject:date:message-id:reply-to;
+        bh=jMlACLQlu7KNgsKUE+rAK6IghqNSJfYH0RjdLmrVNwc=;
+        b=UqANvCs1u4CAS9LDAK7q7Ed180Ay/+s94PMhOyz8l8kd9sNg224oyjotx/Z3hWQGCx
+         +3uH8Ii3p3aYrGBLMDWRGdXQx1ZVIhPK4uOicz2BVzHCwqAOjpGihok/ECWSy+gmGGEd
+         naRttCdFk3s6tCwmQlo28iYI0j0WdPW85vXOHpdCVnYxYYWZMkWBU7oUNrWNtuenPNaJ
+         4dob33dcBlL/eDTuwS17roLpdBJUUn1v4K1+gvkwvR9Pty90aXd4/jQ4h1N5EwROurJX
+         6k+FLIURrCGxFD9RwbJLnEn3icCkRPitC9GGZeP9fQctRSsnviCyii4niJwDFzmf/WQh
+         lpqA==
+X-Gm-Message-State: ACrzQf3ZfOBmkT+fii0fDskzZ8ftnqiI1+8ZTRUYQq1I9syjGSXHHCHT
+	PCT0q4D/Hi3vD9X7KZEERUCYBCzU7Yb5jIZm/Sayq7c62RqwmQ==
+X-Google-Smtp-Source: AMsMyM76BEOgp5tc15OQJxZrOL5rdJVe+f2RYvMfomhNJDZ6Ou3PzaBOOjdiHblfE6Q+cfyC6LCNsZYU0M8y/NaxeQQ=
+X-Received: by 2002:ac8:1102:0:b0:3a5:3f57:ebeb with SMTP id
+ c2-20020ac81102000000b003a53f57ebebmr10605975qtj.59.1667486447325; Thu, 03
+ Nov 2022 07:40:47 -0700 (PDT)
+MIME-Version: 1.0
+From: Gregg Reynolds <dev@mobileink.com>
+Date: Thu, 3 Nov 2022 09:40:36 -0500
+Message-ID: <CAO40MinKZyYCg3xBgJR0_70zrBxctm81pbYtwyg=UJ9fYTFdmw@mail.gmail.com>
+Subject: v1.0.0-rc1 fail on mac: stddef.h not found
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 1492
+Lines: 49
+
+First off: bazel-zig-cc is awesome, thanks so much!
+
+Second: I tried to send this via the mailing list 'new post' button
+and from gmail but both were rejected because they contain html.
+Recommend you find a friendlier mailing list manager.
+
+In any case here's the error:
+
+runtime/caml/config.h:51:10: fatal error: 'stddef.h' file not found
+#include <stddef.h>
+         ^~~~~~~~~~
+
+Selected tc:
+
+INFO: ToolchainResolution: Target platform
+@local_config_platform//:host: Selected execution platform
+@local_config_platform//:host, type
+@bazel_tools//tools/cpp:toolchain_type -> toolchain
+@zig_sdk//:x86_64-macos-none_cc
+
+Compile cmd:
+
+  external/zig_sdk/tools/c++ -MD -MF
+bazel-out/host/bin/runtime/_objs/sak.exe/sak.d
+'-frandom-seed=bazel-out/host/bin/runtime/_objs/sak.exe/sak.o'
+'-DCAMLDLLIMPORT=' -DIN_CAML_RUNTIME -iquote . -iquote
+bazel-out/host/bin -iquote external/bazel_tools -iquote
+bazel-out/host/bin/external/bazel_tools
+-Ibazel-out/host/bin/runtime/caml/_virtual_includes/hdrs -target
+x86_64-macos-none -no-canonical-prefixes -Wno-builtin-macro-redefined
+'-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"'
+'-D__TIME__="redacted"' -O2 -DNDEBUG -g0 -fno-strict-aliasing -fwrapv
+-pthread -Wall -Werror -fno-common -c runtime/sak.c -o
+bazel-out/host/bin/runtime/_objs/sak.exe/sak.o)
+
+System:
+
+$ sw_vers
+ProductName: macOS
+ProductVersion: 12.6
+BuildVersion: 21G115
+
+$ xcodebuild -version
+Xcode 14.1
+Build version 14B47b
+
+Thanks,
+
+Gregg
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lf1-f54.google.com (mail-lf1-f54.google.com [209.85.167.54])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 0938D11EEE2
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri,  4 Nov 2022 19:22:51 +0000 (UTC)
+Received: by mail-lf1-f54.google.com with SMTP id b3so8689903lfv.2
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 04 Nov 2022 12:22:50 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=in-reply-to:content-disposition:mime-version:references:message-id
+         :subject:cc:to:from:date:sender:from:to:cc:subject:date:message-id
+         :reply-to;
+        bh=cYx3yJ/RDDFOSuaADVZfbpxRd8e1fxtTE0tODqcXZvY=;
+        b=l5h3FzQReJw0YY+o5aN9B1W73hto4wvBwHA9uqTpO+Rqxz/fi6EphKCKj1O/C2AW6m
+         FXylGQ3v9wTrwAAnQo4J5OJcvyFMSoN4gsZdkmmLpYSevg/kEr0bQq0+OEcfnclkkOkL
+         xfiWacTxR815RlINVd78QfXOXEHtSNVcSe9NohKcKrOpS2caid1eD6zaJIALtTFMT/SJ
+         QdYmgxQW3tfQMvnTLLhrJTU30bYaAtDpi3D6ny+zMcrogdvhukciyfYeraqCUo140DeK
+         S6JiBgMgIBMv1/q/NB1mZZgK6pdTS/zG2WZgk4b7l03a6RKAZ9qIeROwENBYTpg8pi6u
+         8n5A==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=in-reply-to:content-disposition:mime-version:references:message-id
+         :subject:cc:to:from:date:sender:x-gm-message-state:from:to:cc
+         :subject:date:message-id:reply-to;
+        bh=cYx3yJ/RDDFOSuaADVZfbpxRd8e1fxtTE0tODqcXZvY=;
+        b=AsHMt4/q2cUf6b5jUTlmJ1R+XxvH7sy6tdbTWyySgub0ETTBslvliJf6HssZ4a+STw
+         rcLKvpfbbmxUUfKddXF8XDGgLp7QzRkWvfivlpi1uTzWPcOAf2RekO6QEm3SvDUOn8PS
+         fogoM0R82WwwOM4n3wYjWDPQzRnM8SPjc2TSnZBkwlRwgtu6LwfWFZgqUWrjHaUkvVvy
+         ahS/5jK7dLvV1XSshXTcPb4UcMy24h/HDgXBy+uDgeh8Jy1JdszsaTVQhQAejHI4qOtK
+         ES58jZ5Di/Jw8IE62MEy31BhKqQp7hIMaHhEWwBhQloDy0bwnHYakA+/W9VRivS6brg4
+         9wsQ==
+X-Gm-Message-State: ACrzQf2UsKjdvUskZmJrzDNJnP8dbr+0y7sZe913fc1mn8J5vMisU1jK
+	/KNTHpM7Cy3IxQu4bA9vpFdNS12Yd18=
+X-Google-Smtp-Source: AMsMyM6bqv/PdYuL2wSI9D/WIfaFf9BCRCxNpBwSX5Zco6vmH5ggQJE5zkIYl/shrimNCgdPoH8/0w==
+X-Received: by 2002:a05:6512:3052:b0:4a2:67f0:eaaf with SMTP id b18-20020a056512305200b004a267f0eaafmr15048363lfb.34.1667589769360;
+        Fri, 04 Nov 2022 12:22:49 -0700 (PDT)
+Received: from localhost (m90-131-45-252.cust.tele2.lt. [90.131.45.252])
+        by smtp.gmail.com with ESMTPSA id i14-20020a2ea22e000000b0026e8dd02eacsm44358ljm.16.2022.11.04.12.22.46
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Fri, 04 Nov 2022 12:22:48 -0700 (PDT)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Fri, 4 Nov 2022 21:22:44 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: Gregg Reynolds <dev@mobileink.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: Re: v1.0.0-rc1 fail on mac: stddef.h not found
+Message-ID: <20221104192244.r53ifvwhbnyuughu@mtmine.i.jakstys.lt>
+References: <CAO40MinKZyYCg3xBgJR0_70zrBxctm81pbYtwyg=UJ9fYTFdmw@mail.gmail.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+In-Reply-To: <CAO40MinKZyYCg3xBgJR0_70zrBxctm81pbYtwyg=UJ9fYTFdmw@mail.gmail.com>
+Status: O
+Content-Length: 886
+Lines: 26
+
+On Thu, Nov 03, 2022 at 09:40:36AM -0500, Gregg Reynolds wrote:
+> First off: bazel-zig-cc is awesome, thanks so much!
+
+Hi, thanks!
+
+> Second: I tried to send this via the mailing list 'new post' button
+> and from gmail but both were rejected because they contain html.
+> Recommend you find a friendlier mailing list manager.
+
+bazel-zig-cc is planned to move to github.com/uber ; timelines are
+unknown yet though. Will update this list when I have more details.
+
+> In any case here's the error:
+> 
+> runtime/caml/config.h:51:10: fatal error: 'stddef.h' file not found
+> #include <stddef.h>
+>          ^~~~~~~~~~
+
+Please use v0.9.2, the one that's recommended in the README. 1.0.0-rc
+versions are known to have bugs. See my earlier posts in this mailing
+list.
+
+I will ping here separately when I will need extra hands testing v1.0.
+It's not ready yet.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=mobileink-com.20210112.gappssmtp.com header.i=@mobileink-com.20210112.gappssmtp.com
+Received: from mail-qv1-f47.google.com (mail-qv1-f47.google.com [209.85.219.47])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 5902311EF1B
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri,  4 Nov 2022 21:10:51 +0000 (UTC)
+Received: by mail-qv1-f47.google.com with SMTP id mi9so4024206qvb.8
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 04 Nov 2022 14:10:51 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=mobileink-com.20210112.gappssmtp.com; s=20210112;
+        h=content-transfer-encoding:cc:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:from:to:cc:subject:date
+         :message-id:reply-to;
+        bh=wwFDZqdO3rtoRHVwu4ZKuKsRuY8F7ZOEiEjtfPOftmw=;
+        b=CbgFEisgIrTS2Vv3iefgihY1xKWkOVX+eecol7d5bDFygdOZG0jfIRVCymHF4x7hkQ
+         gcL5F+5dX3ZYmP0fZYK+dkwhQa0XRMNxF7oRiBybFm47ReHMCAgtLoKf9FTCpgizg3fi
+         Bd8z/PQRUu/RTLrwpG5MwdFdJRqSVL6h4wR1VNc9bvj4S1t9tGvR/FE/8aEHf2v806Yt
+         3+m5RJLscKN+4ip7faecSnTC6EuDygD26UpftaeSm3KyRciynfTk095JCmGpBrk4WJ4W
+         pXhzvZhGuLZjlaHmUSUaQZaUVCVvJP3UCwdRqlWfr4pIQicsKlU2yhavqjnNLSl2Uzz0
+         eC7w==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=content-transfer-encoding:cc:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:x-gm-message-state:from:to:cc
+         :subject:date:message-id:reply-to;
+        bh=wwFDZqdO3rtoRHVwu4ZKuKsRuY8F7ZOEiEjtfPOftmw=;
+        b=pkqQqN+V+98+H5TdMtgf7egLO4iSKs7WX/PTaKsTp3R0n8aKwT1w1AzNC7JivO2DT6
+         WAPeW38jeVrD25w1LyLCFBCzg8AV+BrdC8P8jVzWtXHCnRqKsyGR4D8/r8oWUthVlUy/
+         bxhyoxOQcy50/bnjEzBFDZwgp2LoVH/uSM6zmeXmTLPhtYmsFFuBuJXVI9zksxfw1stP
+         FQdqPD7QWK89IQeXXOn6Dbhv3UI0lyBhpg7aAiLHzcBrIa8AnRDlgv6Qoy/Aa5LCmwF9
+         ol9CN3nLbswtf7Xkkf4hbd00UQ8SOuNiy6Ct0dptkdwTrxegnqIsRzqDNjoZ/aGPz5Sf
+         Zhag==
+X-Gm-Message-State: ACrzQf2U/N/7KTmcljCd5C0WLX+6B25mA8Tc+HHRzWcaNTonRv3HrLUM
+	FTHQwBIof+Dmd0Lo+qdVKUrKra2Is+5IHr8EG0FH1VL/z6A=
+X-Google-Smtp-Source: AMsMyM71d61IaU1620tQveHTo6060ovqlBWYOOv540Q8FClBcWmvoniSa2G555UJR0X0M3IEvQRAXEuLk95rocrZsiM=
+X-Received: by 2002:a05:6214:4104:b0:4af:8576:e65a with SMTP id
+ kc4-20020a056214410400b004af8576e65amr34416169qvb.70.1667596250793; Fri, 04
+ Nov 2022 14:10:50 -0700 (PDT)
+MIME-Version: 1.0
+References: <CAO40MinKZyYCg3xBgJR0_70zrBxctm81pbYtwyg=UJ9fYTFdmw@mail.gmail.com>
+ <20221104192244.r53ifvwhbnyuughu@mtmine.i.jakstys.lt>
+In-Reply-To: <20221104192244.r53ifvwhbnyuughu@mtmine.i.jakstys.lt>
+From: Gregg Reynolds <dev@mobileink.com>
+Date: Fri, 4 Nov 2022 16:10:40 -0500
+Message-ID: <CAO40Mi=rKx0W6Xk1gwvaoi=EuNtc8cwPpjcFdAWvxXv7WVZ0_g@mail.gmail.com>
+Subject: Re: v1.0.0-rc1 fail on mac: stddef.h not found
+To: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 1049
+Lines: 31
+
+Ok, thanks for the update.
+
+On Fri, Nov 4, 2022 at 2:22 PM Motiejus Jak=C5=A1tys <motiejus@jakstys.lt> =
+wrote:
+>
+> On Thu, Nov 03, 2022 at 09:40:36AM -0500, Gregg Reynolds wrote:
+> > First off: bazel-zig-cc is awesome, thanks so much!
+>
+> Hi, thanks!
+>
+> > Second: I tried to send this via the mailing list 'new post' button
+> > and from gmail but both were rejected because they contain html.
+> > Recommend you find a friendlier mailing list manager.
+>
+> bazel-zig-cc is planned to move to github.com/uber ; timelines are
+> unknown yet though. Will update this list when I have more details.
+>
+> > In any case here's the error:
+> >
+> > runtime/caml/config.h:51:10: fatal error: 'stddef.h' file not found
+> > #include <stddef.h>
+> >          ^~~~~~~~~~
+>
+> Please use v0.9.2, the one that's recommended in the README. 1.0.0-rc
+> versions are known to have bugs. See my earlier posts in this mailing
+> list.
+>
+> I will ping here separately when I will need extra hands testing v1.0.
+> It's not ready yet.
+>
+> Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 206AC11F051;
+	Sun, 11 Dec 2022 04:56:02 +0000 (UTC)
+From: ~motiejus <motiejus@git.sr.ht>
+Date: Sun, 11 Dec 2022 04:56:01 +0000
+MIME-Version: 1.0
+Subject: [PATCH bazel-zig-cc 0/1] changes in windows zig toolchain wrapper
+Message-ID: <167073456185.10966.5711284970000433405-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~motiejus <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht, fabian@hahn.graphics
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 1046
+Lines: 24
+
+I am doing a change in Windows wrapper, which I have no means to test
+nor know is correct. Fabian, please test/ack.
+
+`--experimental_use_hermetic_linux_sandbox` option is interesting,
+because instead of symlinks in the sandbox it creates hardlinks. Which
+has a chance to fix https://github.com/ziglang/zig/issues/13619 ;
+Bazel's acceptance test in https://git.sr.ht/~motiejus/test-zigcc.
+
+Hermetic sandbox also means one thing: all outside-sandbox directories
+need to be explicitly allowlisted with `sandbox_mount_pair`. Since the
+toolchain wrapper uses /bin/sh, it brings a bunch of stuff with it:
+/bin, /lib, /lib64. If my experiments with
+`experimental_use_hermetic_linux_sandbox` will fix the performance
+issue, the zig wrapper rewrite to zig will happen sooner than later (and
+I may have an interesting bootstrap problem to solve).
+
+Motiejus Jak=C5=A1tys (1):
+  toolchain wrapper: zig_exe path is relative
+
+ toolchain/defs.bzl | 20 +++++++++++++-------
+ 1 file changed, 13 insertions(+), 7 deletions(-)
+
+--=20
+2.34.5
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 4841211F2BB;
+	Sun, 11 Dec 2022 04:56:02 +0000 (UTC)
+From: ~motiejus <motiejus@git.sr.ht>
+Date: Sun, 11 Dec 2022 06:43:28 +0200
+Subject: [PATCH bazel-zig-cc 1/1] toolchain wrapper: zig_exe path is relative
+MIME-Version: 1.0
+Message-ID: <167073456185.10966.5711284970000433405-1@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~motiejus <motiejus@jakstys.lt>
+In-Reply-To: <167073456185.10966.5711284970000433405-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht, fabian@hahn.graphics
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 4250
+Lines: 118
+
+From: Motiejus Jak=C5=A1tys <motiejus@uber.com>
+
+Just like we know the path to zig_lib_dir, we do know the path to
+zig_exe. Lets use that.
+
+This was surfaced by experimenting with
+`--experimental_use_hermetic_linux_sandbox`.
+`repository_ctx.path("zig")` would return the real file system path to
+zig (outside of the sandbox), which is not good when the sandbox is
+hermetic.
+---
+ toolchain/defs.bzl | 20 +++++++++++++-------
+ 1 file changed, 13 insertions(+), 7 deletions(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 3d08abd..752a663 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -92,21 +92,25 @@ _ZIG_TOOLS =3D [
+ _ZIG_TOOL_WRAPPER_WINDOWS_CACHE_KNOWN =3D """@echo off
+ if exist "external\\zig_sdk\\lib\\*" goto :have_external_zig_sdk_lib
+ set ZIG_LIB_DIR=3D%~dp0\\..\\..\\lib
++set ZIG_EXE=3D%~dp0\\..\\..\\zig
+ goto :set_zig_lib_dir
+ :have_external_zig_sdk_lib
+ set ZIG_LIB_DIR=3Dexternal\\zig_sdk\\lib
++set ZIG_EXE=3Dexternal\\zig_sdk\\zig
+ :set_zig_lib_dir
+ set ZIG_LOCAL_CACHE_DIR=3D{cache_prefix}\\bazel-zig-cc
+ set ZIG_GLOBAL_CACHE_DIR=3D%ZIG_LOCAL_CACHE_DIR%
+-"{zig}" "{zig_tool}" {maybe_target} %*
++"$ZIG_EXE" "{zig_tool}" {maybe_target} %*
+ """
+=20
+ _ZIG_TOOL_WRAPPER_WINDOWS_CACHE_GUESS =3D """@echo off
+ if exist "external\\zig_sdk\\lib\\*" goto :have_external_zig_sdk_lib
+ set ZIG_LIB_DIR=3D%~dp0\\..\\..\\lib
++set ZIG_EXE=3D%~dp0\\..\\..\\zig
+ goto :set_zig_lib_dir
+ :have_external_zig_sdk_lib
+ set ZIG_LIB_DIR=3Dexternal\\zig_sdk\\lib
++set ZIG_EXE=3Dexternal\\zig_sdk\\zig
+ :set_zig_lib_dir
+ if exist "%TMP%\\*" goto :usertmp
+ set ZIG_LOCAL_CACHE_DIR=3DC:\\Temp\\bazel-zig-cc
+@@ -115,29 +119,33 @@ goto zig
+ set ZIG_LOCAL_CACHE_DIR=3D%TMP%\\bazel-zig-cc
+ :zig
+ set ZIG_GLOBAL_CACHE_DIR=3D%ZIG_LOCAL_CACHE_DIR%
+-"{zig}" "{zig_tool}" {maybe_target} %*
++"$ZIG_EXE" "{zig_tool}" {maybe_target} %*
+ """
+=20
+ _ZIG_TOOL_WRAPPER_CACHE_KNOWN =3D """#!/bin/sh
+ set -e
+ if [ -d external/zig_sdk/lib ]; then
+     ZIG_LIB_DIR=3Dexternal/zig_sdk/lib
++    ZIG_EXE=3Dexternal/zig_sdk/zig
+ else
+     ZIG_LIB_DIR=3D"$(dirname "$0")/../../lib"
++    ZIG_EXE=3D"$(dirname "$0")/../../zig"
+ fi
+ export ZIG_LIB_DIR
+ export ZIG_LOCAL_CACHE_DIR=3D"{cache_prefix}/bazel-zig-cc"
+ export ZIG_GLOBAL_CACHE_DIR=3D"{cache_prefix}/bazel-zig-cc"
+ {maybe_gohack}
+-exec "{zig}" "{zig_tool}" {maybe_target} "$@"
++exec "$ZIG_EXE" "{zig_tool}" {maybe_target} "$@"
+ """
+=20
+ _ZIG_TOOL_WRAPPER_CACHE_GUESS =3D """#!/bin/sh
+ set -e
+ if [ -d external/zig_sdk/lib ]; then
+     ZIG_LIB_DIR=3Dexternal/zig_sdk/lib
++    ZIG_EXE=3Dexternal/zig_sdk/zig
+ else
+     ZIG_LIB_DIR=3D"$(dirname "$0")/../../lib"
++    ZIG_EXE=3D"$(dirname "$0")/../../zig"
+ fi
+ if [ -n "$TMPDIR" ]; then
+     _cache_prefix=3D$TMPDIR
+@@ -154,7 +162,7 @@ export ZIG_LIB_DIR
+ export ZIG_LOCAL_CACHE_DIR=3D"$_cache_prefix/bazel-zig-cc"
+ export ZIG_GLOBAL_CACHE_DIR=3D$ZIG_LOCAL_CACHE_DIR
+ {maybe_gohack}
+-exec "{zig}" "{zig_tool}" {maybe_target} "$@"
++exec "$ZIG_EXE" "{zig_tool}" {maybe_target} "$@"
+ """
+=20
+ # The abomination below adds "-O2" to Go's link-prober command. Saves around
+@@ -176,14 +184,13 @@ fi
+ eval set -- "$saved"
+ """
+=20
+-def _zig_tool_wrapper(zig_tool, zig, is_windows, cache_prefix, zigtarget):
++def _zig_tool_wrapper(zig_tool, is_windows, cache_prefix, zigtarget):
+     if zig_tool in ["c++", "build-exe", "build-lib", "build-obj"]:
+         maybe_target =3D "-target {}".format(zigtarget)
+     else:
+         maybe_target =3D ""
+=20
+     kwargs =3D dict(
+-        zig =3D str(zig).replace("/", "\\") + ".exe" if is_windows else zig,
+         zig_tool =3D zig_tool,
+         cache_prefix =3D cache_prefix,
+         maybe_gohack =3D _ZIG_TOOL_GOHACK if (zig_tool =3D=3D "c++" and not =
+is_windows) else "",
+@@ -266,7 +273,6 @@ def _zig_repository_impl(repository_ctx):
+         for target_config in target_structs():
+             zig_tool_wrapper =3D _zig_tool_wrapper(
+                 zig_tool,
+-                str(repository_ctx.path("zig")),
+                 os =3D=3D "windows",
+                 repository_ctx.os.environ.get("BAZEL_ZIG_CC_CACHE_PREFIX", "=
+"),
+                 zigtarget =3D target_config.zigtarget,
+--=20
+2.34.5
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=SEhhsERM2tiN+zXwqVbO2CXOMOTdt0C5v57GnHy/avQ=;
+ c=simple/simple; d=sr.ht; h=Date:To:Cc:From:In-Reply-To:Subject;
+ q=dns/txt; s=srht; t=1670735653; v=1;
+ b=SEFNUM+Ip5bueHhETm1VQapGJ2UloAIvplbMQH7UjJp24qUXpLPH91nIaLsFmgLMxh+DKTXF
+ pIv56Z15L9Yxwxv+JEKpUWtvg28UsfYb9xheSkXtpyctY886JISWp3zhUfsvKycIXAuKvEzW9fW
+ 0ywMi50oaylIIlYBJGBKLpOgvaO4riPxHyzq6bOaj/SwagpMl20gnzIdx5PYKCMBePHJaVAgpRM
+ K3L/cmQKS7hHunaWDvtjRlHyu5QofQbM7nDDm7TwOJc7a+Ya2/i3qvE+gdboy8jkPoHeWG+7iWf
+ LpvUKQ9zigB7e+qL67KWgcyxEI7jE0efEy9qxD632lM5Q==
+Received: from localhost (unknown [173.195.146.249])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id 70A9B11F051;
+	Sun, 11 Dec 2022 05:14:13 +0000 (UTC)
+MIME-Version: 1.0
+Date: Sun, 11 Dec 2022 05:14:13 +0000
+To: "~motiejus" <motiejus@jakstys.lt>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <COYQCZAXXEHO.1U9SF6RD39284@cirno>
+In-Reply-To: <167073456185.10966.5711284970000433405-1@git.sr.ht>
+Subject: [bazel-zig-cc/patches/.build.yml] build failed
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 322
+Lines: 9
+
+bazel-zig-cc/patches/.build.yml: FAILED in 18m9s
+
+[changes in windows zig toolchain wrapper][0] from [~motiejus][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/37457
+[1]: mailto:motiejus@jakstys.lt
+
+=E2=9C=97 #902752 FAILED bazel-zig-cc/patches/.build.yml https://builds.sr.=
+ht/~motiejus/job/902752
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id A706A11EF16
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sun, 11 Dec 2022 14:53:50 +0000 (UTC)
+From: Fabian Hahn <fabian@hahn.graphics>
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1670770425;
+	bh=7Cya5rRskvQtJMLM4PNcWn0MIfEynP3CVGQLOZw3gw4=;
+	h=From:To:Cc:Subject;
+	b=SpntOUoK58nipd8RJgxmrLZtvPbf3MIOSbZWOPilLEDSjXeaba6ul2Oh969UVcuKg
+	 WvNmLEqgB4tSkTaQJ4zuGHB7eP19Y2NuXFtOvrZ/GfsAHQJWRWDPKfmQclBFDxO7bQ
+	 sBQ7pZv7FR2fgpF8Nq8cYidoNxqBVNLdxHUiB7o0=
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Fabian Hahn <fabian@hahn.graphics>
+Subject: [PATCH bazel-zig-cc] fix windows include root path
+Date: Sun, 11 Dec 2022 14:53:37 +0000
+Message-Id: <20221211145337.4722-1-fabian@hahn.graphics>
+Mime-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Status: O
+Content-Length: 1306
+Lines: 30
+
+---
+When trying to test the patch
+https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/37457 I noticed that
+the current main branch is broken on Windows. I ran a bisection and the
+offending bad commit is 88e7e47ed20ca7b2f9509dfe09089b812d7d94eb, which
+makes changes to the zig_include_root. Here's a small patch that
+resolves this and fixes Windows host support again on main. The issue
+here is that while paths on Windows do indeed use \ instead of /, the
+variable `d` here is used as a bazel target name for a filegroup rule,
+which must not contain backslashes. And bazel accepts forward slashes
+within glob() just fine on Windows, so no special handling needed here.
+
+ toolchain/defs.bzl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 3d08abd..aa2e4e6 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -318,6 +318,6 @@ def declare_files(os):
+ 
+     for target_config in target_structs():
+         for d in _DEFAULT_INCLUDE_DIRECTORIES + target_config.includes:
+-            d = "lib" + ("\\" if os == "windows" else "/") + d
++            d = "lib/" + d
+             if d not in lazy_filegroups:
+                 lazy_filegroups[d] = filegroup(name = d, srcs = native.glob([d + "/**"]))
+-- 
+2.25.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 2823411EF16
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sun, 11 Dec 2022 14:59:42 +0000 (UTC)
+From: Fabian Hahn <fabian@hahn.graphics>
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1670770778;
+	bh=KshE725FUdjyTNQ0Y1VtqU7JIh3l6+b+PI+dREBWejg=;
+	h=From:To:Cc:Subject;
+	b=g4NLq/WF/nlKGZDU5NY5bHrc/EfG9I+Z7BC2Gqtw/KEQeOiiAzJZzyDB3gjYrgR72
+	 VZCUvK0fwHc0h9wgK4ZJzrhB+Pn8SlVjGXBU6sQYft+1BkNLHr9KM1CDJbzhxMkCob
+	 JveXjGkKvRNcGgf6hlmZZYJcctQxavB0Zv+6vAQE=
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Fabian Hahn <fabian@hahn.graphics>
+Subject: [PATCH bazel-zig-cc v2 0/1] changes in windows zig toolchain wrapper
+Date: Sun, 11 Dec 2022 14:59:28 +0000
+Message-Id: <20221211145929.5701-1-fabian@hahn.graphics>
+Mime-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Status: O
+Content-Length: 716
+Lines: 23
+
+This is a revised version of
+https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/37457 which fixes
+Windows host support. The key is to use %VAR% notation to interpolate
+environment variables within batch file strings, and to use the proper
+exe extension for the zig binary.
+
+Note that in order for this to work on Windows, this other patch I
+submitted also needs to be applied:
+https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/37465
+This is because the current main is broken on Windows otherwise.
+
+Best,
+Fabian
+
+Motiejus Jakštys (1):
+  toolchain wrapper: zig_exe path is relative
+
+ toolchain/defs.bzl | 20 +++++++++++++-------
+ 1 file changed, 13 insertions(+), 7 deletions(-)
+
+-- 
+2.25.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 09C9911EF16
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sun, 11 Dec 2022 14:59:43 +0000 (UTC)
+From: Fabian Hahn <fabian@hahn.graphics>
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1670770780;
+	bh=sKu6Fwv608vhiNqG38OqDveIHqZfZ63kFx0gzrfWuqQ=;
+	h=From:To:Cc:Subject:In-Reply-To:References;
+	b=SWSa1cAZXAWuplP0wXd9v4NabJUNeVXzzaAPgHw2TEWKf+PrU+x2pb0pGI0URmI6k
+	 f0P2EeATswa4KyUYP7VKkZ1FJmfNzKWpXcLQVOnArWMAMODqhPMUuRlGPUq7a9vBZN
+	 T3JrDvip6RwpveyMnCMegb3NfV5SKTL44ZqsEioE=
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: =?UTF-8?q?Motiejus=20Jak=C5=A1tys?= <motiejus@uber.com>
+Subject: [PATCH bazel-zig-cc v2 1/1] toolchain wrapper: zig_exe path is relative
+Date: Sun, 11 Dec 2022 14:59:29 +0000
+Message-Id: <20221211145929.5701-2-fabian@hahn.graphics>
+In-Reply-To: <20221211145929.5701-1-fabian@hahn.graphics>
+References: <20221211145929.5701-1-fabian@hahn.graphics>
+Mime-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Status: O
+Content-Length: 4158
+Lines: 117
+
+From: Motiejus Jakštys <motiejus@uber.com>
+
+Just like we know the path to zig_lib_dir, we do know the path to
+zig_exe. Lets use that.
+
+This was surfaced by experimenting with
+`--experimental_use_hermetic_linux_sandbox`.
+`repository_ctx.path("zig")` would return the real file system path to
+zig (outside of the sandbox), which is not good when the sandbox is
+hermetic.
+---
+ toolchain/defs.bzl | 20 +++++++++++++-------
+ 1 file changed, 13 insertions(+), 7 deletions(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index aa2e4e6..746156d 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -92,21 +92,25 @@ _ZIG_TOOLS = [
+ _ZIG_TOOL_WRAPPER_WINDOWS_CACHE_KNOWN = """@echo off
+ if exist "external\\zig_sdk\\lib\\*" goto :have_external_zig_sdk_lib
+ set ZIG_LIB_DIR=%~dp0\\..\\..\\lib
++set ZIG_EXE=%~dp0\\..\\..\\zig.exe
+ goto :set_zig_lib_dir
+ :have_external_zig_sdk_lib
+ set ZIG_LIB_DIR=external\\zig_sdk\\lib
++set ZIG_EXE=external\\zig_sdk\\zig.exe
+ :set_zig_lib_dir
+ set ZIG_LOCAL_CACHE_DIR={cache_prefix}\\bazel-zig-cc
+ set ZIG_GLOBAL_CACHE_DIR=%ZIG_LOCAL_CACHE_DIR%
+-"{zig}" "{zig_tool}" {maybe_target} %*
++"%ZIG_EXE%" "{zig_tool}" {maybe_target} %*
+ """
+ 
+ _ZIG_TOOL_WRAPPER_WINDOWS_CACHE_GUESS = """@echo off
+ if exist "external\\zig_sdk\\lib\\*" goto :have_external_zig_sdk_lib
+ set ZIG_LIB_DIR=%~dp0\\..\\..\\lib
++set ZIG_EXE=%~dp0\\..\\..\\zig.exe
+ goto :set_zig_lib_dir
+ :have_external_zig_sdk_lib
+ set ZIG_LIB_DIR=external\\zig_sdk\\lib
++set ZIG_EXE=external\\zig_sdk\\zig.exe
+ :set_zig_lib_dir
+ if exist "%TMP%\\*" goto :usertmp
+ set ZIG_LOCAL_CACHE_DIR=C:\\Temp\\bazel-zig-cc
+@@ -115,29 +119,33 @@ goto zig
+ set ZIG_LOCAL_CACHE_DIR=%TMP%\\bazel-zig-cc
+ :zig
+ set ZIG_GLOBAL_CACHE_DIR=%ZIG_LOCAL_CACHE_DIR%
+-"{zig}" "{zig_tool}" {maybe_target} %*
++"%ZIG_EXE%" "{zig_tool}" {maybe_target} %*
+ """
+ 
+ _ZIG_TOOL_WRAPPER_CACHE_KNOWN = """#!/bin/sh
+ set -e
+ if [ -d external/zig_sdk/lib ]; then
+     ZIG_LIB_DIR=external/zig_sdk/lib
++    ZIG_EXE=external/zig_sdk/zig
+ else
+     ZIG_LIB_DIR="$(dirname "$0")/../../lib"
++    ZIG_EXE="$(dirname "$0")/../../zig"
+ fi
+ export ZIG_LIB_DIR
+ export ZIG_LOCAL_CACHE_DIR="{cache_prefix}/bazel-zig-cc"
+ export ZIG_GLOBAL_CACHE_DIR="{cache_prefix}/bazel-zig-cc"
+ {maybe_gohack}
+-exec "{zig}" "{zig_tool}" {maybe_target} "$@"
++exec "$ZIG_EXE" "{zig_tool}" {maybe_target} "$@"
+ """
+ 
+ _ZIG_TOOL_WRAPPER_CACHE_GUESS = """#!/bin/sh
+ set -e
+ if [ -d external/zig_sdk/lib ]; then
+     ZIG_LIB_DIR=external/zig_sdk/lib
++    ZIG_EXE=external/zig_sdk/zig
+ else
+     ZIG_LIB_DIR="$(dirname "$0")/../../lib"
++    ZIG_EXE="$(dirname "$0")/../../zig"
+ fi
+ if [ -n "$TMPDIR" ]; then
+     _cache_prefix=$TMPDIR
+@@ -154,7 +162,7 @@ export ZIG_LIB_DIR
+ export ZIG_LOCAL_CACHE_DIR="$_cache_prefix/bazel-zig-cc"
+ export ZIG_GLOBAL_CACHE_DIR=$ZIG_LOCAL_CACHE_DIR
+ {maybe_gohack}
+-exec "{zig}" "{zig_tool}" {maybe_target} "$@"
++exec "$ZIG_EXE" "{zig_tool}" {maybe_target} "$@"
+ """
+ 
+ # The abomination below adds "-O2" to Go's link-prober command. Saves around
+@@ -176,14 +184,13 @@ fi
+ eval set -- "$saved"
+ """
+ 
+-def _zig_tool_wrapper(zig_tool, zig, is_windows, cache_prefix, zigtarget):
++def _zig_tool_wrapper(zig_tool, is_windows, cache_prefix, zigtarget):
+     if zig_tool in ["c++", "build-exe", "build-lib", "build-obj"]:
+         maybe_target = "-target {}".format(zigtarget)
+     else:
+         maybe_target = ""
+ 
+     kwargs = dict(
+-        zig = str(zig).replace("/", "\\") + ".exe" if is_windows else zig,
+         zig_tool = zig_tool,
+         cache_prefix = cache_prefix,
+         maybe_gohack = _ZIG_TOOL_GOHACK if (zig_tool == "c++" and not is_windows) else "",
+@@ -266,7 +273,6 @@ def _zig_repository_impl(repository_ctx):
+         for target_config in target_structs():
+             zig_tool_wrapper = _zig_tool_wrapper(
+                 zig_tool,
+-                str(repository_ctx.path("zig")),
+                 os == "windows",
+                 repository_ctx.os.environ.get("BAZEL_ZIG_CC_CACHE_PREFIX", ""),
+                 zigtarget = target_config.zigtarget,
+-- 
+2.25.1
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=gT7xKJjOc/1EpJvoZQ71J0eekHIG+7u6QaPoSQv3F0E=;
+ c=simple/simple; d=sr.ht; h=Date:From:In-Reply-To:Subject:To:Cc;
+ q=dns/txt; s=srht; t=1670771490; v=1;
+ b=UUdqKUNb8uacCV2JEjsumQd/QJecOhRkKrAet0hW/6Hl4VgEkxHGS7y38/P3MYnPT1prnAFo
+ AXg7n2SuLZgkyiL/bDj+00Jq5ddDteGquArs5ZBzQTjjh6O0vKEEai04SjlAIrwKg/awX9mh4Zr
+ 1kKhhFXY5sk+VCkZI9Qst8jjrhme2C2IC7YCAMTu1xOIZeozawmq/A4mAlGzsbuvrs88v/niCRo
+ btpyyPqtWSjZu+MZ2AP9wnyHRJS1un7LnD45IFgzhlj6ApU3STG99gyaxLDaJI8kWxRVJmbYEez
+ tPIQ509crvK7uNCDgZiyZd930ZBJNy4AE8qQMEgwnZpAQ==
+Received: from localhost (unknown [173.195.146.249])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id 7F4BE11EF16;
+	Sun, 11 Dec 2022 15:11:30 +0000 (UTC)
+MIME-Version: 1.0
+Date: Sun, 11 Dec 2022 15:11:30 +0000
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <COZ32AMRZNWS.1U3FDYMROMMTJ@cirno>
+In-Reply-To: <20221211145337.4722-1-fabian@hahn.graphics>
+Subject: [bazel-zig-cc/patches/.build.yml] build success
+To: "Fabian Hahn" <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain; charset=UTF-8
+Status: O
+Content-Length: 317
+Lines: 9
+
+bazel-zig-cc/patches/.build.yml: SUCCESS in 17m38s
+
+[fix windows include root path][0] from [Fabian Hahn][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/37465
+[1]: mailto:fabian@hahn.graphics
+
+=E2=9C=93 #902966 SUCCESS bazel-zig-cc/patches/.build.yml https://builds.sr=
+.ht/~motiejus/job/902966
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=dWs0WggYTNebMtC0i1Z/tFNbrDlbP48VuSL24yIPKF4=;
+ c=simple/simple; d=sr.ht; h=Date:In-Reply-To:Subject:To:Cc:From;
+ q=dns/txt; s=srht; t=1670771913; v=1;
+ b=dUW3XL7QbHXCRWODcWUT50O5fldY7S3cx4lVx9wu1kAAK959n1stMhIAmgzwMPKEX2X0P5io
+ w/sB8S0XssNAEpILZecZQ7Ac/tc6J3AL+xGPZPeyzv1xdFzcr3vFVbY3KMejCbg1IFuI1/pdxcb
+ Kawt3xw/8iJRDZA97v7DMHquBffLkfiA8PwHhpZjqwC/kzYytKyhm4B65U1IeTR1f15M57DGVQ5
+ 0u82A4MlEmJtG4GhiJTIvotsLRML7BiJG1rUxjyFTF0JWsl33mxmFAgQnyyd9jAjLU3ar0avQqv
+ iaXk9hUOpygbrlI5pLW4RfBeiRp0AtV28p8DIcmdTsX9w==
+Received: from localhost (unknown [173.195.146.244])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id 34A6511EF16;
+	Sun, 11 Dec 2022 15:18:33 +0000 (UTC)
+MIME-Version: 1.0
+Date: Sun, 11 Dec 2022 15:18:33 +0000
+Message-ID: <COZ37OR4QOLV.11C7959ZF8N9M@cirno2>
+In-Reply-To: <20221211145929.5701-2-fabian@hahn.graphics>
+Subject: [bazel-zig-cc/patches/.build.yml] build success
+To: "Fabian Hahn" <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+From: "builds.sr.ht" <builds@sr.ht>
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 331
+Lines: 9
+
+bazel-zig-cc/patches/.build.yml: SUCCESS in 18m48s
+
+[changes in windows zig toolchain wrapper][0] v2 from [Fabian Hahn][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/37466
+[1]: mailto:fabian@hahn.graphics
+
+=E2=9C=93 #902967 SUCCESS bazel-zig-cc/patches/.build.yml https://builds.sr=
+.ht/~motiejus/job/902967
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-lf1-f51.google.com (mail-lf1-f51.google.com [209.85.167.51])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 56CAB11EF2F
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sun, 11 Dec 2022 16:32:00 +0000 (UTC)
+Received: by mail-lf1-f51.google.com with SMTP id y25so14699483lfa.9
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sun, 11 Dec 2022 08:32:00 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=in-reply-to:content-disposition:mime-version:references:message-id
+         :subject:cc:to:from:date:sender:from:to:cc:subject:date:message-id
+         :reply-to;
+        bh=XzuoAlh6IDmX/e4P7zHpbMNsl+grZq2CS3bqWYvauYY=;
+        b=PgkwAc8n+WjWTU8lay7rY25pAogWGZw3EmgGkjZTH/Mh3pG1nqrgxFfFrH7pR22Crz
+         KjewdZU4iiI8WtaWnB3IsNZJz1D8VnDuU8jjb5saxNS7CCCiWYv38/O1VqzcRTxZidQq
+         ikOc6JrnX+cj49o+P01BrqyuD8otTVQCDfprikCyaJo4ra34B9Ke2gV4F5s5siHbz5dy
+         5TYXsy+k/1b27m34/W3Q1g1rX+yc6wPaC5WGqNnvdnY6pV5TyhJewHasQh7C5Vixh+/R
+         NZ9U7Ti3QXfIebxVqSONaVR2hHIsHncqXD1q4/h8yOMl3RBiXAR0xRDc+pYkYePbBF/t
+         uHHA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=in-reply-to:content-disposition:mime-version:references:message-id
+         :subject:cc:to:from:date:sender:x-gm-message-state:from:to:cc
+         :subject:date:message-id:reply-to;
+        bh=XzuoAlh6IDmX/e4P7zHpbMNsl+grZq2CS3bqWYvauYY=;
+        b=2ZbPviEVg4RsyfS+CSbAgZTaDcaOHQdhgnUCi3pD4dnjVD64DYxb1f5LjdIUpYDRb/
+         4sN8zE1N5/HXHjzAAcx5T4deJyIGB1xgqTJu5MLqOpXfUsi54eBrASCXNzJkwOuEqMON
+         cxj+KTejAZe7lAiXzHoEtPhUyqIZAMLyYBW9D9Pg3Ff2U8dlKY8Lvi1jn+c/ZV+rzPza
+         IyPFVJnV41NR+FXJgKGy4+7Dw1E7vawF9pW9y8f16KgNgr4ffBz6kJu0PM2AnpwROI35
+         cC2P/OSHNdxls5aDYDLtkySmnz97+5lhB83jebUaydyx7WVtlJkkc3NaET4s4pgYIiab
+         B+2Q==
+X-Gm-Message-State: ANoB5pk4uNDEEfl+E3HbtCbOTUHsfmYMnHT06dUQW2RmxQWKkbAzVq0f
+	q7iLcI4XmSVazwanntbUHecUfSKqYG4=
+X-Google-Smtp-Source: AA0mqf6XcpSBJkeV0UESaEJ9tx2dpk5usg4AfPj7UT60r4HdY7jXLKfmVpmTz7E5P8Oj7wGn9NgVEw==
+X-Received: by 2002:ac2:58ea:0:b0:4a4:68b7:f86e with SMTP id v10-20020ac258ea000000b004a468b7f86emr4690733lfo.18.1670776318489;
+        Sun, 11 Dec 2022 08:31:58 -0800 (PST)
+Received: from localhost ([88.223.105.24])
+        by smtp.gmail.com with ESMTPSA id m10-20020a056512358a00b004b585003839sm1235842lfr.265.2022.12.11.08.31.57
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Sun, 11 Dec 2022 08:31:57 -0800 (PST)
+Sender: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <desired.mta@gmail.com>
+Date: Sun, 11 Dec 2022 18:31:56 +0200
+From: Motiejus =?utf-8?Q?Jak=C5=A1tys?= <motiejus@jakstys.lt>
+To: Fabian Hahn <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Subject: Re: [PATCH bazel-zig-cc v2 0/1] changes in windows zig toolchain
+ wrapper
+Message-ID: <20221211163156.evp5thus2itgiful@mtmine.i.jakstys.lt>
+References: <20221211145929.5701-1-fabian@hahn.graphics>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+In-Reply-To: <20221211145929.5701-1-fabian@hahn.graphics>
+Status: O
+Content-Length: 811
+Lines: 21
+
+On Sun, Dec 11, 2022 at 02:59:28PM +0000, Fabian Hahn wrote:
+> This is a revised version of
+> https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/37457 which fixes
+> Windows host support. The key is to use %VAR% notation to interpolate
+> environment variables within batch file strings, and to use the proper
+> exe extension for the zig binary.
+> 
+> Note that in order for this to work on Windows, this other patch I
+> submitted also needs to be applied:
+> https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/37465
+> This is because the current main is broken on Windows otherwise.
+
+Hi Fabian,
+
+thank you, applied both.
+
+Be assured that I will break Windows again. However, I will definitely
+ask for your testing/feedback before I cut v1.0. Thanks for your
+continued contributions.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f52.google.com (mail-oa1-f52.google.com [209.85.160.52])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 986F411F284
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 14 Dec 2022 13:19:16 +0000 (UTC)
+Received: by mail-oa1-f52.google.com with SMTP id 586e51a60fabf-1322d768ba7so16526094fac.5
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 14 Dec 2022 05:19:16 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=to:subject:message-id:date:from:mime-version:from:to:cc:subject
+         :date:message-id:reply-to;
+        bh=/YM5JhtOsbamKOhauM3du3FSimX3Xr1KXH8guB6PdaU=;
+        b=TN4Awr18kkm/s9QY1rHHfEC/DyyIH2G9rjwSfBhcR6ffQWvSDbSiLH86uzjU967eDw
+         EpGKaD2A+kO+nvUj0FeveXez7PTa7Ezg/8CbUh78sfFfLZrdUZLzpfDFfyiApurOR7d/
+         KrAWX70FJiJacYdzUDvj269CrQKhqoh8l+8ep+Yy2uQVkDD0NJRLdT7Gj57kves8tPaS
+         GKMQrTVEqjHLvtv1R/3lWu/ERVXIoxybHcaS3fGsrO+xNkjFQ1mxvCYVJ5RT43RoFXiJ
+         ZPCSsY3zZnpM/aYFdSL0NjJGjDoYWoCadzEI3hysRBJ+fsyTVKUYAxAFNdmG53Go5P2/
+         IMHA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=to:subject:message-id:date:from:mime-version:x-gm-message-state
+         :from:to:cc:subject:date:message-id:reply-to;
+        bh=/YM5JhtOsbamKOhauM3du3FSimX3Xr1KXH8guB6PdaU=;
+        b=4ThcRJ7KY8rgRVNLpvk0d+NfvYS3ZUlgvcAKWAmRqRCAPCoKLRCSjp9kPdmoKHgp/W
+         e5zGRTpHtriAS5a+xV5XmUqXKfGTXovOJ8EfLfZgbaI9arecyV1yq8U0DJzHcNCsDA9V
+         Y7l7MJExJDKXrRfjP53Mx5JqPh2byBHsUwB5qHP0u6G2gfVRzaA9VMD+Swyl6MljqN2M
+         4gMVIGKnSCnhUTzABwn83ZDAgVbdg7xJ1B8wGVCPq5qi1SO7SouifU1KjNc5GyoOsm/O
+         kOEMBqDR2BC/nxNoFhe5UYyIDcZPxkfJDHQFRQ6R/X5VgEZjyB6NlPp3dJI7v0ImK4KG
+         fDsg==
+X-Gm-Message-State: AFqh2kqg1b0z0Q3bot3583L92TFQ4i2TS0tlzmkSQwtGH3vXIExNalUg
+	JzWt1/EYlipoQl9AovxyaaWFs84JzUkvF0olRVCf3uyi
+X-Google-Smtp-Source: AMrXdXvksExt1FuthkzBs3iXHM1abzQrv02CRMiIXyuO3R4DhRartHbRV4cFZRKKyKGpS8OjLGHeuyot7Kr7NqqhNh8=
+X-Received: by 2002:a05:6870:d147:b0:143:fa7f:2b29 with SMTP id
+ f7-20020a056870d14700b00143fa7f2b29mr228736oac.116.1671023955813; Wed, 14 Dec
+ 2022 05:19:15 -0800 (PST)
+MIME-Version: 1.0
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Wed, 14 Dec 2022 15:19:04 +0200
+Message-ID: <CAFVMu-pnKCOoK+KSqjiVvzME+eL6+N+Y83Q45bkY0rkKSc6xeQ@mail.gmail.com>
+Subject: bazel-zig-cc v1.0.0-rc4: call for testers
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 1024
+Lines: 21
+
+Hi all,
+
+I just cut a v1.0.0-rc4 for testing. Comparing to v0.9 series it does
+not have new features, but offers substantial performance gains:
+* all compiler paths are now relative, making it remote-cache friendly.
+* number of files it needs to pull in to the sandbox is much smaller:
+2k for a compile step of x86_64-linux-gnu.2.28, and ~3700 for the
+linking step. Compared to almost 16k previously.
+
+Please test and report back any regressions. I tested Uber's Go
+Monorepo with it, it seems fine. However, we are very x86_64-linux-gnu
+centric (both host and target). Please run your tests *especially* if
+you have a different environment.
+
+All bazel-zig-cc contributors should have received an email asking for
+permission to re-license it to Apache License 2.0. If you contributed
+to bazel-zig-cc and did not receive that email, please let me know! I
+am still waiting for a few replies. The sooner we change the license,
+the sooner bazel-zig-cc can be put under Uber's open-source umbrella.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 14CE711EEFC
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed, 14 Dec 2022 18:17:37 +0000 (UTC)
+Message-ID: <a2ad4a4e-6cef-da88-1922-48c7d4717c64@hahn.graphics>
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1671041851;
+	bh=BMp6CboYmE/Exg83TwZU/aQC/jh5oe7x5ndAVB68ZK8=;
+	h=To:Cc:References:Subject:From:In-Reply-To;
+	b=LHpTnQUc+qTS2hPpEmrHVdLMCMX7oQMXtbLA/NQNlBDdZ1foh60kwwE2YWW2YZgOH
+	 QJIqx1eVlSPKduDugTPQfVIu97VpLVnUOSVTLjy6/BkkmGa5GOztUF4XG2uSxQ+QOA
+	 rEt34hnFzyRCWb+ICpexFsOZMLbZ497Iz7CcJr4M=
+Date: Wed, 14 Dec 2022 18:17:30 +0000
+Mime-Version: 1.0
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: =?UTF-8?Q?Motiejus_Jak=c5=a1tys?= <motiejus@jakstys.lt>
+References: <CAFVMu-pnKCOoK+KSqjiVvzME+eL6+N+Y83Q45bkY0rkKSc6xeQ@mail.gmail.com>
+Subject: Re: bazel-zig-cc v1.0.0-rc4: call for testers
+Content-Language: en-US
+From: Fabian Hahn <fabian@hahn.graphics>
+In-Reply-To: <CAFVMu-pnKCOoK+KSqjiVvzME+eL6+N+Y83Q45bkY0rkKSc6xeQ@mail.gmail.com>
+Content-Type: text/plain; charset=UTF-8; format=flowed
+Content-Transfer-Encoding: 7bit
+Status: O
+Content-Length: 222
+Lines: 9
+
+Hi Motiejus,
+
+I've successfully tested v1.0.0-rc4 on both linux_amd64 and 
+windows_amd64 as both hosts and targets with my project. Performance 
+looks very good and I couldn't spot any regressions.
+
+Best,
+Fabian
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 4CB9411EF38
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat, 17 Dec 2022 01:00:18 +0000 (UTC)
+From: ~jvolkman <jvolkman@git.sr.ht>
+Date: Sat, 17 Dec 2022 01:00:18 +0000
+Subject: [PATCH bazel-zig-cc 0/1] Adds supports_dynamic_linker feature
+MIME-Version: 1.0
+Message-ID: <167123881817.10048.795028335685500161-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~jvolkman <jeremy@jvolkman.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+Status: O
+Content-Length: 532
+Lines: 16
+
+I noticed that the default cc toolchain outputs .so files next to the
+.a, and provides a "dynamic_library" output group. With bazel-zig-cc, an
+attempt to use the "dynamic_library" output group fails with
+> failed: Toolchain does not support dynamic linking
+
+Maybe I'm missing something, but adding support seems as simple as
+enabling the "supports_dynamic_linker" flag.
+
+Jeremy Volkman (1):
+  Adds supports_dynamic_linker feature
+
+ toolchain/zig_toolchain.bzl | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+-- 
+2.34.5
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 7DDEA11EFC3
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat, 17 Dec 2022 01:00:18 +0000 (UTC)
+From: ~jvolkman <jvolkman@git.sr.ht>
+Date: Fri, 16 Dec 2022 16:44:57 -0800
+Subject: [PATCH bazel-zig-cc 1/1] Adds supports_dynamic_linker feature
+Message-ID: <167123881817.10048.795028335685500161-1@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~jvolkman <jeremy@jvolkman.com>
+In-Reply-To: <167123881817.10048.795028335685500161-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+MIME-Version: 1.0
+Status: O
+Content-Length: 894
+Lines: 30
+
+From: Jeremy Volkman <jeremy@jvolkman.com>
+
+With this feature, cc_library generates a .so as well as a .a and the
+"dynamic_library" output group is enabled.
+---
+ toolchain/zig_toolchain.bzl | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/toolchain/zig_toolchain.bzl b/toolchain/zig_toolchain.bzl
+index f76aa80..2578973 100644
+--- a/toolchain/zig_toolchain.bzl
++++ b/toolchain/zig_toolchain.bzl
+@@ -129,9 +129,15 @@ def _zig_cc_toolchain_config_impl(ctx):
+         flag_sets = dynamic_library_flag_sets,
+     )
+ 
++    supports_dynamic_linker = feature(
++        name = "supports_dynamic_linker",
++        enabled = True,
++    )
++
+     features = [
+         compile_and_link_flags,
+         default_linker_flags,
++        supports_dynamic_linker,
+     ] + _compilation_mode_features(ctx)
+ 
+     return cc_common.create_cc_toolchain_config_info(
+-- 
+2.34.5
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=B4GNcGx65AMDP24hxZuXybpuduDUZjyLoGhAR8fLS3o=;
+ c=simple/simple; d=sr.ht; h=Date:From:In-Reply-To:Subject:To:Cc;
+ q=dns/txt; s=srht; t=1671239906; v=1;
+ b=AZSd92xt/wJIUIuQYCQh+zb4JwHRY7Yo9MFIQ6lbUnbT7OJ8XS2hSBytcnHhy44BEEkLiIlz
+ aZhe6SNyMWolSsX5HQAN6qQbBsUXZWA0tApokfTR6PTP4FxEx0LTsMg8002iZL9q/2p2mR2Z0P3
+ H+LmTEyDS74tuIwl6+0si28sE3BExfcOzPRxmmtM2ksu/xJMfXOdECIFlnq4RlVMyE+DfuQsLNd
+ wES+c1WgITlCcwuZf5T7rm+Kzdfly/ZsXSnHnS0333kD1J6O0Qo+R2IOsIFVMXksCP0vpZprCoJ
+ /H/vzcpQfFVxbH4UY/WpIjMWT6CSUrA6MmPca4ebRFR8w==
+Received: from localhost (unknown [173.195.146.249])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id EEDB511EF38;
+	Sat, 17 Dec 2022 01:18:26 +0000 (UTC)
+MIME-Version: 1.0
+Date: Sat, 17 Dec 2022 01:18:26 +0000
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CP3P3Q65ZUNA.3VDQONMO1EZ3D@cirno>
+In-Reply-To: <167123881817.10048.795028335685500161-1@git.sr.ht>
+Subject: [bazel-zig-cc/patches/.build.yml] build success
+To: "~jvolkman" <jeremy@jvolkman.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 320
+Lines: 9
+
+bazel-zig-cc/patches/.build.yml: SUCCESS in 18m7s
+
+[Adds supports_dynamic_linker feature][0] from [~jvolkman][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/37589
+[1]: mailto:jeremy@jvolkman.com
+
+=E2=9C=93 #906609 SUCCESS bazel-zig-cc/patches/.build.yml https://builds.sr=
+.ht/~motiejus/job/906609
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 3490811EF0D
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat, 17 Dec 2022 19:28:06 +0000 (UTC)
+From: ~jvolkman <jvolkman@git.sr.ht>
+Date: Sat, 17 Dec 2022 19:28:05 +0000
+Subject: 
+ [PATCH bazel-zig-cc 0/2] Use -mcpu=apple_m1 when targeting macos + aarch64
+MIME-Version: 1.0
+Message-ID: <167130528597.14686.15641291907532780059-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~jvolkman <jeremy@jvolkman.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 1325
+Lines: 34
+
+I ran into a build failure using bazel-zig-cc to build BoringSSL -
+Google's OpenSSL fork that ships with Bazel rules. BoringSSL assumes
+some features present on an M1 mac and fails if they're not present [1].
+
+When using -target aarch64-macos.11-none, zig sets the cpu model to
+"generic", as far as I can tell, which lacks a bunch of features -
+including SHA2 and AES that BoringSSL is expecting. I think we can
+assume that macos + aarch64 means at least an M1 ship, so instead we can
+use the -mcpu=3Dapple_m1 flag which adds these features and more [3].
+
+I also renamed _target_darwin to _target_macos to align with the Bazel
+os name. I think darwin technically lies under iOS and Apple's other
+mobile OSs as well.
+
+1:
+https://github.com/google/boringssl/blob/97dd962a20b1d19c9e569cf8756fbcfc48ff=
+7c73/crypto/cpu_aarch64_apple.c#L56
+2:
+https://github.com/ziglang/zig/blob/90477e5c10c9c263a3c0038e1ae7b814d2c5397e/=
+lib/std/target/aarch64.zig#L2031
+3:
+https://github.com/ziglang/zig/blob/90477e5c10c9c263a3c0038e1ae7b814d2c5397e/=
+lib/std/target/aarch64.zig#L1507
+
+
+Jeremy Volkman (2):
+  Rename _target_darwin to _target_macos
+  Use -mcpu=3Dapple_m1 when targeting macos + aarch64
+
+ toolchain/private/defs.bzl | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+--=20
+2.34.5
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 4D5B511EF5B
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat, 17 Dec 2022 19:28:06 +0000 (UTC)
+From: ~jvolkman <jvolkman@git.sr.ht>
+Date: Sat, 17 Dec 2022 10:19:28 -0800
+Subject: [PATCH bazel-zig-cc 1/2] Rename _target_darwin to _target_macos
+Message-ID: <167130528597.14686.15641291907532780059-1@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~jvolkman <jeremy@jvolkman.com>
+In-Reply-To: <167130528597.14686.15641291907532780059-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+MIME-Version: 1.0
+Status: O
+Content-Length: 1018
+Lines: 31
+
+From: Jeremy Volkman <jeremy@cedarai.com>
+
+This aligns with bazel's @platforms//os:macos
+---
+ toolchain/private/defs.bzl | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+index 96830ca..8387ce6 100644
+--- a/toolchain/private/defs.bzl
++++ b/toolchain/private/defs.bzl
+@@ -39,14 +39,14 @@ def zig_tool_path(os):
+ def target_structs():
+     ret = []
+     for zigcpu, gocpu in (("x86_64", "amd64"), ("aarch64", "arm64")):
+-        ret.append(_target_darwin(gocpu, zigcpu))
++        ret.append(_target_macos(gocpu, zigcpu))
+         ret.append(_target_windows(gocpu, zigcpu))
+         ret.append(_target_linux_musl(gocpu, zigcpu))
+         for glibc in _GLIBCS:
+             ret.append(_target_linux_gnu(gocpu, zigcpu, glibc))
+     return ret
+ 
+-def _target_darwin(gocpu, zigcpu):
++def _target_macos(gocpu, zigcpu):
+     min_os = "11"
+     return struct(
+         gotarget = "darwin_{}".format(gocpu),
+-- 
+2.34.5
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 67C2811EF0D
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat, 17 Dec 2022 19:28:06 +0000 (UTC)
+From: ~jvolkman <jvolkman@git.sr.ht>
+Date: Sat, 17 Dec 2022 10:26:04 -0800
+Subject: 
+ [PATCH bazel-zig-cc 2/2] Use -mcpu=apple_m1 when targeting macos + aarch64
+Message-ID: <167130528597.14686.15641291907532780059-2@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~jvolkman <jeremy@jvolkman.com>
+In-Reply-To: <167130528597.14686.15641291907532780059-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+MIME-Version: 1.0
+Status: O
+Content-Length: 981
+Lines: 33
+
+From: Jeremy Volkman <jeremy@cedarai.com>
+
+---
+ toolchain/private/defs.bzl | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+index 8387ce6..8571621 100644
+--- a/toolchain/private/defs.bzl
++++ b/toolchain/private/defs.bzl
+@@ -48,6 +48,11 @@ def target_structs():
+ 
+ def _target_macos(gocpu, zigcpu):
+     min_os = "11"
++    copts = []
++
++    if zigcpu == "aarch64":
++        copts = ["-mcpu=apple_m1"]
++
+     return struct(
+         gotarget = "darwin_{}".format(gocpu),
+         zigtarget = "{}-macos-none".format(zigcpu),
+@@ -59,7 +64,7 @@ def _target_macos(gocpu, zigcpu):
+             "libc/include/any-macos-any",
+         ] + _INCLUDE_TAIL,
+         dynamic_library_linkopts = ["-Wl,-undefined=dynamic_lookup"],
+-        copts = [],
++        copts = copts,
+         libc = "darwin",
+         bazel_target_cpu = "darwin",
+         constraint_values = [
+-- 
+2.34.5
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=4+EoGXdTYKSFBPZqzlT3wwpXHnnEGxav8ELNjt9LerM=;
+ c=simple/simple; d=sr.ht; h=Date:From:In-Reply-To:Subject:To:Cc;
+ q=dns/txt; s=srht; t=1671306380; v=1;
+ b=E/O0ssHT/MtvNxttPg0W2VQvOxVHWaGvpydQUsQv83D0vi84H2HSqEUBPvKrmGLEdviGjQWx
+ x1M1RsYxuv9v+8fNwYPEI3CFnVOALYSlkdZUamKmCwMZhiHyrmHXsJ4Y1bnWag4jYl7yQADDNkI
+ q1pWJ3L/WRtUvWVWULRLrlNPxAaVrTHJ8+w1DoEumtdT1Y1YwOSigQ37t22vJyPoi5Wy1H82jh2
+ ZMuYp79X0YW3B7T5AK4C/Hky93cWa+Z91mhvj/BYsdRdmZANg0IwE8wvFtJvR608w/TIF9LsSTi
+ CRW5R6R7x97QYRiY4T1W0yEmNzSTSzZnN2jWN49xVgS4g==
+Received: from localhost (unknown [173.195.146.244])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id 1E98611EF0D;
+	Sat, 17 Dec 2022 19:46:20 +0000 (UTC)
+MIME-Version: 1.0
+Date: Sat, 17 Dec 2022 19:46:20 +0000
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CP4CNZH0ZPUG.247Z9P6ZBAT67@cirno2>
+In-Reply-To: <167130528597.14686.15641291907532780059-2@git.sr.ht>
+Subject: [bazel-zig-cc/patches/.build.yml] build success
+To: "~jvolkman" <jeremy@jvolkman.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 339
+Lines: 10
+
+bazel-zig-cc/patches/.build.yml: SUCCESS in 18m11s
+
+[Use -mcpu=3Dapple_m1 when targeting macos + aarch64][0] from [~jvolkman][1=
+]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/37601
+[1]: mailto:jeremy@jvolkman.com
+
+=E2=9C=93 #906945 SUCCESS bazel-zig-cc/patches/.build.yml https://builds.sr=
+.ht/~motiejus/job/906945
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id E89F411F103
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat, 17 Dec 2022 23:56:27 +0000 (UTC)
+From: ~jvolkman <jvolkman@git.sr.ht>
+Date: Sat, 17 Dec 2022 23:56:27 +0000
+Subject: [PATCH bazel-zig-cc 0/1] Use artifact_name_pattern to specify proper
+ macos and windows artifact names
+MIME-Version: 1.0
+Message-ID: <167132138766.5086.1705176352038753909-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~jvolkman <jeremy@jvolkman.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+Status: O
+Content-Length: 1286
+Lines: 29
+
+I found that Bazel's cc toolchain system allows specifying artifact name
+patterns. So we can make shared libraries end with ".dylib" on macos and
+".dll" on Windows. This is likely a breaking change for anyone relying
+on the defaults, but it seems like the proper thing to do, and the
+built-in toolchains do the same thing.
+
+There wasn't an obvious way to pass complex values from the
+target_structs entries to the zig_cc_toolchain_config rule, so I opted
+to pass a list of json-encoded strings. One other way I thought of was
+to break the artifact_name_pattern parameters into
+"artifact_name_prefixes" and "artifact_name_suffixes" dicts which would
+fit into an attr.string_dict, but it was adding complexity for not much
+gain IMO.
+
+I based this patch on top of my other two recent patchsets. It might not
+apply cleanly on top of main, but conflicts should be small.
+
+Jeremy Volkman (1):
+  Use artifact_name_pattern to specify proper macos and windows artifact
+    names.
+
+ README.md                           | 11 -----------
+ toolchain/private/cc_toolchains.bzl |  5 +++++
+ toolchain/private/defs.bzl          | 26 ++++++++++++++++++++++++++
+ toolchain/zig_toolchain.bzl         |  7 +++++++
+ 4 files changed, 38 insertions(+), 11 deletions(-)
+
+-- 
+2.34.5
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 1EC9111F161
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat, 17 Dec 2022 23:56:28 +0000 (UTC)
+From: ~jvolkman <jvolkman@git.sr.ht>
+Date: Sat, 17 Dec 2022 15:27:21 -0800
+Subject: [PATCH bazel-zig-cc 1/1] Use artifact_name_pattern to specify proper
+ macos and windows artifact names.
+Message-ID: <167132138766.5086.1705176352038753909-1@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~jvolkman <jeremy@jvolkman.com>
+In-Reply-To: <167132138766.5086.1705176352038753909-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 5910
+Lines: 160
+
+From: Jeremy Volkman <jeremy@cedarai.com>
+
+On macos, dynamic libraries are generated as "libfoo.dylib".
+
+On windows, executables end with ".exe", static libraries end with ".lib",
+and dynamic libraries end with ".dll".
+---
+ README.md                           | 11 -----------
+ toolchain/private/cc_toolchains.bzl |  5 +++++
+ toolchain/private/defs.bzl          | 26 ++++++++++++++++++++++++++
+ toolchain/zig_toolchain.bzl         |  7 +++++++
+ 4 files changed, 38 insertions(+), 11 deletions(-)
+
+diff --git a/README.md b/README.md
+index c447ae8..3931247 100644
+--- a/README.md
++++ b/README.md
+@@ -338,17 +338,6 @@ is currently not implemented.
+ target macos.10 (Catalina), macos.11 (Big Sur) or macos.12 (Monterey). It
+ currently targets the lowest version, without ability to change it.
+=20
+-## Windows only: output file extensions
+-
+-For Windows targets Bazel uses Unix extensions for output binaries. Those may
+-need to be renamed before deploying to the Windows system. Here is a primer:
+-
+-| Binary type    | Bazel extension | Windows extension |
+-|----------------|-----------------|-------------------|
+-| Static library | .a              | .lib              |
+-| Shared library | .so             | .dll              |
+-| Executable     | (no extension)  | .exe              |
+-
+ # Known Issues In Upstream
+=20
+ This section lists issues that I've stumbled into when using `zig cc`, and is
+diff --git a/toolchain/private/cc_toolchains.bzl b/toolchain/private/cc_toolc=
+hains.bzl
+index 3fa0b93..a935ef5 100644
+--- a/toolchain/private/cc_toolchains.bzl
++++ b/toolchain/private/cc_toolchains.bzl
+@@ -39,6 +39,10 @@ def declare_cc_toolchains(os, zig_sdk_path):
+         for incl in getattr(target_config, "compiler_extra_includes", []):
+             copts =3D copts + ["-include", zig_sdk_path + "/" + incl]
+=20
++        # We can't pass a list of structs to a rule, so we use json encoding.
++        artifact_name_patterns =3D getattr(target_config, "artifact_name_pat=
+terns", [])
++        artifact_name_pattern_strings =3D [json.encode(p) for p in artifact_=
+name_patterns]
++
+         zig_cc_toolchain_config(
+             name =3D zigtarget + "_cc_config",
+             target =3D zigtarget,
+@@ -53,6 +57,7 @@ def declare_cc_toolchains(os, zig_sdk_path):
+             compiler =3D "clang",
+             abi_version =3D "unknown",
+             abi_libc_version =3D "unknown",
++            artifact_name_patterns =3D artifact_name_pattern_strings,
+             visibility =3D ["//visibility:private"],
+         )
+=20
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+index 8571621..9409f5e 100644
+--- a/toolchain/private/defs.bzl
++++ b/toolchain/private/defs.bzl
+@@ -72,6 +72,13 @@ def _target_macos(gocpu, zigcpu):
+             "@platforms//cpu:{}".format(zigcpu),
+         ],
+         tool_paths =3D {"ld": "ld64.lld"},
++        artifact_name_patterns =3D [
++            {
++                "category_name": "dynamic_library",
++                "prefix": "lib",
++                "extension": ".dylib",
++            },
++        ],
+     )
+=20
+ def _target_windows(gocpu, zigcpu):
+@@ -92,6 +99,23 @@ def _target_windows(gocpu, zigcpu):
+             "@platforms//cpu:{}".format(zigcpu),
+         ],
+         tool_paths =3D {"ld": "ld64.lld"},
++        artifact_name_patterns =3D [
++            {
++                "category_name": "static_library",
++                "prefix": "",
++                "extension": ".lib",
++            },
++            {
++                "category_name": "dynamic_library",
++                "prefix": "",
++                "extension": ".dll",
++            },
++            {
++                "category_name": "executable",
++                "prefix": "",
++                "extension": ".exe",
++            },
++        ],
+     )
+=20
+ def _target_linux_gnu(gocpu, zigcpu, glibc_version):
+@@ -126,6 +150,7 @@ def _target_linux_gnu(gocpu, zigcpu, glibc_version):
+         ],
+         libc_constraint =3D "@zig_sdk//libc:{}".format(glibc_suffix),
+         tool_paths =3D {"ld": "ld.lld"},
++        artifact_name_patterns =3D [],
+     )
+=20
+ def _target_linux_musl(gocpu, zigcpu):
+@@ -151,4 +176,5 @@ def _target_linux_musl(gocpu, zigcpu):
+         ],
+         libc_constraint =3D "@zig_sdk//libc:musl",
+         tool_paths =3D {"ld": "ld.lld"},
++        artifact_name_patterns =3D [],
+     )
+diff --git a/toolchain/zig_toolchain.bzl b/toolchain/zig_toolchain.bzl
+index 2578973..974221f 100644
+--- a/toolchain/zig_toolchain.bzl
++++ b/toolchain/zig_toolchain.bzl
+@@ -1,6 +1,7 @@
+ load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+ load(
+     "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
++    "artifact_name_pattern",
+     "feature",
+     "feature_set",
+     "flag_group",
+@@ -140,6 +141,10 @@ def _zig_cc_toolchain_config_impl(ctx):
+         supports_dynamic_linker,
+     ] + _compilation_mode_features(ctx)
+=20
++    artifact_name_patterns =3D [
++        artifact_name_pattern(**json.decode(p)) for p in ctx.attr.artifact_n=
+ame_patterns
++    ]
++
+     return cc_common.create_cc_toolchain_config_info(
+         ctx =3D ctx,
+         features =3D features,
+@@ -156,6 +161,7 @@ def _zig_cc_toolchain_config_impl(ctx):
+             for name, path in ctx.attr.tool_paths.items()
+         ],
+         cxx_builtin_include_directories =3D ctx.attr.cxx_builtin_include_dir=
+ectories,
++        artifact_name_patterns =3D artifact_name_patterns,
+     )
+=20
+ zig_cc_toolchain_config =3D rule(
+@@ -174,6 +180,7 @@ zig_cc_toolchain_config =3D rule(
+         "compiler": attr.string(),
+         "abi_version": attr.string(),
+         "abi_libc_version": attr.string(),
++        "artifact_name_patterns": attr.string_list(),
+     },
+     provides =3D [CcToolchainConfigInfo],
+ )
+--=20
+2.34.5
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=lQ/sf/yE9eKxhnwauX7K3Ve92atirTQn6we2cXX7mcA=;
+ c=simple/simple; d=sr.ht; h=Date:To:Cc:From:In-Reply-To:Subject;
+ q=dns/txt; s=srht; t=1671321437; v=1;
+ b=glOY+ahAMS8qZax0hyzlXX+m53d5GExecJWP4AWd7GOQRgY2d70bimtRL8FCmBVIFAA5Ue1+
+ oDb+DikuQE58h2j4rgBOxeGBxFr1b9Rxvxc7eFnbGElOhODkcflEkc7BhW5V1Q6agyFpVOdUfLs
+ vvCNTnw7BAbh4BafAh3niYNYMQaePxZqiiQHxeCY37Ep3XblAY1xQJobNaHtbhyX6iF8H8Tg4+M
+ tZMNXNSYnZ4eO6vuUf+HpwQ7QDnF8Y9tcVNgVrLP4urhOL2ozErBAjs/DQzzyYD282hPnRUEOU+
+ /0VvVL9ukWzetNVROsaZ2RXOdeozP4NAs3yzA0sYDaMhw==
+Received: from localhost (unknown [173.195.146.249])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id 7C92F11F103;
+	Sat, 17 Dec 2022 23:57:17 +0000 (UTC)
+MIME-Version: 1.0
+Date: Sat, 17 Dec 2022 23:57:17 +0000
+To: "~jvolkman" <jeremy@jvolkman.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CP4I04SZK598.1JK9JTPTL69N9@cirno>
+In-Reply-To: <167132138766.5086.1705176352038753909-1@git.sr.ht>
+Subject: [bazel-zig-cc/patches/.build.yml] build failed
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain; charset=UTF-8
+Status: O
+Content-Length: 359
+Lines: 10
+
+bazel-zig-cc/patches/.build.yml: FAILED in 47s
+
+[Use artifact_name_pattern to specify proper macos and windows artifact nam=
+es][0] from [~jvolkman][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/37613
+[1]: mailto:jeremy@jvolkman.com
+
+=E2=9C=97 #907041 FAILED bazel-zig-cc/patches/.build.yml https://builds.sr.=
+ht/~motiejus/job/907041
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id DB6C811F103
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sun, 18 Dec 2022 00:03:47 +0000 (UTC)
+From: ~jvolkman <jvolkman@git.sr.ht>
+Date: Sun, 18 Dec 2022 00:03:47 +0000
+Subject: [PATCH bazel-zig-cc v2 0/1] Use artifact_name_pattern to specify
+ proper macos and windows artifact names
+MIME-Version: 1.0
+Message-ID: <167132182778.22969.1520355961703744701-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~jvolkman <jeremy@jvolkman.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+Status: O
+Content-Length: 1228
+Lines: 29
+
+[This is the second revision which should apply cleanly to the main
+branch]
+
+I found that Bazel's cc toolchain system allows specifying artifact name
+patterns. So we can make shared libraries end with ".dylib" on macos and
+".dll" on Windows. This is likely a breaking change for anyone relying
+on the defaults, but it seems like the proper thing to do, and the
+built-in toolchains do the same thing.
+
+There wasn't an obvious way to pass complex values from the
+target_structs entries to the zig_cc_toolchain_config rule, so I opted
+to pass a list of json-encoded strings. One other way I thought of was
+to break the artifact_name_pattern parameters into
+"artifact_name_prefixes" and "artifact_name_suffixes" dicts which would
+fit into an attr.string_dict, but it was adding complexity for not much
+gain IMO.
+
+Jeremy Volkman (1):
+  Use artifact_name_pattern to specify proper macos and windows artifact
+    names.
+
+ README.md                           | 11 -----------
+ toolchain/private/cc_toolchains.bzl |  5 +++++
+ toolchain/private/defs.bzl          | 26 ++++++++++++++++++++++++++
+ toolchain/zig_toolchain.bzl         |  7 +++++++
+ 4 files changed, 38 insertions(+), 11 deletions(-)
+
+-- 
+2.34.5
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 019CA11F161
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sun, 18 Dec 2022 00:03:48 +0000 (UTC)
+From: ~jvolkman <jvolkman@git.sr.ht>
+Date: Sat, 17 Dec 2022 15:27:21 -0800
+Subject: [PATCH bazel-zig-cc v2 1/1] Use artifact_name_pattern to specify
+ proper macos and windows artifact names.
+Message-ID: <167132182778.22969.1520355961703744701-1@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~jvolkman <jeremy@jvolkman.com>
+In-Reply-To: <167132182778.22969.1520355961703744701-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 5908
+Lines: 160
+
+From: Jeremy Volkman <jeremy@cedarai.com>
+
+On macos, dynamic libraries are generated as "libfoo.dylib".
+
+On windows, executables end with ".exe", static libraries end with ".lib",
+and dynamic libraries end with ".dll".
+---
+ README.md                           | 11 -----------
+ toolchain/private/cc_toolchains.bzl |  5 +++++
+ toolchain/private/defs.bzl          | 26 ++++++++++++++++++++++++++
+ toolchain/zig_toolchain.bzl         |  7 +++++++
+ 4 files changed, 38 insertions(+), 11 deletions(-)
+
+diff --git a/README.md b/README.md
+index c447ae8..3931247 100644
+--- a/README.md
++++ b/README.md
+@@ -338,17 +338,6 @@ is currently not implemented.
+ target macos.10 (Catalina), macos.11 (Big Sur) or macos.12 (Monterey). It
+ currently targets the lowest version, without ability to change it.
+=20
+-## Windows only: output file extensions
+-
+-For Windows targets Bazel uses Unix extensions for output binaries. Those may
+-need to be renamed before deploying to the Windows system. Here is a primer:
+-
+-| Binary type    | Bazel extension | Windows extension |
+-|----------------|-----------------|-------------------|
+-| Static library | .a              | .lib              |
+-| Shared library | .so             | .dll              |
+-| Executable     | (no extension)  | .exe              |
+-
+ # Known Issues In Upstream
+=20
+ This section lists issues that I've stumbled into when using `zig cc`, and is
+diff --git a/toolchain/private/cc_toolchains.bzl b/toolchain/private/cc_toolc=
+hains.bzl
+index 3fa0b93..a935ef5 100644
+--- a/toolchain/private/cc_toolchains.bzl
++++ b/toolchain/private/cc_toolchains.bzl
+@@ -39,6 +39,10 @@ def declare_cc_toolchains(os, zig_sdk_path):
+         for incl in getattr(target_config, "compiler_extra_includes", []):
+             copts =3D copts + ["-include", zig_sdk_path + "/" + incl]
+=20
++        # We can't pass a list of structs to a rule, so we use json encoding.
++        artifact_name_patterns =3D getattr(target_config, "artifact_name_pat=
+terns", [])
++        artifact_name_pattern_strings =3D [json.encode(p) for p in artifact_=
+name_patterns]
++
+         zig_cc_toolchain_config(
+             name =3D zigtarget + "_cc_config",
+             target =3D zigtarget,
+@@ -53,6 +57,7 @@ def declare_cc_toolchains(os, zig_sdk_path):
+             compiler =3D "clang",
+             abi_version =3D "unknown",
+             abi_libc_version =3D "unknown",
++            artifact_name_patterns =3D artifact_name_pattern_strings,
+             visibility =3D ["//visibility:private"],
+         )
+=20
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+index 96830ca..3ff4cd0 100644
+--- a/toolchain/private/defs.bzl
++++ b/toolchain/private/defs.bzl
+@@ -67,6 +67,13 @@ def _target_darwin(gocpu, zigcpu):
+             "@platforms//cpu:{}".format(zigcpu),
+         ],
+         tool_paths =3D {"ld": "ld64.lld"},
++        artifact_name_patterns =3D [
++            {
++                "category_name": "dynamic_library",
++                "prefix": "lib",
++                "extension": ".dylib",
++            },
++        ],
+     )
+=20
+ def _target_windows(gocpu, zigcpu):
+@@ -87,6 +94,23 @@ def _target_windows(gocpu, zigcpu):
+             "@platforms//cpu:{}".format(zigcpu),
+         ],
+         tool_paths =3D {"ld": "ld64.lld"},
++        artifact_name_patterns =3D [
++            {
++                "category_name": "static_library",
++                "prefix": "",
++                "extension": ".lib",
++            },
++            {
++                "category_name": "dynamic_library",
++                "prefix": "",
++                "extension": ".dll",
++            },
++            {
++                "category_name": "executable",
++                "prefix": "",
++                "extension": ".exe",
++            },
++        ],
+     )
+=20
+ def _target_linux_gnu(gocpu, zigcpu, glibc_version):
+@@ -121,6 +145,7 @@ def _target_linux_gnu(gocpu, zigcpu, glibc_version):
+         ],
+         libc_constraint =3D "@zig_sdk//libc:{}".format(glibc_suffix),
+         tool_paths =3D {"ld": "ld.lld"},
++        artifact_name_patterns =3D [],
+     )
+=20
+ def _target_linux_musl(gocpu, zigcpu):
+@@ -146,4 +171,5 @@ def _target_linux_musl(gocpu, zigcpu):
+         ],
+         libc_constraint =3D "@zig_sdk//libc:musl",
+         tool_paths =3D {"ld": "ld.lld"},
++        artifact_name_patterns =3D [],
+     )
+diff --git a/toolchain/zig_toolchain.bzl b/toolchain/zig_toolchain.bzl
+index f76aa80..7bd31ee 100644
+--- a/toolchain/zig_toolchain.bzl
++++ b/toolchain/zig_toolchain.bzl
+@@ -1,6 +1,7 @@
+ load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+ load(
+     "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
++    "artifact_name_pattern",
+     "feature",
+     "feature_set",
+     "flag_group",
+@@ -134,6 +135,10 @@ def _zig_cc_toolchain_config_impl(ctx):
+         default_linker_flags,
+     ] + _compilation_mode_features(ctx)
+=20
++    artifact_name_patterns =3D [
++        artifact_name_pattern(**json.decode(p)) for p in ctx.attr.artifact_n=
+ame_patterns
++    ]
++
+     return cc_common.create_cc_toolchain_config_info(
+         ctx =3D ctx,
+         features =3D features,
+@@ -150,6 +155,7 @@ def _zig_cc_toolchain_config_impl(ctx):
+             for name, path in ctx.attr.tool_paths.items()
+         ],
+         cxx_builtin_include_directories =3D ctx.attr.cxx_builtin_include_dir=
+ectories,
++        artifact_name_patterns =3D artifact_name_patterns,
+     )
+=20
+ zig_cc_toolchain_config =3D rule(
+@@ -168,6 +174,7 @@ zig_cc_toolchain_config =3D rule(
+         "compiler": attr.string(),
+         "abi_version": attr.string(),
+         "abi_libc_version": attr.string(),
++        "artifact_name_patterns": attr.string_list(),
+     },
+     provides =3D [CcToolchainConfigInfo],
+ )
+--=20
+2.34.5
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=8rBuJCAjAvEg2EB1R2O+D8aaQ7Nim31RACivz90X7bI=;
+ c=simple/simple; d=sr.ht; h=Date:From:In-Reply-To:Subject:To:Cc;
+ q=dns/txt; s=srht; t=1671321889; v=1;
+ b=qnHQPLW3aaXAmBWztMlUo1O0HWkVPqre6SE0s+JkmAeIsNKG9xxMZ43m5GVHYsf1qw5UPs1N
+ iwEPo+KZE1D5KkY8jHeXrE8J3z9YOofmy+6ikPzP37e3FIfsKR3gpsLzsrhv288A5o7zTYCgT8e
+ Mcm/Cj/oz+linchVvFDN/GMbQ3HIL+ZRtJEoclqk7qDud1uj/Sicf9J3f8s+DarTGF4tj1vbHBx
+ ZEb/OaAxWG6XEKl9+y2YIc8C/EOr/Q0Zejro9OIz8ZbxSQ5qFEbp1uSKJxMQABejLxnEZfwCOIb
+ 4TpbOuKv98L8kA8ZIIyPz6m9FgYCV775ADW2B5kq0vPdw==
+Received: from localhost (unknown [173.195.146.249])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id 81DF011F103;
+	Sun, 18 Dec 2022 00:04:49 +0000 (UTC)
+MIME-Version: 1.0
+Date: Sun, 18 Dec 2022 00:04:49 +0000
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CP4I5WHKFI7T.8GIPTF6JMCNI@cirno>
+In-Reply-To: <167132182778.22969.1520355961703744701-1@git.sr.ht>
+Subject: [bazel-zig-cc/patches/.build.yml] build failed
+To: "~jvolkman" <jeremy@jvolkman.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 363
+Lines: 10
+
+bazel-zig-cc/patches/.build.yml: FAILED in 1m0s
+
+[Use artifact_name_pattern to specify proper macos and windows artifact nam=
+es][0] v2 from [~jvolkman][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/37614
+[1]: mailto:jeremy@jvolkman.com
+
+=E2=9C=97 #907046 FAILED bazel-zig-cc/patches/.build.yml https://builds.sr.=
+ht/~motiejus/job/907046
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 9353311F0F6
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sun, 18 Dec 2022 00:18:23 +0000 (UTC)
+From: ~jvolkman <jvolkman@git.sr.ht>
+Date: Sun, 18 Dec 2022 00:18:23 +0000
+Subject: [PATCH bazel-zig-cc v3 0/1] Use artifact_name_pattern to specify
+ proper macos and windows artifact names
+MIME-Version: 1.0
+Message-ID: <167132270337.32399.6857496830832816046-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~jvolkman <jeremy@jvolkman.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+Status: O
+Content-Length: 1236
+Lines: 30
+
+Changelog:
+# v2: should apply cleanly to the main branch
+# v3: fix a linter error
+
+I found that Bazel's cc toolchain system allows specifying artifact name
+patterns. So we can make shared libraries end with ".dylib" on macos and
+".dll" on Windows. This is likely a breaking change for anyone relying
+on the defaults, but it seems like the proper thing to do, and the
+built-in toolchains do the same thing.
+
+There wasn't an obvious way to pass complex values from the
+target_structs entries to the zig_cc_toolchain_config rule, so I opted
+to pass a list of json-encoded strings. One other way I thought of was
+to break the artifact_name_pattern parameters into
+"artifact_name_prefixes" and "artifact_name_suffixes" dicts which would
+fit into an attr.string_dict, but it was adding complexity for not much
+gain IMO.
+
+Jeremy Volkman (1):
+  Use artifact_name_pattern to specify proper macos and windows artifact
+    names.
+
+ README.md                           | 11 -----------
+ toolchain/private/cc_toolchains.bzl |  5 +++++
+ toolchain/private/defs.bzl          | 26 ++++++++++++++++++++++++++
+ toolchain/zig_toolchain.bzl         |  8 ++++++++
+ 4 files changed, 39 insertions(+), 11 deletions(-)
+
+-- 
+2.34.5
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id B1BCD11F103
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sun, 18 Dec 2022 00:18:23 +0000 (UTC)
+From: ~jvolkman <jvolkman@git.sr.ht>
+Date: Sat, 17 Dec 2022 15:27:21 -0800
+Subject: [PATCH bazel-zig-cc v3 1/1] Use artifact_name_pattern to specify
+ proper macos and windows artifact names.
+Message-ID: <167132270337.32399.6857496830832816046-1@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~jvolkman <jeremy@jvolkman.com>
+In-Reply-To: <167132270337.32399.6857496830832816046-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+Status: O
+Content-Length: 5916
+Lines: 160
+
+From: Jeremy Volkman <jeremy@cedarai.com>
+
+On macos, dynamic libraries are generated as "libfoo.dylib".
+
+On windows, executables end with ".exe", static libraries end with ".lib",
+and dynamic libraries end with ".dll".
+---
+ README.md                           | 11 -----------
+ toolchain/private/cc_toolchains.bzl |  5 +++++
+ toolchain/private/defs.bzl          | 26 ++++++++++++++++++++++++++
+ toolchain/zig_toolchain.bzl         |  8 ++++++++
+ 4 files changed, 39 insertions(+), 11 deletions(-)
+
+diff --git a/README.md b/README.md
+index c447ae8..3931247 100644
+--- a/README.md
++++ b/README.md
+@@ -338,17 +338,6 @@ is currently not implemented.
+ target macos.10 (Catalina), macos.11 (Big Sur) or macos.12 (Monterey). It
+ currently targets the lowest version, without ability to change it.
+=20
+-## Windows only: output file extensions
+-
+-For Windows targets Bazel uses Unix extensions for output binaries. Those may
+-need to be renamed before deploying to the Windows system. Here is a primer:
+-
+-| Binary type    | Bazel extension | Windows extension |
+-|----------------|-----------------|-------------------|
+-| Static library | .a              | .lib              |
+-| Shared library | .so             | .dll              |
+-| Executable     | (no extension)  | .exe              |
+-
+ # Known Issues In Upstream
+=20
+ This section lists issues that I've stumbled into when using `zig cc`, and is
+diff --git a/toolchain/private/cc_toolchains.bzl b/toolchain/private/cc_toolc=
+hains.bzl
+index 3fa0b93..a935ef5 100644
+--- a/toolchain/private/cc_toolchains.bzl
++++ b/toolchain/private/cc_toolchains.bzl
+@@ -39,6 +39,10 @@ def declare_cc_toolchains(os, zig_sdk_path):
+         for incl in getattr(target_config, "compiler_extra_includes", []):
+             copts =3D copts + ["-include", zig_sdk_path + "/" + incl]
+=20
++        # We can't pass a list of structs to a rule, so we use json encoding.
++        artifact_name_patterns =3D getattr(target_config, "artifact_name_pat=
+terns", [])
++        artifact_name_pattern_strings =3D [json.encode(p) for p in artifact_=
+name_patterns]
++
+         zig_cc_toolchain_config(
+             name =3D zigtarget + "_cc_config",
+             target =3D zigtarget,
+@@ -53,6 +57,7 @@ def declare_cc_toolchains(os, zig_sdk_path):
+             compiler =3D "clang",
+             abi_version =3D "unknown",
+             abi_libc_version =3D "unknown",
++            artifact_name_patterns =3D artifact_name_pattern_strings,
+             visibility =3D ["//visibility:private"],
+         )
+=20
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+index 96830ca..3ff4cd0 100644
+--- a/toolchain/private/defs.bzl
++++ b/toolchain/private/defs.bzl
+@@ -67,6 +67,13 @@ def _target_darwin(gocpu, zigcpu):
+             "@platforms//cpu:{}".format(zigcpu),
+         ],
+         tool_paths =3D {"ld": "ld64.lld"},
++        artifact_name_patterns =3D [
++            {
++                "category_name": "dynamic_library",
++                "prefix": "lib",
++                "extension": ".dylib",
++            },
++        ],
+     )
+=20
+ def _target_windows(gocpu, zigcpu):
+@@ -87,6 +94,23 @@ def _target_windows(gocpu, zigcpu):
+             "@platforms//cpu:{}".format(zigcpu),
+         ],
+         tool_paths =3D {"ld": "ld64.lld"},
++        artifact_name_patterns =3D [
++            {
++                "category_name": "static_library",
++                "prefix": "",
++                "extension": ".lib",
++            },
++            {
++                "category_name": "dynamic_library",
++                "prefix": "",
++                "extension": ".dll",
++            },
++            {
++                "category_name": "executable",
++                "prefix": "",
++                "extension": ".exe",
++            },
++        ],
+     )
+=20
+ def _target_linux_gnu(gocpu, zigcpu, glibc_version):
+@@ -121,6 +145,7 @@ def _target_linux_gnu(gocpu, zigcpu, glibc_version):
+         ],
+         libc_constraint =3D "@zig_sdk//libc:{}".format(glibc_suffix),
+         tool_paths =3D {"ld": "ld.lld"},
++        artifact_name_patterns =3D [],
+     )
+=20
+ def _target_linux_musl(gocpu, zigcpu):
+@@ -146,4 +171,5 @@ def _target_linux_musl(gocpu, zigcpu):
+         ],
+         libc_constraint =3D "@zig_sdk//libc:musl",
+         tool_paths =3D {"ld": "ld.lld"},
++        artifact_name_patterns =3D [],
+     )
+diff --git a/toolchain/zig_toolchain.bzl b/toolchain/zig_toolchain.bzl
+index f76aa80..bebd1da 100644
+--- a/toolchain/zig_toolchain.bzl
++++ b/toolchain/zig_toolchain.bzl
+@@ -1,6 +1,7 @@
+ load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+ load(
+     "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
++    "artifact_name_pattern",
+     "feature",
+     "feature_set",
+     "flag_group",
+@@ -134,6 +135,11 @@ def _zig_cc_toolchain_config_impl(ctx):
+         default_linker_flags,
+     ] + _compilation_mode_features(ctx)
+=20
++    artifact_name_patterns =3D [
++        artifact_name_pattern(**json.decode(p))
++        for p in ctx.attr.artifact_name_patterns
++    ]
++
+     return cc_common.create_cc_toolchain_config_info(
+         ctx =3D ctx,
+         features =3D features,
+@@ -150,6 +156,7 @@ def _zig_cc_toolchain_config_impl(ctx):
+             for name, path in ctx.attr.tool_paths.items()
+         ],
+         cxx_builtin_include_directories =3D ctx.attr.cxx_builtin_include_dir=
+ectories,
++        artifact_name_patterns =3D artifact_name_patterns,
+     )
+=20
+ zig_cc_toolchain_config =3D rule(
+@@ -168,6 +175,7 @@ zig_cc_toolchain_config =3D rule(
+         "compiler": attr.string(),
+         "abi_version": attr.string(),
+         "abi_libc_version": attr.string(),
++        "artifact_name_patterns": attr.string_list(),
+     },
+     provides =3D [CcToolchainConfigInfo],
+ )
+--=20
+2.34.5
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=24fbNqgKGb5+hnCSSGK5euIUNyLWMMmzDHdiEAKm20Y=;
+ c=simple/simple; d=sr.ht; h=Date:Subject:To:Cc:From:In-Reply-To;
+ q=dns/txt; s=srht; t=1671323784; v=1;
+ b=p43ZnUo7iXAS2erOyTIrINtLtrbwMzVt+R1IPoQxG6UXBu2+4skXEaWauN10LYsmnNgSWnrL
+ Dj1+aqUNP+kOGxxGz4C7kH4+LubNmXsPwwsCV67igwMrcQsLspxPT8ZbHmfgCQZR4IfJp++Jg2J
+ HsdYP7OQis89yFoohCux2xhXMJT5IYWS7hHs8spCzzi6mwocylXVtarAfFbG9D+iT0aOXxUTYrb
+ k0mhe33Ijg3/goe9rqVfOzQbjYpgLhTXHuDdSCXVdznphuEn6FRsmHYlSS4YiAnZhB6lyiySd7j
+ D/SVJ5Nj18/LppJwdXe8t2GLQsWHAnHbVThhyjXC4RQTg==
+Received: from localhost (unknown [173.195.146.249])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id B933611F0F6;
+	Sun, 18 Dec 2022 00:36:24 +0000 (UTC)
+MIME-Version: 1.0
+Date: Sun, 18 Dec 2022 00:36:24 +0000
+Subject: [bazel-zig-cc/patches/.build.yml] build success
+To: "~jvolkman" <jeremy@jvolkman.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CP4IU33AM0YO.2Y1R1A3B83MJJ@cirno>
+In-Reply-To: <167132270337.32399.6857496830832816046-1@git.sr.ht>
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 367
+Lines: 10
+
+bazel-zig-cc/patches/.build.yml: SUCCESS in 17m59s
+
+[Use artifact_name_pattern to specify proper macos and windows artifact nam=
+es][0] v3 from [~jvolkman][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/37615
+[1]: mailto:jeremy@jvolkman.com
+
+=E2=9C=93 #907052 SUCCESS bazel-zig-cc/patches/.build.yml https://builds.sr=
+.ht/~motiejus/job/907052
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f41.google.com (mail-oa1-f41.google.com [209.85.160.41])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 7E26911EF68
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sun, 18 Dec 2022 03:33:16 +0000 (UTC)
+Received: by mail-oa1-f41.google.com with SMTP id 586e51a60fabf-1433ef3b61fso7900385fac.10
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Sat, 17 Dec 2022 19:33:16 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:from:to:cc:subject:date:message-id:reply-to;
+        bh=VQQ5JQQXydXvQrrZM6bgyC/G5bES5UgkO+QOKjvz0Ho=;
+        b=5seBlbZXjIy94Gr8XclRAZ6R2v/Nj4WFjcfp0ZrEaE/hQPEVbpzOLAegTCz1XXnoJH
+         Z+8ZWCAmlrxuwBUDQ5G4sPjmMeRIgEIF869YSVsqRiF3zmp/fbs6FlNCnFkuGf4qsb+N
+         stxiAVEa2rf60FiMwl/4M/IGRduQNvIAKSotixLMqAKrkmmn67tEHF4cbNgSZeg1K7Gi
+         +jQ+Wy+szKQl+Dm0kHow43o/wkGMx6YGIVAcsqlOo9PSjvJunBaHp2AcvIr07QB9tp3V
+         fheQ4xSMIB6W/BNm+Nz+rb6IfG8eLsJD4wHPEQ2bpodm4ASnmhDG5pls6OXyESjOTDV9
+         kQwA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:x-gm-message-state:from:to:cc:subject:date:message-id
+         :reply-to;
+        bh=VQQ5JQQXydXvQrrZM6bgyC/G5bES5UgkO+QOKjvz0Ho=;
+        b=sJVZXkEGtJLQB7i9Q9KEqL4uRrP0Xey/2GEjnrbnK1rZlBbKHMvxb9r60nTxUlnJ13
+         V9E63U3n1vIc0b5L+wYlUrz2uic26sPxeMNOap5WPnQrwqQtB0/XdnZL0AugZvkeUnQv
+         pMZlk6hni5E62ikjuUUMYLA5T+xuqr3d5Z8ySJyz0svbCBAveS3yH8Y82EmkVQYtZi7e
+         OoylzxhADMfwzUpcxBk0qdviZEr8a6IuZKZNyo+XgvSS3ibtLJxSTb5lB7DQWHfse30j
+         lqFzpuTuZvrWyJ7So/W8QvLTeJ2uB/y8M9y7teAVhs8VK1P7w3NN693azGmP22xVF28t
+         l4YA==
+X-Gm-Message-State: AFqh2kp0PnV6747vhhxqcArKCeNCxc7pxaNTSc5U+bU9VHb8GBAdjBxh
+	8xmST05gEdzmhWUgoGZX5GTIG/5XL4lzLEFeM/I=
+X-Google-Smtp-Source: AMrXdXte+V60oaY3T4ine7Xqbr5Q2j2ashSMuQdH9RG66mOT4iN/4Px4KzJrOYZsavMrc/UPABTopoGqIVKu02GE7XI=
+X-Received: by 2002:a05:6870:d147:b0:143:fa7f:2b29 with SMTP id
+ f7-20020a056870d14700b00143fa7f2b29mr1301172oac.116.1671334395794; Sat, 17
+ Dec 2022 19:33:15 -0800 (PST)
+MIME-Version: 1.0
+References: <167132270337.32399.6857496830832816046-0@git.sr.ht> <167132270337.32399.6857496830832816046-1@git.sr.ht>
+In-Reply-To: <167132270337.32399.6857496830832816046-1@git.sr.ht>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Sun, 18 Dec 2022 05:33:04 +0200
+Message-ID: <CAFVMu-qp3cuDjMvQ9_qhFHXziN+iOwinPYN9=0d9Qqu17BSv4Q@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc v3 1/1] Use artifact_name_pattern to specify
+ proper macos and windows artifact names.
+To: "~jvolkman" <jeremy@jvolkman.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 660
+Lines: 18
+
+On Sun, Dec 18, 2022 at 2:18 AM ~jvolkman <jvolkman@git.sr.ht> wrote:
+>
+> From: Jeremy Volkman <jeremy@cedarai.com>
+>
+> On macos, dynamic libraries are generated as "libfoo.dylib".
+>
+> On windows, executables end with ".exe", static libraries end with ".lib",
+> and dynamic libraries end with ".dll".
+> ---
+>  README.md                           | 11 -----------
+>  toolchain/private/cc_toolchains.bzl |  5 +++++
+>  toolchain/private/defs.bzl          | 26 ++++++++++++++++++++++++++
+>  toolchain/zig_toolchain.bzl         |  8 ++++++++
+>  4 files changed, 39 insertions(+), 11 deletions(-)
+
+Thanks! Applied all 4 patches verbatim.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id D675011EF44;
+	Fri, 23 Dec 2022 11:04:31 +0000 (UTC)
+From: ~motiejus <motiejus@git.sr.ht>
+Date: Fri, 23 Dec 2022 11:04:31 +0000
+MIME-Version: 1.0
+Subject: 
+ [PATCH bazel-zig-cc 0/1] zig launcher: replace shell wrappers with a binary
+Message-ID: <167179347159.25324.12223141818448163553-0@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~motiejus <motiejus@jakstys.lt>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht, fabian@hahn.graphics
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 930
+Lines: 24
+
+TLDR: I am looking to replace the two (unix and windows) shell scripts
+with a single program with unit tests. Motivations and more discussion
+in the commit message. If there are any concerns with it, it is a great
+time to raise them.
+
+Fabian, I did my best to test this "on windows" without actually having
+a windows host. Please let me know if it works for you. Hopefully I
+don't break the windows wrapper ever again!
+
+Motiejus Jak=C5=A1tys (1):
+  zig launcher: replace shell wrappers with a binary
+
+ .build.yml                 |   9 +-
+ ci/launcher                |  13 +
+ ci/test                    |  25 +-
+ toolchain/defs.bzl         | 128 +++------
+ toolchain/launcher.zig     | 531 +++++++++++++++++++++++++++++++++++++
+ toolchain/private/defs.bzl |   2 +-
+ 6 files changed, 613 insertions(+), 95 deletions(-)
+ create mode 100755 ci/launcher
+ create mode 100644 toolchain/launcher.zig
+
+--=20
+2.34.5
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=none 
+Received: from git.sr.ht (unknown [173.195.146.142])
+	by mail-b.sr.ht (Postfix) with ESMTPSA id 0259E11EF68;
+	Fri, 23 Dec 2022 11:04:32 +0000 (UTC)
+From: ~motiejus <motiejus@git.sr.ht>
+Date: Tue, 20 Dec 2022 17:00:50 +0200
+Subject: 
+ [PATCH bazel-zig-cc 1/1] zig launcher: replace shell wrappers with a binary
+MIME-Version: 1.0
+Message-ID: <167179347159.25324.12223141818448163553-1@git.sr.ht>
+X-Mailer: git.sr.ht
+Reply-to: ~motiejus <motiejus@jakstys.lt>
+In-Reply-To: <167179347159.25324.12223141818448163553-0@git.sr.ht>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht, fabian@hahn.graphics
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 29801
+Lines: 851
+
+From: Motiejus Jak=C5=A1tys <motiejus@uber.com>
+
+Until now we needed to maintain two versions of the zig launcher: one
+for Windows and one for everything else. This was problematic for two
+reasons:
+1. I do not know powershell and thus keep breaking the Windows wrapper
+   all the time (see git history of Fabian fixing stuff that I broke).
+2. This makes bazel-zig-cc dependent on the system shell, making it not
+   really hermetic. So the recently added
+   `--experimental_use_hermetic_linux_sandbox` does not work with
+   bazel-zig-cc, unless we bind-mount a bunch of stuff: `/usr`, `/bin`,
+   `/lib`, `/usr/lib:/lib`, `/usr/lib64:/lib64` and `/proc`.
+
+Switching to a Zig-based wrapper solves both issues, and we can do this:
+
+    bazel build "$@" \
+        --experimental_use_hermetic_linux_sandbox \
+        --sandbox_add_mount_pair=3D/proc \
+        <...>
+
+Zig itself still depends on `/proc` for `/proc/self/exe`, so we need to
+keep that. I will look into reducing even that dependency separately.
+
+Not all is nice and shiny though: this commit replaces ~80 LOC worth of
+shell scripts wrappers with a singe ~250 LOC zig program, which is
+arguably harder to understand. However, it is easier to change, at least
+for me, because it's a single file with unit tests! Most importantly,
+the gnarly code (which resolves paths and sets environment variables) is
+cross-platform.
+---
+ .build.yml                 |   9 +-
+ ci/launcher                |  13 +
+ ci/test                    |  25 +-
+ toolchain/defs.bzl         | 128 +++------
+ toolchain/launcher.zig     | 531 +++++++++++++++++++++++++++++++++++++
+ toolchain/private/defs.bzl |   2 +-
+ 6 files changed, 613 insertions(+), 95 deletions(-)
+ create mode 100755 ci/launcher
+ create mode 100644 toolchain/launcher.zig
+
+diff --git a/.build.yml b/.build.yml
+index 664b847..e12a558 100644
+--- a/.build.yml
++++ b/.build.yml
+@@ -31,6 +31,13 @@ tasks:
+   - list_toolchains_platforms: |
+       cd bazel-zig-cc; . .envrc
+       ./ci/list_toolchains_platforms
++  - test_launcher: |
++      cd bazel-zig-cc; . .envrc
++      ./ci/launcher --color=3Dyes --curses=3Dyes
+   - test: |
+       cd bazel-zig-cc; . .envrc
+-      ./ci/test --color=3Dyes --curses=3Dyes
++      export BAZEL_ZIG_CC_CACHE_PREFIX=3D/tmp/bazel-zig-cc-2
++      ./ci/test \
++        --color=3Dyes --curses=3Dyes \
++        --repo_env BAZEL_ZIG_CC_CACHE_PREFIX=3D$BAZEL_ZIG_CC_CACHE_PREFIX \
++        --sandbox_writable_path "$BAZEL_ZIG_CC_CACHE_PREFIX"
+diff --git a/ci/launcher b/ci/launcher
+new file mode 100755
+index 0000000..2c57c8f
+--- /dev/null
++++ b/ci/launcher
+@@ -0,0 +1,13 @@
++#!/usr/bin/env bash
++set -xeuo pipefail
++
++# until bazel-zig-cc gets a zig toolchain, run launcher's unit tests here.
++bazel run "$@" @zig_sdk//:zig -- test toolchain/launcher.zig
++
++# ReleaseSafe because of https://github.com/ziglang/zig/issues/14036
++bazel run "$@" @zig_sdk//:zig -- test \
++    -OReleaseSafe \
++    -target x86_64-windows-gnu \
++    --test-cmd wine64-stable \
++    --test-cmd-bin \
++    toolchain/launcher.zig
+diff --git a/ci/test b/ci/test
+index e3f4cf5..4cbc3ca 100755
+--- a/ci/test
++++ b/ci/test
+@@ -1,16 +1,29 @@
+ #!/usr/bin/env bash
+-set -euo pipefail
++set -xeuo pipefail
++
++BAZEL_ZIG_CC_CACHE_PREFIX=3D${BAZEL_ZIG_CC_CACHE_PREFIX:-/tmp/bazel-zig-cc}
++mkdir -p "${BAZEL_ZIG_CC_CACHE_PREFIX}"
+=20
+ bazel test "$@" ...
+=20
+-# /tmp/bazel-zig-cc should be empty for the test below to be valid.
+-# This test ensures that github.com/ziglang/zig/issues/13050 does not
+-# regress
+-find /tmp/bazel-zig-cc -name mutex_destructor.o -execdir file '{}' \; | \
++bazel clean; bazel shutdown
++
++# smoke-test a very hermetic setup with a single target. Re-building all of
++# them takes a long time, so using only one. If we ever decide to build all
++# targets, we will need to exclude Go, since go dynamically links to glibc on
++# linux.
++bazel build "$@" \
++    --experimental_use_hermetic_linux_sandbox \
++    --sandbox_add_mount_pair=3D/proc \
++    //test/c:which_libc_linux_amd64_gnu.2.19
++
++# $BAZEL_ZIG_CC_CACHE_PREFIX should be empty for the test below to be valid.
++# Ensure that github.com/ziglang/zig/issues/13050 does not regress
++find "$BAZEL_ZIG_CC_CACHE_PREFIX" -name mutex_destructor.o -execdir file '{}=
+' \; | \
+     sort | uniq -c | sort -rn > /tmp/got_cache
+=20
+ diff -u ci/testdata/want_cache /tmp/got_cache || {
+     >&2 echo "ERROR: unexpected artifacts."
+-    >&2 echo "Was /tmp/bazel-zig-cc empty before the test?"
++    >&2 echo "Was $BAZEL_ZIG_CC_CACHE_PREFIX empty before the test?"
+     exit 1
+ }
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index dfd1ef8..483d9fa 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -1,3 +1,4 @@
++load("@bazel_skylib//lib:paths.bzl", "paths")
+ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_user_netrc", "us=
+e_netrc")
+ load("@bazel-zig-cc//toolchain/private:defs.bzl", "target_structs", "zig_too=
+l_path")
+@@ -79,83 +80,8 @@ def toolchains(
+ _ZIG_TOOLS =3D [
+     "c++",
+     "ar",
+-    "build-exe",
+-    "build-lib",
+-    "build-obj",
+ ]
+=20
+-_ZIG_TOOL_WRAPPER_WINDOWS_CACHE =3D """@echo off
+-if exist "external\\zig_sdk\\lib\\*" goto :have_external_zig_sdk_lib
+-set ZIG_LIB_DIR=3D%~dp0\\..\\..\\lib
+-set ZIG_EXE=3D%~dp0\\..\\..\\zig.exe
+-goto :set_zig_lib_dir
+-:have_external_zig_sdk_lib
+-set ZIG_LIB_DIR=3Dexternal\\zig_sdk\\lib
+-set ZIG_EXE=3Dexternal\\zig_sdk\\zig.exe
+-:set_zig_lib_dir
+-set ZIG_LOCAL_CACHE_DIR=3D{cache_prefix}\\bazel-zig-cc
+-set ZIG_GLOBAL_CACHE_DIR=3D%ZIG_LOCAL_CACHE_DIR%
+-"%ZIG_EXE%" "{zig_tool}" {maybe_target} %*
+-"""
+-
+-_ZIG_TOOL_WRAPPER_CACHE =3D """#!/bin/sh
+-set -e
+-if [ -d external/zig_sdk/lib ]; then
+-    ZIG_LIB_DIR=3Dexternal/zig_sdk/lib
+-    ZIG_EXE=3Dexternal/zig_sdk/zig
+-else
+-    ZIG_LIB_DIR=3D"$(dirname "$0")/../../lib"
+-    ZIG_EXE=3D"$(dirname "$0")/../../zig"
+-fi
+-export ZIG_LIB_DIR
+-export ZIG_LOCAL_CACHE_DIR=3D"{cache_prefix}/bazel-zig-cc"
+-export ZIG_GLOBAL_CACHE_DIR=3D"{cache_prefix}/bazel-zig-cc"
+-{maybe_gohack}
+-exec "$ZIG_EXE" "{zig_tool}" {maybe_target} "$@"
+-"""
+-
+-# The hackery below will be deleted after Go 1.20 is released (in particular,
+-# if/after https://go-review.googlesource.com/c/go/+/436884 )
+-# Arg-messing snippet from
+-# https://web.archive.org/web/20100129154217/http://www.seanius.net/blog/200=
+9/03/saving-and-restoring-positional-params
+-_ZIG_TOOL_GOHACK =3D """
+-quote(){ echo "$1" | sed -e "s,','\\\\'',g"; }
+-for arg in "$@"; do saved=3D"${saved:+$saved }'$(quote "$arg")'"; done
+-while [ "$#" -gt 6 ]; do shift; done
+-if [ "$*" =3D "-Wl,--no-gc-sections -x c - -o /dev/null" ]; then
+-  # This command probes if `--no-gc-sections` is accepted by the linker.
+-  # Since it is executed in /tmp, the ZIG_LIB_DIR is absolute,
+-  # glibc stubs and libc++ cannot be shared with other invocations (which use
+-  # a relative ZIG_LIB_DIR).
+-  exit 0;
+-fi
+-eval set -- "$saved"
+-"""
+-
+-def _zig_tool_wrapper(zig_tool, is_windows, cache_prefix, zigtarget):
+-    if zig_tool in ["c++", "build-exe", "build-lib", "build-obj"]:
+-        maybe_target =3D "-target {}".format(zigtarget)
+-    else:
+-        maybe_target =3D ""
+-
+-    if not cache_prefix:
+-        if is_windows:
+-            cache_prefix =3D "C:\\Temp\\bazel-zig-cc"
+-        else:
+-            cache_prefix =3D "/tmp/bazel-zig-cc"
+-
+-    kwargs =3D dict(
+-        zig_tool =3D zig_tool,
+-        cache_prefix =3D cache_prefix,
+-        maybe_gohack =3D _ZIG_TOOL_GOHACK if (zig_tool =3D=3D "c++" and not =
+is_windows) else "",
+-        maybe_target =3D maybe_target,
+-    )
+-
+-    if is_windows:
+-        return _ZIG_TOOL_WRAPPER_WINDOWS_CACHE.format(**kwargs)
+-    else:
+-        return _ZIG_TOOL_WRAPPER_CACHE.format(**kwargs)
+-
+ def _quote(s):
+     return "'" + s.replace("'", "'\\''") + "'"
+=20
+@@ -217,22 +143,50 @@ def _zig_repository_impl(repository_ctx):
+         sha256 =3D zig_sha256,
+     )
+=20
++    cache_prefix =3D repository_ctx.os.environ.get("BAZEL_ZIG_CC_CACHE_PREFI=
+X", "")
++    if cache_prefix =3D=3D "":
++        if os =3D=3D "windows":
++            cache_prefix =3D "C:\\Temp\\bazel-zig-cc"
++        else:
++            cache_prefix =3D "/tmp/bazel-zig-cc"
++
++    repository_ctx.template(
++        "tools/launcher.zig",
++        Label("//toolchain:launcher.zig"),
++        executable =3D False,
++        substitutions =3D {
++            "{BAZEL_ZIG_CC_CACHE_PREFIX}": cache_prefix,
++        },
++    )
++
++    ret =3D repository_ctx.execute(
++        [
++            paths.join("..", "zig"),
++            "build-exe",
++            "-OReleaseSafe",
++            "launcher.zig",
++        ] + (["-static"] if os =3D=3D "linux" else []),
++        working_directory =3D "tools",
++        environment =3D {
++            "ZIG_LOCAL_CACHE_DIR": cache_prefix,
++            "ZIG_GLOBAL_CACHE_DIR": cache_prefix,
++        },
++    )
++    if ret.return_code !=3D 0:
++        fail("compilation failed:\nreturn_code=3D{}\nstderr=3D{}\nstdout=3D{=
+}".format(
++            ret.return_code,
++            ret.stdout,
++            ret.stderr,
++        ))
++
++    exe =3D ".exe" if os =3D=3D "windows" else ""
+     for target_config in target_structs():
+         for zig_tool in _ZIG_TOOLS + target_config.tool_paths.values():
+-            zig_tool_wrapper =3D _zig_tool_wrapper(
+-                zig_tool,
+-                os =3D=3D "windows",
+-                repository_ctx.os.environ.get("BAZEL_ZIG_CC_CACHE_PREFIX", "=
+"),
++            tool_path =3D zig_tool_path(os).format(
++                zig_tool =3D zig_tool,
+                 zigtarget =3D target_config.zigtarget,
+             )
+-
+-            repository_ctx.file(
+-                zig_tool_path(os).format(
+-                    zig_tool =3D zig_tool,
+-                    zigtarget =3D target_config.zigtarget,
+-                ),
+-                zig_tool_wrapper,
+-            )
++            repository_ctx.symlink("tools/launcher{}".format(exe), tool_path)
+=20
+     repository_ctx.file(
+         "glibc-hacks/fcntl.map",
+diff --git a/toolchain/launcher.zig b/toolchain/launcher.zig
+new file mode 100644
+index 0000000..0cf86e8
+--- /dev/null
++++ b/toolchain/launcher.zig
+@@ -0,0 +1,531 @@
++// A wrapper for `zig` subcommands.
++//
++// In simple cases it is usually enough to:
++//
++//      zig c++ -target <triple> <...>
++//
++// However, there are some caveats:
++//
++// * Sometimes toolchains (looking at you, Go, see an example in
++// https://github.com/golang/go/pull/55966) skip CFLAGS to the underlying
++// compiler. Doing that may carry a huge cost, because zig may need to spend
++// ~30s compiling libc++ for an innocent feature test. Having an executable =
+per
++// target platform (like GCC does things, e.g. aarch64-linux-gnu-<tool>) is
++// what most toolchains are designed to work with. So we need a wrapper per
++// zig sub-command per target. As of writing, the layout is:
++//   tools/
++//   =E2=94=9C=E2=94=80=E2=94=80 x86_64-linux-gnu.2.34
++//   =E2=94=82=C2=A0=C2=A0 =E2=94=9C=E2=94=80=E2=94=80 ar
++//   =E2=94=82=C2=A0=C2=A0 =E2=94=9C=E2=94=80=E2=94=80 c++
++//   =E2=94=82=C2=A0=C2=A0 =E2=94=94=E2=94=80=E2=94=80 ld.lld
++//   =E2=94=9C=E2=94=80=E2=94=80 x86_64-linux-musl
++//   =E2=94=82=C2=A0=C2=A0 =E2=94=9C=E2=94=80=E2=94=80 ar
++//   =E2=94=82=C2=A0=C2=A0 =E2=94=9C=E2=94=80=E2=94=80 c++
++//   =E2=94=82=C2=A0=C2=A0 =E2=94=94=E2=94=80=E2=94=80 ld.lld
++//   =E2=94=9C=E2=94=80=E2=94=80 x86_64-macos-none
++//   =E2=94=82=C2=A0=C2=A0 =E2=94=9C=E2=94=80=E2=94=80 ar
++//   =E2=94=82=C2=A0=C2=A0 =E2=94=9C=E2=94=80=E2=94=80 c++
++//   =E2=94=82=C2=A0=C2=A0 =E2=94=94=E2=94=80=E2=94=80 ld64.lld
++//   ...
++// * ZIG_LIB_DIR controls the output of `zig c++ -MF -MD <...>`. Bazel uses
++// command to understand which input files were used to the compilation. If =
+any
++// of the files are not in `external/<...>/`, Bazel will understand and
++// complain that the compiler is using undeclared directories on the host fi=
+le
++// system. We do not declare prerequisites using absolute paths, because that
++// busts Bazel's remote cache.
++// * BAZEL_ZIG_CC_CACHE_PREFIX is configurable per toolchain instance, and
++// ZIG_GLOBAL_CACHE_DIR and ZIG_LOCAL_CACHE_DIR must be set to its value for
++// all `zig` invocations.
++//
++// Originally this was a Bash script, then a POSIX shell script, then two
++// scripts (one with pre-defined BAZEL_ZIG_CC_CACHE_PREFIX, one without). Th=
+en
++// Windows came along with two PowerShell scripts (ports of the POSIX shell
++// scripts), which I kept breaking. Then Bazel 6 came with
++// `--experimental_use_hermetic_linux_sandbox`, which hermetizes the sandbox=
+ to
++// the extreme: the sandbox has nothing that is not declared. /bin/sh and its
++// dependencies (/lib/x86_64-linux-gnu/libc.so.6 on my system) are obviously
++// not declared. So one can either declare those dependencies, bundle a shell
++// to execute the wrapper, or port the shell logic to a cross-platform progr=
+am
++// that compiles to a static binary. By a chance we happen to already ship a
++// toolchain of a language that could compile such program. And behold, the
++// program is below.
++
++const builtin =3D @import("builtin");
++const std =3D @import("std");
++const fs =3D std.fs;
++const mem =3D std.mem;
++const process =3D std.process;
++const ChildProcess =3D std.ChildProcess;
++const ArrayList =3D std.ArrayList;
++const ArrayListUnmanaged =3D std.ArrayListUnmanaged;
++const Allocator =3D std.mem.Allocator;
++const sep =3D fs.path.sep_str;
++
++const EXE =3D switch (builtin.target.os.tag) {
++    .windows =3D> ".exe",
++    else =3D> "",
++};
++
++const CACHE_DIR =3D "{BAZEL_ZIG_CC_CACHE_PREFIX}";
++
++const usage_cpp =3D
++    \\Usage: <...>/tools/<target-triple>/{[zig_tool]s}{[exe]s} <args>...
++    \\
++    \\Wraps the "zig" multi-call binary. It determines the target platform f=
+rom
++    \\the directory where it was called. Then sets ZIG_LIB_DIR,
++    \\ZIG_GLOBAL_CACHE_DIR, ZIG_LOCAL_CACHE_DIR and then calls:
++    \\
++    \\  zig c++ -target <target-triple> <args>...
++;
++
++const usage_other =3D
++    \\Usage: <...>/tools/<target-triple>/{[zig_tool]s}{[exe]s} <args>...
++    \\
++    \\Wraps the "zig" multi-call binary. It sets ZIG_LIB_DIR,
++    \\ZIG_GLOBAL_CACHE_DIR, ZIG_LOCAL_CACHE_DIR, and then calls:
++    \\
++    \\  zig {[zig_tool]s} <args>...
++;
++
++const Action =3D enum {
++    early_ok,
++    early_err,
++    exec,
++};
++
++const ExecParams =3D struct {
++    args: ArrayListUnmanaged([]const u8),
++    env: process.EnvMap,
++};
++
++const ParseResults =3D union(Action) {
++    early_ok,
++    early_err: []const u8,
++    exec: ExecParams,
++};
++
++pub fn main() u8 {
++    var allocator =3D if (builtin.link_libc)
++        std.heap.c_allocator
++    else blk: {
++        var gpa =3D std.heap.GeneralPurposeAllocator(.{}){};
++        break :blk gpa.allocator();
++    };
++    var arena_allocator =3D std.heap.ArenaAllocator.init(allocator);
++    defer arena_allocator.deinit();
++    const arena =3D arena_allocator.allocator();
++
++    var argv_it =3D process.argsWithAllocator(arena) catch |err| {
++        std.debug.print("error parsing args: {s}\n", .{@errorName(err)});
++        return 1;
++    };
++
++    const action =3D parseArgs(arena, fs.cwd(), &argv_it) catch |err| {
++        std.debug.print("error: {s}\n", .{@errorName(err)});
++        return 1;
++    };
++
++    switch (action) {
++        .early_ok =3D> return 0,
++        .early_err =3D> |msg| {
++            std.io.getStdErr().writeAll(msg) catch {};
++            return 1;
++        },
++        .exec =3D> |params| {
++            if (builtin.os.tag =3D=3D .windows) {
++                return spawnWindows(arena, params);
++            } else {
++                return execUnix(arena, params);
++            }
++        },
++    }
++}
++
++fn spawnWindows(arena: Allocator, params: ExecParams) u8 {
++    var proc =3D ChildProcess.init(params.args.items, arena);
++    proc.env_map =3D &params.env;
++    const ret =3D proc.spawnAndWait() catch |err| {
++        std.debug.print(
++            "error spawning {s}: {s}\n",
++            .{ params.args.items[0], @errorName(err) },
++        );
++        return 1;
++    };
++
++    switch (ret) {
++        .Exited =3D> |code| return code,
++        else =3D> |other| {
++            std.debug.print("abnormal exit: {any}\n", .{other});
++            return 1;
++        },
++    }
++}
++
++fn execUnix(arena: Allocator, params: ExecParams) u8 {
++    const err =3D process.execve(arena, params.args.items, &params.env);
++    std.debug.print(
++        "error execing {s}: {s}\n",
++        .{ params.args.items[0], @errorName(err) },
++    );
++    return 1;
++}
++
++// argv_it is an object that has such method:
++//     fn next(self: *Self) ?[]const u8
++// in non-testing code it is *process.ArgIterator.
++// Leaks memory: the name of the first argument is arena not by chance.
++fn parseArgs(
++    arena: Allocator,
++    cwd: fs.Dir,
++    argv_it: anytype,
++) error{OutOfMemory}!ParseResults {
++    const arg0 =3D argv_it.next() orelse
++        return fatal(arena, "error: argv[0] cannot be null", .{});
++
++    const zig_tool =3D blk: {
++        const b =3D fs.path.basename(arg0);
++        if (builtin.target.os.tag =3D=3D .windows and
++            std.ascii.eqlIgnoreCase(".exe", b[b.len - 4 ..]))
++            break :blk b[0 .. b.len - 4];
++
++        break :blk b;
++    };
++    const maybe_target =3D getTarget(arg0) catch |err| switch (err) {
++        error.BadParent =3D> {
++            const fmt_args =3D .{ .zig_tool =3D zig_tool, .exe =3D EXE };
++            if (mem.eql(u8, zig_tool, "c++")) {
++                return fatal(arena, usage_cpp, fmt_args);
++            } else return fatal(arena, usage_other, fmt_args);
++        },
++        else =3D> |e| return e,
++    };
++
++    const root =3D blk: {
++        var dir =3D cwd.openDir(
++            "external" ++ sep ++ "zig_sdk" ++ sep ++ "lib",
++            .{ .access_sub_paths =3D false, .no_follow =3D true },
++        );
++
++        if (dir) |*dir_exists| {
++            dir_exists.close();
++            break :blk "external" ++ sep ++ "zig_sdk";
++        } else |_| {}
++
++        // directory does not exist or there was an error opening it
++        const here =3D fs.path.dirname(arg0) orelse ".";
++        break :blk try fs.path.join(arena, &[_][]const u8{ here, "..", ".." =
+});
++    };
++
++    const zig_lib_dir =3D try fs.path.join(arena, &[_][]const u8{ root, "lib=
+" });
++    const zig_exe =3D try fs.path.join(
++        arena,
++        &[_][]const u8{ root, "zig" ++ EXE },
++    );
++
++    var env =3D process.getEnvMap(arena) catch |err| {
++        return fatal(
++            arena,
++            "error getting process environment: {s}",
++            .{@errorName(err)},
++        );
++    };
++    try env.put("ZIG_LIB_DIR", zig_lib_dir);
++    try env.put("ZIG_LOCAL_CACHE_DIR", CACHE_DIR);
++    try env.put("ZIG_GLOBAL_CACHE_DIR", CACHE_DIR);
++
++    // args is the path to the zig binary and args to it.
++    var args =3D ArrayListUnmanaged([]const u8){};
++    try args.appendSlice(arena, &[_][]const u8{ zig_exe, zig_tool });
++    if (maybe_target) |target|
++        try args.appendSlice(arena, &[_][]const u8{ "-target", target });
++
++    while (argv_it.next()) |arg|
++        try args.append(arena, arg);
++
++    if (mem.eql(u8, zig_tool, "c++") and shouldReturnEarly(args.items))
++        return .early_ok;
++
++    return ParseResults{
++        .exec =3D .{
++            .args =3D args,
++            .env =3D env,
++        },
++    };
++}
++
++fn fatal(
++    arena: Allocator,
++    comptime fmt: []const u8,
++    args: anytype,
++) error{OutOfMemory}!ParseResults {
++    const msg =3D try std.fmt.allocPrint(arena, fmt ++ "\n", args);
++    return ParseResults{ .early_err =3D msg };
++}
++
++// Golang probing for a particular linker flag causes many unneeded stubs to=
+ be
++// built, e.g. glibc, musl, libc++. The hackery can probably be deleted after
++// Go 1.20 is released. In particular,
++// https://go-review.googlesource.com/c/go/+/436884
++fn shouldReturnEarly(args: []const []const u8) bool {
++    const prelude =3D &[_][]const u8{
++        "-Wl,--no-gc-sections",
++        "-x",
++        "c",
++        "-",
++        "-o",
++        "/dev/null",
++    };
++    if (args.len < prelude.len)
++        return false;
++    for (prelude) |arg, i|
++        if (!mem.eql(u8, arg, args[args.len - prelude.len + i]))
++            return false;
++    return true;
++}
++
++fn getTarget(self_exe: []const u8) error{BadParent}!?[]const u8 {
++    const here =3D fs.path.dirname(self_exe) orelse return error.BadParent;
++    const triple =3D fs.path.basename(here);
++
++    // Validating the triple now will help users catch errors even if they
++    // don't yet need the target. yes yes the validation will miss things
++    // strings `is.it.x86_64?-stallinux,macos-`; we are trying to aid users
++    // that run things from the wrong directory, not trying to punish the on=
+es
++    // having fun.
++    {
++        var it =3D mem.split(u8, triple, "-");
++        if (it.next()) |arch| {
++            if (mem.indexOf(u8, "aarch64,x86_64", arch) =3D=3D null)
++                return error.BadParent;
++        } else return error.BadParent;
++
++        if (it.next()) |got_os| {
++            if (mem.indexOf(u8, "linux,macos,windows", got_os) =3D=3D null)
++                return error.BadParent;
++        } else return error.BadParent;
++
++        // ABI triple is too much of a moving target
++        if (it.next() =3D=3D null) return error.BadParent;
++
++        // but the target needs to have 3 dashes.
++        if (it.next() !=3D null) return error.BadParent;
++    }
++
++    if (mem.eql(u8, "c++" ++ EXE, fs.path.basename(self_exe))) {
++        return triple;
++    } else return null;
++}
++
++const testing =3D std.testing;
++
++fn split(comptime str: []const u8) []const []const u8 {
++    var arr: [str.len][]const u8 =3D undefined;
++    var i: usize =3D 0;
++    var it =3D mem.split(u8, str, " ");
++    while (it.next()) |arg| : (i +=3D 1)
++        arr[i] =3D arg;
++    return arr[0..i];
++}
++
++test "launcher:shouldReturnEarly" {
++    const pos =3D .{
++        "-Wl,--no-gc-sections -x c - -o /dev/null",
++        "foo.c -o main -Wl,--no-gc-sections -x c - -o /dev/null",
++    };
++    const neg =3D .{
++        "cc -Wl,--no-gc-sections -x c - -o /dev/null x",
++        "-Wl,--no-gc-sections -x c - -o",
++        "incorrect-value -x c - -o /dev/null",
++    };
++
++    inline for (pos) |tt|
++        try testing.expect(shouldReturnEarly(split(tt)));
++
++    inline for (neg) |tt|
++        try testing.expect(!shouldReturnEarly(split(tt)));
++}
++
++pub const TestArgIterator =3D struct {
++    index: usize =3D 0,
++    argv: []const [:0]const u8,
++
++    pub fn next(self: *TestArgIterator) ?[:0]const u8 {
++        if (self.index =3D=3D self.argv.len) return null;
++
++        defer self.index +=3D 1;
++        return self.argv[self.index];
++    }
++
++    pub fn skip(self: *TestArgIterator) bool {
++        if (self.index =3D=3D self.len) return false;
++
++        self.index +=3D 1;
++        return true;
++    }
++};
++
++fn compareExec(
++    res: ParseResults,
++    want_args: []const [:0]const u8,
++    want_env_zig_lib_dir: []const u8,
++) !void {
++    try testing.expectEqual(want_args.len, res.exec.args.items.len);
++    for (want_args) |want_arg, i| {
++        try testing.expectEqualStrings(
++            want_arg,
++            res.exec.args.items[i],
++        );
++    }
++    try testing.expectEqualStrings(
++        want_env_zig_lib_dir,
++        res.exec.env.get("ZIG_LIB_DIR").?,
++    );
++}
++
++test "launcher:parseArgs" {
++    // not using testing.allocator, because parseArgs is designed to be used
++    // with an arena.
++    var gpa =3D std.heap.GeneralPurposeAllocator(.{}){};
++    var allocator =3D gpa.allocator();
++
++    const tests =3D [_]struct {
++        args: []const [:0]const u8,
++        precreate_dir: ?[]const u8 =3D null,
++        want_result: union(Action) {
++            early_ok,
++            early_err: []const u8,
++            exec: struct {
++                args: []const [:0]const u8,
++                env_zig_lib_dir: []const u8,
++            },
++        },
++    }{
++        .{
++            .args =3D &[_][:0]const u8{"ar" ++ EXE},
++            .want_result =3D .{
++                .early_err =3D std.fmt.comptimePrint(usage_other ++ "\n", .{
++                    .zig_tool =3D "ar",
++                    .exe =3D EXE,
++                }),
++            },
++        },
++        .{
++            .args =3D &[_][:0]const u8{"c++" ++ EXE},
++            .want_result =3D .{
++                .early_err =3D std.fmt.comptimePrint(usage_cpp ++ "\n", .{
++                    .zig_tool =3D "c++",
++                    .exe =3D EXE,
++                }),
++            },
++        },
++        .{
++            .args =3D &[_][:0]const u8{
++                "external" ++ sep ++ "zig_sdk" ++ "tools" ++ sep ++
++                    "x86_64-linux-musl" ++ sep ++ "c++" ++ EXE,
++                "-Wl,--no-gc-sections",
++                "-x",
++                "c",
++                "-",
++                "-o",
++                "/dev/null",
++            },
++            .want_result =3D .early_ok,
++        },
++        .{
++            .args =3D &[_][:0]const u8{
++                "tools" ++ sep ++ "x86_64-linux-musl" ++ sep ++ "c++" ++ EXE,
++                "main.c",
++                "-o",
++                "/dev/null",
++            },
++            .want_result =3D .{
++                .exec =3D .{
++                    .args =3D &[_][:0]const u8{
++                        "tools" ++ sep ++ "x86_64-linux-musl" ++ sep ++
++                            ".." ++ sep ++ ".." ++ sep ++ "zig" ++ EXE,
++                        "c++",
++                        "-target",
++                        "x86_64-linux-musl",
++                        "main.c",
++                        "-o",
++                        "/dev/null",
++                    },
++                    .env_zig_lib_dir =3D "tools" ++ sep ++ "x86_64-linux-mus=
+l" ++
++                        sep ++ ".." ++ sep ++ ".." ++ sep ++ "lib",
++                },
++            },
++        },
++        .{
++            .args =3D &[_][:0]const u8{
++                "tools" ++ sep ++ "x86_64-linux-musl" ++ sep ++ "ar" ++ EXE,
++                "-rcs",
++                "all.a",
++                "main.o",
++                "foo.o",
++            },
++            .want_result =3D .{
++                .exec =3D .{
++                    .args =3D &[_][:0]const u8{
++                        "tools" ++ sep ++ "x86_64-linux-musl" ++ sep ++ ".."=
+ ++
++                            sep ++ ".." ++ sep ++ "zig" ++ EXE,
++                        "ar",
++                        "-rcs",
++                        "all.a",
++                        "main.o",
++                        "foo.o",
++                    },
++                    .env_zig_lib_dir =3D "tools" ++ sep ++ "x86_64-linux-mus=
+l" ++
++                        sep ++ ".." ++ sep ++ ".." ++ sep ++ "lib",
++                },
++            },
++        },
++        .{
++            .args =3D &[_][:0]const u8{
++                "external_zig_sdk" ++ sep ++ "tools" ++ sep ++
++                    "x86_64-linux-gnu.2.28" ++ sep ++ "c++" ++ EXE,
++                "main.c",
++                "-o",
++                "/dev/null",
++            },
++            .precreate_dir =3D "external" ++ sep ++ "zig_sdk" ++ sep ++ "lib=
+",
++            .want_result =3D .{
++                .exec =3D .{
++                    .args =3D &[_][:0]const u8{
++                        "external" ++ sep ++ "zig_sdk" ++ sep ++ "zig" ++ EX=
+E,
++                        "c++",
++                        "-target",
++                        "x86_64-linux-gnu.2.28",
++                        "main.c",
++                        "-o",
++                        "/dev/null",
++                    },
++                    .env_zig_lib_dir =3D "external" ++ sep ++ "zig_sdk" ++
++                        sep ++ "lib",
++                },
++            },
++        },
++    };
++
++    for (tests) |tt| {
++        var tmp =3D testing.tmpDir(.{});
++        defer tmp.cleanup();
++
++        if (tt.precreate_dir) |dir|
++            try tmp.dir.makePath(dir);
++
++        var res =3D try parseArgs(allocator, tmp.dir, &TestArgIterator{
++            .argv =3D tt.args,
++        });
++
++        switch (tt.want_result) {
++            .early_ok =3D> try testing.expectEqual(res, .early_ok),
++            .early_err =3D> |want_msg| try testing.expectEqualStrings(
++                want_msg,
++                res.early_err,
++            ),
++            .exec =3D> |want| {
++                try compareExec(res, want.args, want.env_zig_lib_dir);
++            },
++        }
++    }
++}
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+index 9409f5e..635dde9 100644
+--- a/toolchain/private/defs.bzl
++++ b/toolchain/private/defs.bzl
+@@ -32,7 +32,7 @@ LIBCS =3D ["musl"] + ["gnu.{}".format(glibc) for glibc in _=
+GLIBCS]
+=20
+ def zig_tool_path(os):
+     if os =3D=3D "windows":
+-        return _ZIG_TOOL_PATH + ".bat"
++        return _ZIG_TOOL_PATH + ".exe"
+     else:
+         return _ZIG_TOOL_PATH
+=20
+--=20
+2.34.5
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+DKIM-Signature: a=rsa-sha256; bh=MCi9WbpoJ4f9XVbwrKOVO3MbBdlb8SYntje2gmBylJY=;
+ c=simple/simple; d=sr.ht; h=Date:Cc:From:In-Reply-To:Subject:To;
+ q=dns/txt; s=srht; t=1671794655; v=1;
+ b=Z/DVc/S/JZ5kDYQNhdVx20vIRegt2UVXp9LHqIdKk1ek+9G689IjEaH+lOKj8RnwFvJL1xyZ
+ Qj3wNohhFc3EMDFh2/rpthJh8UA658h1n5UcRHa/C4lWMB9hCHKW7XwmM/58mdU1z+HHJuea5o2
+ 6KaD4atEBf0deKTdvukQkEkc5lu0ZgMlT/OIbPEuCG/uBKvmTcY9BsKg4Q3wQHx8H31pA/+C4ew
+ zFtedFVHc0x75PTuJ+alItXiTLKhRbUeeDlKyXkaQw6M8slpinj5M+w9AftxlkByRn1qR5SwHlx
+ 8a1NMt3snRSPPKgcajW8C4xFz39RctEA3pQkuPSR/3v7A==
+Received: from localhost (unknown [173.195.146.244])
+	by mail-b.sr.ht (Postfix) with UTF8SMTPSA id 4733711EEC6;
+	Fri, 23 Dec 2022 11:24:15 +0000 (UTC)
+MIME-Version: 1.0
+Date: Fri, 23 Dec 2022 11:24:15 +0000
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+From: "builds.sr.ht" <builds@sr.ht>
+Message-ID: <CP95QTZK2NUR.2ZJMZ66K85XC1@cirno2>
+In-Reply-To: <167179347159.25324.12223141818448163553-1@git.sr.ht>
+Subject: [bazel-zig-cc/patches/.build.yml] build success
+To: "~motiejus" <motiejus@jakstys.lt>
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain; charset=UTF-8
+Status: O
+Content-Length: 335
+Lines: 9
+
+bazel-zig-cc/patches/.build.yml: SUCCESS in 19m41s
+
+[zig launcher: replace shell wrappers with a binary][0] from [~motiejus][1]
+
+[0]: https://lists.sr.ht/~motiejus/bazel-zig-cc/patches/37721
+[1]: mailto:motiejus@jakstys.lt
+
+=E2=9C=93 #910438 SUCCESS bazel-zig-cc/patches/.build.yml https://builds.sr=
+.ht/~motiejus/job/910438
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=deepjudge.ai header.i=@deepjudge.ai
+Received: from mail-lj1-f175.google.com (mail-lj1-f175.google.com [209.85.208.175])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 2BF5A11EF31
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 30 Dec 2022 18:55:11 +0000 (UTC)
+Received: by mail-lj1-f175.google.com with SMTP id s22so22803484ljp.5
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 30 Dec 2022 10:55:11 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=deepjudge.ai; s=google;
+        h=cc:to:subject:message-id:date:from:mime-version:from:to:cc:subject
+         :date:message-id:reply-to;
+        bh=SKfm5xAly6Wk5FrjV8xWZn6E9RXjg7/mbH2I7j03ZZc=;
+        b=D/OLaMrf8vELXp6vmTaDggT8qQhpoGuXQwjiJjegJfKR3QTuvMzTWSJGpWBsC8ZaEg
+         1pu32u9tcUr9Jb3+hdWhIjy+R96yxVeq4RtTXJ81JQRcGiuMqLjQbLMtnJ3cVFEoD8hB
+         kDUKprPeDLZ23sTSRVvvL6KJPO3wdYwk08lnQ=
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:mime-version:x-gm-message-state
+         :from:to:cc:subject:date:message-id:reply-to;
+        bh=SKfm5xAly6Wk5FrjV8xWZn6E9RXjg7/mbH2I7j03ZZc=;
+        b=d9YTuRyYixyQjaAw3uMRNpBcjbQ6yJ5KOHQE5TArho2d+LyqoJ7fKD8Z0crOrbUzRR
+         5tYezJk1GZ32SQIA40vwd7EvB5VBuhVgo3V9ZeLYJJeubujb7142gW8nLWuvnx6jCx3U
+         b8UnMQozOWTdpizOtr4z0RcTAU94HhwpfqRXipe+/WeCtdkqh56f48ArpdU1gUeXHl4X
+         38dabs8Jq2GjuURonGZi1rUVHbK76BVw0h0MZ5Q9nKMU1Q10s8TyVhxmq7vvD8Agk6xg
+         YDvG8kDms3dlIJjNU5y3yFTWG9215Miq3yOt8VFYWg/mI7rHWj/Y7Hiie6RTTpDtdwtw
+         8S+w==
+X-Gm-Message-State: AFqh2kpQ4epCf6OirIj3oLrq+tImpJld354xkP+DFUyKI0WRIdLCa3Mw
+	ET4PdyegyNmNZgieqI5qimhtdJSxhwnrr7Y+Y5aJYXt4PZpFeFZp+5s=
+X-Google-Smtp-Source: AMrXdXsBskO4fyQXyYFokAjiSHxvZk9zwMlx6z5XbYI9YSStfzG+UKsqXAVrzCw/d4WEA7LWxm4AtO1z34EH7k/5Wp8=
+X-Received: by 2002:a05:651c:1077:b0:279:df97:e895 with SMTP id
+ y23-20020a05651c107700b00279df97e895mr1388586ljm.226.1672426509679; Fri, 30
+ Dec 2022 10:55:09 -0800 (PST)
+MIME-Version: 1.0
+From: Philippe Voinov <philippe@deepjudge.ai>
+Date: Fri, 30 Dec 2022 19:54:59 +0100
+Message-ID: <CALeCjqTQROq9LCEEczNNLcrfsskQhKZ7u44qcaa-OfEtGLJGbg@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc 1/1] zig launcher: replace shell wrappers
+ with a binary
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: "~motiejus" <motiejus@git.sr.ht>
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 291
+Lines: 5
+
+I ran into problems with missing shell utilities (dirname and sed)
+when using bazel-zig-cc with rules_rust. rustc seems to unset PATH
+when calling tools like the linker, which causes problems with the zig
+tool wrapper scripts. I guess this patch would solve the issues that
+I'm seeing?
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oi1-f173.google.com (mail-oi1-f173.google.com [209.85.167.173])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 4377111EF31
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 30 Dec 2022 19:08:07 +0000 (UTC)
+Received: by mail-oi1-f173.google.com with SMTP id j130so14457908oif.4
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Fri, 30 Dec 2022 11:08:07 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:from:to:cc:subject:date:message-id:reply-to;
+        bh=XWYAcB2nhXupEMMFX4i72OixK2OQRANNd6NEl0AOX+Y=;
+        b=LcWUFKd19DeMxUWAOp6CW1Z+j7473+uCxUNnY91OgpuC8vwL1FMYCN2jwGUjnMeudU
+         9m0XbB6XvjFMykX4OO0Daq3iDFQp3w1NPQnkLWGzZYIL2VRL/4rha7PAzq4RBPgoOlLP
+         lLB62fK/dA5EojEzmpMyM1nHntFOJbziHkrWEBb8maGvUm3nNzs9txq09E6an5B658C+
+         /UpL0pyoWgdtri1vwZZS79Wo94csUSr0MO1HL0COzhrOkAm1bQd9FyOcGt8HVDizb8Ax
+         xw8JulmdHTA2gCRze894jJV1FXam8JEi9XUL4uraL1aKHehB0050bZG82hG7803Z38EC
+         fQkQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:x-gm-message-state:from:to:cc:subject:date:message-id
+         :reply-to;
+        bh=XWYAcB2nhXupEMMFX4i72OixK2OQRANNd6NEl0AOX+Y=;
+        b=2Gdymd4ZxZku7mQN3/p0oHm3tPaAHV+whUgmvBdw9ENOISfKya9S47QXTzcLKMhr/Z
+         ju+04qG6g3UM1BjMIMLiQl22OANiL9Ae7W3rspWcV+ptSpLT7Fgj7q/Lf/mehc/7agLH
+         Q+Bn9Gq/OJ4yqV1sgkPgc67IoXDi4pXA2Fdi+F6FN3sSYJpsf68lYEr7GFo79+XMo57B
+         STt13pgG5+GXQNjMb/S4LRHTqfEg5CBYprWjze7Xm0jN3GmH51NMjfPvV4kOLuRkZxZY
+         6o1gSds1g7+LcAr7vD00FmpR/sa87a/CWYrDoC1kDJVmkbcpu6BNio513pBkW/C+sCwj
+         +uxw==
+X-Gm-Message-State: AFqh2kqcPfvps5ATQfp4dTyWUyytvxH1fFBZzqS0+HwQrvu3jPyeK5Mo
+	F7bvbBQkEf46mXWbBhFB40vKyerCK0lkQdDzYY8=
+X-Google-Smtp-Source: AMrXdXtU0ipM//F9jKYZpaT4SEPRGH1Flj6ejICI0vl9vz+jac8aao7JEUjcn2+Sy1PiWVeUwskU3Y/R0rmDsVgDd9o=
+X-Received: by 2002:a05:6808:2885:b0:35b:dac6:cc84 with SMTP id
+ eu5-20020a056808288500b0035bdac6cc84mr1745942oib.116.1672427286299; Fri, 30
+ Dec 2022 11:08:06 -0800 (PST)
+MIME-Version: 1.0
+References: <CALeCjqTQROq9LCEEczNNLcrfsskQhKZ7u44qcaa-OfEtGLJGbg@mail.gmail.com>
+In-Reply-To: <CALeCjqTQROq9LCEEczNNLcrfsskQhKZ7u44qcaa-OfEtGLJGbg@mail.gmail.com>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Fri, 30 Dec 2022 21:07:55 +0200
+Message-ID: <CAFVMu-riAWd3yrzH3=Xq=beniKfXSaH6BeGSVPKT=JGeTFA7vA@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc 1/1] zig launcher: replace shell wrappers
+ with a binary
+To: Philippe Voinov <philippe@deepjudge.ai>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht, "~motiejus" <motiejus@git.sr.ht>
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 747
+Lines: 18
+
+On Fri, Dec 30, 2022 at 8:55 PM Philippe Voinov <philippe@deepjudge.ai> wrote:
+>
+> I ran into problems with missing shell utilities (dirname and sed)
+> when using bazel-zig-cc with rules_rust. rustc seems to unset PATH
+> when calling tools like the linker, which causes problems with the zig
+> tool wrapper scripts. I guess this patch would solve the issues that
+> I'm seeing?
+
+Hi Philippe,
+
+It has a high chance to work, but you never know until you try. Feel
+free to test the patch yourself (or the remote branch
+motiejus_launcher_zig[1]) and please report back.
+
+I am hesitant to merge it as-is without Fabian's ack whether it works
+on Windows though.
+
+[1]: https://git.sr.ht/~motiejus/bazel-zig-cc/tree/motiejus_launcher_zig
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id B1A7D11EFBC
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon,  2 Jan 2023 21:53:54 +0000 (UTC)
+Message-ID: <ee9821ec-6b7c-4d62-a1f2-0b54cc2ef728@hahn.graphics>
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1672696431;
+	bh=eOA61wVHDLksK5hazy+Rc+92DG49TO7UW474//DmaBI=;
+	h=To:Cc:References:Subject:From:In-Reply-To;
+	b=hJ1QyamFGw3nf6UUzQEoIrlAc3P+b8bppR4fOWNAp5+JUIYL4XXx1QmYrVtfoTgzX
+	 0e2YZSsnfZ6kxVl15mL+/VuZlNhPE5KSZ6YIqP+sDDWltCnLJJEH/CNt33OhcNe48o
+	 VLai9jvtiEVut0KTID0+/1LzEtTHjQ1kYxUu5dUQ=
+Date: Mon, 2 Jan 2023 21:53:48 +0000
+Mime-Version: 1.0
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: ~motiejus <motiejus@git.sr.ht>
+References: <167179347159.25324.12223141818448163553-1@git.sr.ht>
+Subject: Re: [PATCH bazel-zig-cc 1/1] zig launcher: replace shell wrappers
+ with a binary
+Content-Language: en-US
+From: Fabian Hahn <fabian@hahn.graphics>
+In-Reply-To: <167179347159.25324.12223141818448163553-1@git.sr.ht>
+Content-Type: text/plain; charset=UTF-8; format=flowed
+Content-Transfer-Encoding: 8bit
+Status: O
+Content-Length: 2197
+Lines: 61
+
+Hi Motiejus,
+
+Apologies for the delay in responding, I was traveling over the 
+Christmas and new year break and just got back home.
+
+I've tested your patch on Windows and there are currently two issues 
+with it, one is trivial to fix and the other one I'm not sure about:
+
+First, cache_prefix in toolchain/defs.bzl needs to have its backslashes 
+double escaped: once for bazel, and once for zig itself, otherwise the 
+zig compiler will complain about invalid escape characters. So it should 
+be "C:\\\\Temp\\\\bazel-zig-cc"
+
+Second, zig further fails to compile launcher.zig with the following error:
+
+launcher.zig:70:73: error: expected ';' after declaration
+
+     \\Usage: <...>/tools/<target-triple>/{[zig_tool]s}{[exe]s} <args>...
+
+                                                                         ^~~~
+
+launcher.zig:71:3: note: invalid byte: ' '
+
+     \\
+
+   ^
+
+
+The reason for this is that Git on Windows inserts carriage return 
+characters before newlines when checking out local files so they show up 
+fine in Windows text editors where \r\n is the default for line breaks. 
+This then breaks the zig parser's support for multiline constants as 
+detailed in https://github.com/ziglang/zig/issues/9257 which is marked 
+as closed even though it doesn't look resolved to me at all. Converting 
+newlines is the default behavior for Git unless you explicitly disable 
+it by setting core.autocrlf in your Git config. While that would be a 
+workaround, I would find this an uncommon thing to do and an odd thing 
+to require of Windows users, which is something also pointed out in the 
+above issue.
+
+
+I did confirm that either of the following two hacks to launcher.zig do 
+make your patch work on Windows:
+
+1. Replace usage_cpp and usage_other by regular strings without 
+multiline constant syntax.
+
+2. Setting core.autocrlf to false in Git and recloning the repository.
+
+3. Running dos2unix on launcher.zig before compiling it.
+
+
+None of these are ideal, so I'm not quite sure how to go about solving 
+this. What do you think?
+
+
+Best,
+
+Fabian
+
+
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-ot1-f45.google.com (mail-ot1-f45.google.com [209.85.210.45])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 82C7E11EFBC
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon,  2 Jan 2023 22:34:26 +0000 (UTC)
+Received: by mail-ot1-f45.google.com with SMTP id m7-20020a9d73c7000000b00683e2f36c18so13153779otk.0
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 02 Jan 2023 14:34:26 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:from:to:cc:subject:date:message-id:reply-to;
+        bh=YEv3oJ7FtfUki/5yS+k9UTcY+XBhauUSMD9KeWCuTVs=;
+        b=TKH3kCfOiBLN+6lfyblD07YHSY7j0xI/q3eBYMk6MJxy1d7WgJi90OIes1+S48/ncN
+         Twg22oiPJUHXznmGYIfZzKSDEV1yHsdTBofLblue2FyQ+yhpmYSKCTbGp2deXP902jCd
+         nfqtzQ2gPXR0DI8BvYzf+Wvdyuk8lKMK333WAemvO/ceKVRkS2f19k88OMc7x26qcIPp
+         zfkWXMRv1UiQ0GGjnUn+e2N4jKD7sdLcsPF8Dm0pCk81MOZDh49NNZVoDadm6Xw5jyUc
+         oiEv05ATB0J8qNeU+GPCEOA2U64LZ7e7n+4xS/vWC9UFBAYcikUH11EL+3ofzQ11wNuH
+         8N1Q==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:in-reply-to:references
+         :mime-version:x-gm-message-state:from:to:cc:subject:date:message-id
+         :reply-to;
+        bh=YEv3oJ7FtfUki/5yS+k9UTcY+XBhauUSMD9KeWCuTVs=;
+        b=e4rwA4AFDbfSgOWdaosXLdNP2g+1b8Udfj4IV24suPdwW1dEeLdLhDjN5yMWfPzTox
+         4vj1YzjMqIAaRauqhF3IvzXtuHMXmYPB6Oxl2w4jRzJqxu1y4anz8LKTnfqw6KEdF87q
+         /WRDEsngSMsSx4Q/XTFD7XbbpqNriYRKLyr83cRVFpiIH6wiY9INO/ZBvO5CJwBYYG7D
+         3b0OB0cR4k9CzBXDhUeiz87IhlfdJMIHGxbteb5+sxw6MRAWlux4hQ4Sh7m8zyo24rE5
+         T59pFtIT/qaP9OEjkaIcEnbUN3WN0bDI28qhoIxv7xxDS9FKIl+bQ6v6ahL/3OeIMO2p
+         CDIg==
+X-Gm-Message-State: AFqh2kpi85JRMmzaWw1nBrJLKIQ1FexXWNRoTHFk9Pt2z6GMJ7Oups/6
+	AC5iOXVLSoGuugDdKpaWuN9BI4IFwRGv3kH2d0E=
+X-Google-Smtp-Source: AMrXdXuikI3anogpEpEmdCbJbmoeFbvLB3TevJUgj12X/NBpbdSDu94XSuiq9NuBpGUwSHfUZ23WGPRNpOjycSRwCTc=
+X-Received: by 2002:a05:6830:567:b0:661:dd09:fcc4 with SMTP id
+ f7-20020a056830056700b00661dd09fcc4mr2360534otc.60.1672698864797; Mon, 02 Jan
+ 2023 14:34:24 -0800 (PST)
+MIME-Version: 1.0
+References: <167179347159.25324.12223141818448163553-1@git.sr.ht> <ee9821ec-6b7c-4d62-a1f2-0b54cc2ef728@hahn.graphics>
+In-Reply-To: <ee9821ec-6b7c-4d62-a1f2-0b54cc2ef728@hahn.graphics>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Tue, 3 Jan 2023 00:34:13 +0200
+Message-ID: <CAFVMu-q9QmVd+rTxHMqX==8E_-fZ=7x8Sq6St_q9YXcJz451Xg@mail.gmail.com>
+Subject: Re: [PATCH bazel-zig-cc 1/1] zig launcher: replace shell wrappers
+ with a binary
+To: Fabian Hahn <fabian@hahn.graphics>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht, "~motiejus" <motiejus@git.sr.ht>
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 1213
+Lines: 41
+
+On Mon, Jan 2, 2023 at 11:53 PM Fabian Hahn <fabian@hahn.graphics> wrote:
+>
+> Hi Motiejus,
+>
+> Apologies for the delay in responding, I was traveling over the
+> Christmas and new year break and just got back home.
+
+Happy new year! :)
+
+> I've tested your patch on Windows and there are currently two issues
+> with it, one is trivial to fix and the other one I'm not sure about:
+>
+> First, cache_prefix in toolchain/defs.bzl needs to <...>
+> be "C:\\\\Temp\\\\bazel-zig-cc"
+
+Fixed, thanks.
+
+> Second, zig further fails to compile launcher.zig with the following error:
+>
+> launcher.zig:70:73: error: expected ';' after declaration
+>
+>      \\Usage: <...>/tools/<target-triple>/{[zig_tool]s}{[exe]s} <args>...
+>
+<...>
+
+> 1. Replace usage_cpp and usage_other by regular strings without
+> multiline constant syntax.
+
+This.
+
+> None of these are ideal, so I'm not quite sure how to go about solving
+> this. What do you think?
+
+I am OK with using ugly strings with ++ until
+https://github.com/ziglang/zig/issues/9257 is fixed one way or
+another. Can you do a final test on
+https://git.sr.ht/~motiejus/bazel-zig-cc/commit/motiejus_launcher_zig
+before I merge it?
+
+Thanks,
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=hahn.graphics header.i=@hahn.graphics
+Received: from mail.hahn.graphics (poliwhirl.hahn.graphics [139.162.183.182])
+	by mail-b.sr.ht (Postfix) with ESMTPS id D672011EED7
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue,  3 Jan 2023 08:43:11 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=hahn.graphics;
+	s=mail; t=1672735389;
+	bh=2iL93w52CB/FTkYi7s1VtI4kgojNZXlvRaiafHFAhiQ=;
+	h=From:To:Cc:Subject:In-Reply-To:References;
+	b=pNVRFxw42ymR5gTFYgl1MpqSWBCJaGcyOmEbbfXIEtzgiwomOZduLveMxoQA5jBFn
+	 bzMYMf0/Gfu0MUvdt/XlmoB8A4I7F8EAVpYNlIsIGLR8wOgU6BV0lePz8hBWmewCec
+	 uU4lr8XqhHuWNg820IzUt5kgQMx+jp6TOYAZaDGE=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8;
+ format=flowed
+Content-Transfer-Encoding: 8bit
+Date: Tue, 03 Jan 2023 08:43:02 +0000
+From: fabian@hahn.graphics
+To: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht, ~motiejus <motiejus@git.sr.ht>
+Subject: Re: [PATCH bazel-zig-cc 1/1] zig launcher: replace shell wrappers
+ with a binary
+In-Reply-To: <CAFVMu-q9QmVd+rTxHMqX==8E_-fZ=7x8Sq6St_q9YXcJz451Xg@mail.gmail.com>
+References: <167179347159.25324.12223141818448163553-1@git.sr.ht>
+ <ee9821ec-6b7c-4d62-a1f2-0b54cc2ef728@hahn.graphics>
+ <CAFVMu-q9QmVd+rTxHMqX==8E_-fZ=7x8Sq6St_q9YXcJz451Xg@mail.gmail.com>
+Message-ID: <ff04585641095da2b75f8f802ade9715@hahn.graphics>
+X-Sender: fabian@hahn.graphics
+Status: O
+Content-Length: 436
+Lines: 12
+
+On 2023-01-02 22:34, Motiejus Jakštys wrote:
+> I am OK with using ugly strings with ++ until
+> https://github.com/ziglang/zig/issues/9257 is fixed one way or
+> another. Can you do a final test on
+> https://git.sr.ht/~motiejus/bazel-zig-cc/commit/motiejus_launcher_zig
+> before I merge it?
+
+Sounds good, thanks for making the change. I've tested your latest 
+branch and Windows host support is working fine :)
+
+Best,
+Fabian
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=avilabs-is.20210112.gappssmtp.com header.i=@avilabs-is.20210112.gappssmtp.com
+Received: from mail-ed1-f54.google.com (mail-ed1-f54.google.com [209.85.208.54])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 6CC1A11EF61
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon,  9 Jan 2023 10:59:26 +0000 (UTC)
+Received: by mail-ed1-f54.google.com with SMTP id i9so11943880edj.4
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 09 Jan 2023 02:59:26 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=avilabs-is.20210112.gappssmtp.com; s=20210112;
+        h=cc:to:subject:message-id:date:from:mime-version:from:to:cc:subject
+         :date:message-id:reply-to;
+        bh=wiO/vRQsIvbU7BYL+3sg/r15a0jG1SiXTC1zvb/GmUg=;
+        b=VsAytavVhwOlNShKfzv02O3lK0oX02MQvQz1fgx5bzNOEiM0Zw1SYU3uSFp8PKvzrt
+         HhRU7xxbOe+v7w2hV82NumJ7bivyb4u5OaQOf2hxxyAu/INfAAcndulbGHtx/iXnjSK0
+         0QMRnnmdn19yUTFqrd93pAcV9gqu3nLL8rqywy9lqF4HuOvSXsM6Dg1exL1qLB48tinB
+         dCsDsnQ5PCk/tomv7WfsjvaZJh726wdeYRz3j2bszebWHgjUQoyfP4P3R+NlYlZSBK7Q
+         ASSmiXUiB6qxpSfzGAp2tn5qqpWPHBkBdsGa5mPfmcczxjJx0d3hLT3vCQQxG+UhMV3t
+         zLDA==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=cc:to:subject:message-id:date:from:mime-version:x-gm-message-state
+         :from:to:cc:subject:date:message-id:reply-to;
+        bh=wiO/vRQsIvbU7BYL+3sg/r15a0jG1SiXTC1zvb/GmUg=;
+        b=yG42sbLb13v5ukIb7APiTXVaof1TDMw1AA7xcE9ODa0+OnxaIH4ElSD3+PP06UebHs
+         XkJUOM3camI2uqfNwBQk3SCQrSXXMEvGrKfKpCMLkPdxW+r5ZZ+fTxHwJDUwuqgs8Mwg
+         Ic3A8qDnvlIfdOVVioLPqOOSrVfUSh7mUIkpZgj6323gl4dX2EUi4coHExB+e748MiJ2
+         AtlGL3lOlG155ljzTf4dDqmoXrNdcfUcUaihA+rOOAPJoUyREIgRZRKwDzli2c7o7DBn
+         z3iIVjPE/equF2bAk4MMidVVCP0Ed8mCzvX1dawXUjdjq36vDzSm2yonZ4TcW5s/f8Xp
+         WuhA==
+X-Gm-Message-State: AFqh2kpD9+EEeQtwVV0VX/xv0fgPaoDVEijQtPuXdBJUqqQP/Ke+vu7e
+	BMXqC9bLtz8ACRJ7vmEV5+JhsACwovjh3Paz6BSC3LprIsLQfNGt1m0=
+X-Google-Smtp-Source: AMrXdXuZ/GQWTSkeEcqkeUiPR7niaGSYFMaJAxSsxtnIUKOqlJrp1Oq7XYR0IyWnSwNMpRcbs2qxivY2GzZ5Z60KKMY=
+X-Received: by 2002:a05:6402:4c4:b0:496:839b:351f with SMTP id
+ n4-20020a05640204c400b00496839b351fmr1306911edw.287.1673261964948; Mon, 09
+ Jan 2023 02:59:24 -0800 (PST)
+MIME-Version: 1.0
+From: =?UTF-8?B?RGFuw61lbCBQdXJraMO6cw==?= <danielp@avilabs.is>
+Date: Mon, 9 Jan 2023 10:59:14 +0000
+Message-ID: <CAOY-u7Y6wvk8LeCj9QOpgjSieBcPhV2SUEvf3ARd5B2LCJbtAg@mail.gmail.com>
+Subject: Re: bazel-zig-cc v1.0.0-rc4: call for testers
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Cc: Fabian Hahn <fabian@hahn.graphics>
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 800
+Lines: 18
+
+I tested this with our repository but it fails to compile Rust code
+due to the following error:
+
+```
+error: /home/danielp/.cache/bazel/_bazel_danielp/f060a56172a8e8c557483bbe1399c8d9/execroot/monorepo/bazel-out/k8-opt-exec-2B5CBBC6/bin/external/cargo__pin-project-internal-1.0.12/libpin_project_internal-932791180.so:
+cannot allocate memory in static TLS block
+  --> external/cargo__axum-0.5.9/src/routing/method_routing.rs:20:5
+   |
+20 | use tower_http::map_response_body::MapResponseBodyLayer;
+   |     ^^^^^^^^^^
+
+```
+
+I tested this using the HEAD of the Zig toolchain and the default Zig
+version using the latest release of rules_rust.
+I'm not sure if this is an issue with Zig, Rust, rules_rust or the Zig
+toolchain and don't have the capacity to do
+a deep dive at the moment.
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oi1-f171.google.com (mail-oi1-f171.google.com [209.85.167.171])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 2171011EE64
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon,  9 Jan 2023 12:10:32 +0000 (UTC)
+Received: by mail-oi1-f171.google.com with SMTP id r130so6899008oih.2
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 09 Jan 2023 04:10:32 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=content-transfer-encoding:cc:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:from:to:cc:subject:date
+         :message-id:reply-to;
+        bh=eX6AsbvvO56a6DTz/iqP5zl+424Ez637Al7XfYFbF5s=;
+        b=EHSbmQ4MKCWl21TfWtjUzyhOIbegataFY+GNitS9LAFxqccK5+UsBs7gTuA6Mq7lKq
+         GijeFJN9dLeb15CZaoO6gEXunDQD/NrPCDk5GLCSx9cOtqbOVMzkfuKYxWFzgStnU/ek
+         UFX2gDTAOWG2PLn+rvQkq6+mc4kWcAOkl1Rq5CZlNIZpgQgEILaVfpDwlTUyd8kRRdYi
+         Sh4VvZnp2W55eXdeB8EB67YJa+NPXdslDXwL6KFHqQf5viMhsFFCYflWWFadrb6gFVno
+         mCQil7F8AQGJMO0Q28110fYXuNgeiVlPRspamtY6rUMPebQSmxtnSCWArM2BNrfRE5BF
+         Pn+A==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=content-transfer-encoding:cc:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:x-gm-message-state:from:to:cc
+         :subject:date:message-id:reply-to;
+        bh=eX6AsbvvO56a6DTz/iqP5zl+424Ez637Al7XfYFbF5s=;
+        b=ooy4Sg3Fd1UbFmkhculn5O1uNmekLz3cdxpxuoso4mjJRiPRz4afo06DvVb8rVBQg9
+         um8h5ugWHkrZJTIICLTG+5oR3/Q6VCBFVBgSF8YGHzNzU+8vnsS6lCLAQ1fHLNmT6/hB
+         Uzl2aue1PpHW2uo+svbQtgmXSP/fEavTEK/7VbJVaBsVpNbNqA0poqGKg4NNwhQAApB5
+         7AUOG45ZYc1VGVhWMZ23/s6H2Sn2w/J4S0fapmPgpktQHerBwT29Q0kMG9uy2Bvg3IBl
+         FhWAP/wGmLDB7TCRaDKxdDUYTgbP0mubbd2P6hLQhpLJKsrswC2EbvIDRczTb2QlfgnU
+         qo0w==
+X-Gm-Message-State: AFqh2kos9whboE9lEwoAOyGSvWSt6vP0wonRpO0nYN67eBNJwmgNrrqz
+	1ECYN19BTHARFopYbU76qcA150iLRkX2EeEVZOIXOyQ6eLaHuQ==
+X-Google-Smtp-Source: AMrXdXtirHZFFMJg1W+C4d5rl4P6m0gNou81Hr5u9nd2Ayaz+JQEpWaQQe9esXsCh17ncRN0faj08o/Y7cHK1A/HUqk=
+X-Received: by 2002:a05:6808:8c3:b0:35b:740:7598 with SMTP id
+ k3-20020a05680808c300b0035b07407598mr3270960oij.216.1673266231218; Mon, 09
+ Jan 2023 04:10:31 -0800 (PST)
+MIME-Version: 1.0
+References: <CAOY-u7Y6wvk8LeCj9QOpgjSieBcPhV2SUEvf3ARd5B2LCJbtAg@mail.gmail.com>
+In-Reply-To: <CAOY-u7Y6wvk8LeCj9QOpgjSieBcPhV2SUEvf3ARd5B2LCJbtAg@mail.gmail.com>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Mon, 9 Jan 2023 14:10:20 +0200
+Message-ID: <CAFVMu-o1w-6WF=WOKUX=Te4SXLE5FDgMrUZB1HEzxjQPhB3OFA@mail.gmail.com>
+Subject: Re: bazel-zig-cc v1.0.0-rc4: call for testers
+To: =?UTF-8?B?RGFuw61lbCBQdXJraMO6cw==?= <danielp@avilabs.is>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 1266
+Lines: 34
+
+On Mon, Jan 9, 2023 at 12:59 PM Dan=C3=ADel Purkh=C3=BAs <danielp@avilabs.i=
+s> wrote:
+>
+> I tested this with our repository but it fails to compile Rust code
+> due to the following error:
+>
+> ```
+> error: /home/danielp/.cache/bazel/_bazel_danielp/f060a56172a8e8c557483bbe=
+1399c8d9/execroot/monorepo/bazel-out/k8-opt-exec-2B5CBBC6/bin/external/carg=
+o__pin-project-internal-1.0.12/libpin_project_internal-932791180.so:
+> cannot allocate memory in static TLS block
+>   --> external/cargo__axum-0.5.9/src/routing/method_routing.rs:20:5
+>    |
+> 20 | use tower_http::map_response_body::MapResponseBodyLayer;
+>    |     ^^^^^^^^^^
+>
+> ```
+>
+> I tested this using the HEAD of the Zig toolchain and the default Zig
+> version using the latest release of rules_rust.
+> I'm not sure if this is an issue with Zig, Rust, rules_rust or the Zig
+> toolchain and don't have the capacity to do
+> a deep dive at the moment.
+
+Hi Dan=C3=ADel,
+
+Having spent a few minutes searching for a similar issue,
+https://github.com/rust-cross/cargo-zigbuild/issues/27#issuecomment-1094177=
+369
+may be a good start. I am not planning to work on adding Rust-specific
+support to bazel-zig-cc, but will accept patches that make support
+*better* for Rust.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oi1-f177.google.com (mail-oi1-f177.google.com [209.85.167.177])
+	by mail-b.sr.ht (Postfix) with ESMTPS id B6D2311EF5B
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 24 Jan 2023 09:12:15 +0000 (UTC)
+Received: by mail-oi1-f177.google.com with SMTP id p133so12713748oig.8
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 24 Jan 2023 01:12:15 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=content-transfer-encoding:to:subject:message-id:date:from
+         :mime-version:from:to:cc:subject:date:message-id:reply-to;
+        bh=pirDsVdLJZtJJTnvtmK6QCkfNIPZaeF2xWVl50xvN1Q=;
+        b=5y8MsL2MPc5sTpRtSIlkgnSrkX3G+47FKsAHPRzaVbWu+c/cc+3ZqYbq4vT/fyz5VA
+         H0jHnFTj4ytvHAX+bJBZOxAoX6xJsr9iiXHHRC8F+J0b34Z/FQ5PMNDc7wxe2Iv+OlUW
+         hYAjO5pPoBMzNJXUAGgD4p+md8mEbUEBUZKTWvXvDYbV1iLXMo8D7HvqWvS4AcSxpFPz
+         taar6aDzy2GsbATJsz0/MbIBmIhi3ln3CzXChe36Yit5WY/nKaPW9sjrZZuk9LS6rvAB
+         ffQMvkCxHppcpf+32C5EACWmf1g3A3qj0kI+SbSQaTH7BRlcdNzyPq1ofw4uLbsiTXlJ
+         X8gw==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=content-transfer-encoding:to:subject:message-id:date:from
+         :mime-version:x-gm-message-state:from:to:cc:subject:date:message-id
+         :reply-to;
+        bh=pirDsVdLJZtJJTnvtmK6QCkfNIPZaeF2xWVl50xvN1Q=;
+        b=gIdYJNFL/qVVIElJa5IaC2a2X2IpXREirrkJhFgH28XgwCNlZybc8E/uSp4yXWF1gx
+         pkHEFvzGNi+InzA3vUPlfgBbPsCH3eYNwKoJYxYN39CrkuElpz4BhENOrDsw5szn199M
+         uz65FRMoyocTzLwlm5AxKMcG2C9gjkon1XE0NDyK8hs4caXXgSti1auuM3h9fWyXIKJg
+         5UhsVU4Ulkp+Fxj0D+X/wjKa+zjwdrLkLmZyhcALs4n6Q/6pSSfjzrHES/sNRwodktaI
+         6pP7ZOb3yzTn1NrHdpF2+S4FT/LolJVNn8aAnmU+vq/SmxyqibHZtkWSNfXQdIjgQZ75
+         ZKRQ==
+X-Gm-Message-State: AFqh2kpqio7abc7ea/9cSUIVNB56iF7fZF0sToWeH/OZ6gXW90DGygRe
+	pTxzTjWseH8WwP67CpaZGfeGN8t1JqA0wxX/JZABNMuybAfwQask
+X-Google-Smtp-Source: AMrXdXvOo38z8zJaeMPG1n9kq4ZJdGctq2rPkcWCyUipqGRJG9yZTbsGJMclKgeemTV4Eee5T14X1QnhKRR9Ievv3ic=
+X-Received: by 2002:a05:6808:1396:b0:36c:3082:f21f with SMTP id
+ c22-20020a056808139600b0036c3082f21fmr1293665oiw.116.1674551534859; Tue, 24
+ Jan 2023 01:12:14 -0800 (PST)
+MIME-Version: 1.0
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Tue, 24 Jan 2023 11:12:03 +0200
+Message-ID: <CAFVMu-rYbf_jDTT4p=CS2KV1asdS5Ovo5AyuCwgv2AXr8OOP0g@mail.gmail.com>
+Subject: bazel-zig-cc v1.0.0
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 1087
+Lines: 34
+
+Hi all,
+
+I just released bazel-zig-cc v1.0. It has been compiling Uber's Go
+Monorepo since Jan 4 of this year, so we feel it's good enough for v1.
+
+Changes since v1.0.0-rc4:
+- add `res_search` workaround for ziglang/zig#9485[1], equivalent to `fcntl=
+64`.
+- replace the shell-based wrapper scripts with one written in zig.
+This enables --experimental_use_hermetic_linux_sandbox, leaving only
+/proc/self/exe required outside of the toolchain (I will probably fix
+even this eventually).
+- Apple M1 improvements by Jeremy Volkman.
+
+This is probably the last release of bazel-zig-cc in sourcehut. In
+very short order bazel-zig-cc will become an official Uber's project
+and move to github. I will send a separate announcement when that
+happens (and maybe a blog post somewhere).
+
+Thanks everyone involved in working with us towards v1.0; here are our
+contributors:
+Motiejus Jak=C5=A1tys
+Ken Micklas
+Laurynas Lubys
+Fabian Hahn
+Jeremy Volkman
+Adam Bouhenguel
+Luis Holanda
+Mantas Jonaitis
+Piotr Sikora
+
+Motiejus
+
+[1]: https://github.com/ziglang/zig/issues/9485
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=gmail.com header.i=@gmail.com
+Received: from mail-wm1-f52.google.com (mail-wm1-f52.google.com [209.85.128.52])
+	by mail-b.sr.ht (Postfix) with ESMTPS id BA87E11EF33
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 31 Jan 2023 18:30:33 +0000 (UTC)
+Received: by mail-wm1-f52.google.com with SMTP id j32-20020a05600c1c2000b003dc4fd6e61dso6295706wms.5
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 31 Jan 2023 10:30:33 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20210112;
+        h=to:message-id:subject:date:mime-version:from
+         :content-transfer-encoding:from:to:cc:subject:date:message-id
+         :reply-to;
+        bh=n12HA2hV21eFT3bpEeIz2d10w7v0CipRR2jUa02tUdE=;
+        b=iCc4+90qqkNRna/kCzqObfppv+ElKz3Qchv68ZrirWNsRtC7Zbb8Obt8crREfDR2p8
+         kdyujunCjfopwBonDHjK8MBm35bdJmmd6jsJ+d0KM18Pz7IweV/qX+hh9cacRgh6lTNm
+         WUyecoZ7t2a/wewB86nC+47hWGXq3rQUgSUAGp6Wytfe+CTCtJmsJ/l25YYtT5kjTJT0
+         t78xT9R91GuOF3FHyxTSI5xpnFhGY4jbXOdYCAO9GAAl3dMB6YMhCLR5wfPR4reh922O
+         crgM5Tg9QK5ryG6x4xHCYD0MZWgDt+TasJw3WXLHMEcAOQxUljvURBOPe39vu5V7RuvB
+         sJCw==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=to:message-id:subject:date:mime-version:from
+         :content-transfer-encoding:x-gm-message-state:from:to:cc:subject
+         :date:message-id:reply-to;
+        bh=n12HA2hV21eFT3bpEeIz2d10w7v0CipRR2jUa02tUdE=;
+        b=JKUltrn4s3MwuRg4MwK1m3QVbu65yMPXAho/0x/beT+dvdkosYnXl3meELHxzw170W
+         kw5GQkc6FhSpwEXJijLj+5eA3k2RRA8VoVdagauDW13wQydJ9fZ0AzTmNdqb64+MbIWR
+         twktQK4lgpSBd5hDqnnBGfUGARo4MPsFcf8oUpO2sarr+K0aByG3yU5TRN2uEqqKlC8E
+         L0/Vx4Cq4UAdaBnnk9zzsjHbG7sI+iKal28MngHqzkHHUdquHhE13vZ3h77PqL4ur/Pf
+         av6zjWGPeK8/Eumg7xbL0wNlCSwaJEQdQtKjEego5gxdm0Gm1bM7JUdLJlcHgd2bkVLp
+         L1bQ==
+X-Gm-Message-State: AO0yUKUQbJ5XZyYrAxW4wTfHYW+RgVK8sD4t0+GT/xblG7Y1ohR6x5Ws
+	HHizatbnrXdjJ8BKtfAP81H9Ek04Q1M=
+X-Google-Smtp-Source: AK7set9HHZ8jlVWGbInO+6dsL0SeC45/Tw9jT2n4UK8yDRAjPgBH7t5Cr/DG1XmGwCBygjNDQ+lodw==
+X-Received: by 2002:a7b:c416:0:b0:3dc:5950:b358 with SMTP id k22-20020a7bc416000000b003dc5950b358mr9086394wmi.14.1675189832389;
+        Tue, 31 Jan 2023 10:30:32 -0800 (PST)
+Received: from smtpclient.apple (cpc73674-dals20-2-0-cust516.20-2.cable.virginm.net. [82.39.238.5])
+        by smtp.gmail.com with ESMTPSA id l16-20020a7bc350000000b003d9aa76dc6asm23192438wmj.0.2023.01.31.10.30.31
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>
+        (version=TLS1_3 cipher=TLS_AES_128_GCM_SHA256 bits=128/128);
+        Tue, 31 Jan 2023 10:30:32 -0800 (PST)
+Content-Type: text/plain; charset=us-ascii
+Content-Transfer-Encoding: quoted-printable
+From: Simon Mavi Stewart <simon.m.stewart@gmail.com>
+Mime-Version: 1.0 (1.0)
+Date: Tue, 31 Jan 2023 18:30:21 +0000
+Subject: Setting sysroots
+Message-Id: <B83A9681-7EBB-4230-8543-160AC09A0436@gmail.com>
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+X-Mailer: iPhone Mail (20D47)
+Status: O
+Content-Length: 581
+Lines: 18
+
+Hi,
+
+Is there any recommended way of passing a sysroot to use to the zig-cc toolc=
+hains that are created? And also to pass additional linker flags?
+
+I'm trying to use bazel-zig-cc to compile code using Rust, and some of the d=
+ependencies need to link against `libiconv`. For macOS compiles, I know that=
+ I need to supply my own sysroot, and that needs to contain not just the lib=
+raries, but also the frameworks that are linked against. Being able to speci=
+fy additional linker flags would help with that a lot.
+
+Kind regards,
+
+Simon
+
+
+
+Sent from my iPhone=
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f42.google.com (mail-oa1-f42.google.com [209.85.160.42])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 80EE111EEF6
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed,  1 Feb 2023 06:42:09 +0000 (UTC)
+Received: by mail-oa1-f42.google.com with SMTP id 586e51a60fabf-1631b928691so22324331fac.11
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 31 Jan 2023 22:42:09 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=content-transfer-encoding:cc:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:from:to:cc:subject:date
+         :message-id:reply-to;
+        bh=utQqHvcPaIgRS3drT1L6mOTb/DE6v2Z5Z4nvezVHXo8=;
+        b=QNj8Fgbg64imNlrUAZOU+4Ysi9t8ZQ++3BdhjAKtpwgQMS6L9VVkVxXG2OAUZJt1fb
+         tjvL3O4r2h3qJcDf86c2D4V1ke6tK2oZ23GuHYteyEmJ4vd/5iD7k7eAkeh6wOESqrs8
+         IOg0cxKvtmpUOF1HvG7R/w/gSF6mzcDpSDzTQ3J9xORh7xiWca1YqCFHw4oj7haq/5lU
+         LA7vbBS0Lzc5bhl2UDbbqb71GJodejcPcDRimap2he7O0DT7tIBKEUnB/l9Vsh5uv9M4
+         zQZFa5lnzsKU63Jtw/JW6/6AUPOGgD3Lg/RnzIx0yOc7KLu7AtGpeaHHQl6KuZpJ9AJx
+         QQ2w==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=content-transfer-encoding:cc:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:x-gm-message-state:from:to:cc
+         :subject:date:message-id:reply-to;
+        bh=utQqHvcPaIgRS3drT1L6mOTb/DE6v2Z5Z4nvezVHXo8=;
+        b=zX9rrE9EwCb96vXqEMDpfSNM8cTHEiTMvV5AGGMH/k3OqNsgpZcnzswL30DlfjSw/A
+         ulDN6BS29a+Jqg8vmTfqVQMA/c30RHgjvAOOvr54QhQyWjZO5lajHCHmOXsWT5O7PUAB
+         YUERu6DQndcuMd422CEr1Zn6toYQ0KNSylWnur8yrknGDf6i43wlE1dzUuk/+bdrEaFj
+         fizV5/f0BTe2Bm6KiqQi+UNDKK6IPI/S809+qQI5ZFYBzaDcj0PzQYlft96a2IDwaa9a
+         q0lbF3D9iIddmNXJ9AknLz4PKxsWzjyea0EvjX3cefOAYrK78NPXwP9BRw2b1f6jF+dc
+         611A==
+X-Gm-Message-State: AO0yUKU1ZuTfa3PbEglkvvv1OFNPedCt1liK4CERhF1dy5vO/cNYZsXH
+	z8FTOe7XUJBiPOtxzqBEnP9JyOdd32g8UH8QMf0=
+X-Google-Smtp-Source: AK7set/IkiK0iQuBnALkIDIzes66XmYL73mGXcw76xghv+LidxYFnTwOLGdqZmeqmjmQxhk5P5fe7eAOp2ZapzQYaUw=
+X-Received: by 2002:a05:6870:391e:b0:154:210:aad8 with SMTP id
+ b30-20020a056870391e00b001540210aad8mr79503oap.116.1675233728702; Tue, 31 Jan
+ 2023 22:42:08 -0800 (PST)
+MIME-Version: 1.0
+References: <B83A9681-7EBB-4230-8543-160AC09A0436@gmail.com>
+In-Reply-To: <B83A9681-7EBB-4230-8543-160AC09A0436@gmail.com>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Tue, 31 Jan 2023 22:41:57 -0800
+Message-ID: <CAFVMu-pH1ZJxQzHBUaBHFvQuXLSDrZxF6BJgpsLY2gaf0THUfQ@mail.gmail.com>
+Subject: Re: Setting sysroots
+To: Simon Mavi Stewart <simon.m.stewart@gmail.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 1400
+Lines: 37
+
+On Tue, Jan 31, 2023 at 10:30 AM Simon Mavi Stewart
+<simon.m.stewart@gmail.com> wrote:
+>
+> Hi,
+>
+> Is there any recommended way of passing a sysroot to use to the zig-cc to=
+olchains that are created? And also to pass additional linker flags?
+
+Hi,
+
+Yes. See this snippet in the README:
+
+    version =3D "<...>",
+    url_formats =3D [
+        "https://example.org/zig/zig-{host_platform}-{version}.{_ext}",
+    ],
+    host_platform_sha256 =3D { ... },
+
+Does that explain it?
+
+> I'm trying to use bazel-zig-cc to compile code using Rust, and some of th=
+e dependencies need to link against `libiconv`. For macOS compiles, I know =
+that I need to supply my own sysroot, and that needs to contain not just th=
+e libraries, but also the frameworks that are linked against. Being able to=
+ specify additional linker flags would help with that a lot.
+
+Linking to libraries outside the sandbox is highly, highly
+discouraged. Normally you would build libiconv with bazel (cc_library
+et al) and statically (recommended; you can also link dynamically, but
+that has its own caveats) link to it in your application.
+
+As far as *.tbd files of MacOS are concerned (do I correctly
+understand that this is what you mean by sysroot?), this is currently
+unsupported, and, honestly, I have very little idea how to implement
+it. But I will review/accept patches that do it.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-ot1-f45.google.com (mail-ot1-f45.google.com [209.85.210.45])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 352CC11EF87
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed,  1 Mar 2023 07:01:22 +0000 (UTC)
+Received: by mail-ot1-f45.google.com with SMTP id l13-20020a0568301d6d00b0068f24f576c5so7004174oti.11
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 28 Feb 2023 23:01:22 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112;
+        h=content-transfer-encoding:cc:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:from:to:cc:subject:date
+         :message-id:reply-to;
+        bh=341AQbBr8EeqGhQIedaqTUph1hVhMvfQgTdnHn9B2sQ=;
+        b=qIrCEoiOrms7UfacVUNeb5bFOh388I4VD9vC/hOBJWEOC6Y8GqIAT8Js3GiwoxHqUU
+         kE+/DoZBVxo+rL+M0uNtOv2geejLDYrsYIzb25ys0/eJtW+yRHvpZARKlhBvknSfNCI9
+         0tUbaBaVoqG95JUnXpdjETBA/zFPOjopHNiqAznaqlpQkk4FmL3JSLATibrJk0LcNccf
+         kZ9AU9dEqdQbFlSszOZPME7LUUEwSeHBqoqnPS2C4g/W2+QDG8CLojbC5gIttybb/xFj
+         i68lTVL+Xi3zDVU+wZcby8Ch2zvMiQx5ovRuGS5vN4mJgF4xSJY6W1LyrftZIqE0QKGY
+         T91A==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=content-transfer-encoding:cc:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:x-gm-message-state:from:to:cc
+         :subject:date:message-id:reply-to;
+        bh=341AQbBr8EeqGhQIedaqTUph1hVhMvfQgTdnHn9B2sQ=;
+        b=KoUhs0a6HASgYeIH5vXlY9P96d+/QNO2rJvEC2lp0PHAx9piVB7JeE+Q2G2DtmatZ6
+         5nOjkIz/hAOLondRBXeZ7qdbcADZ0iy81QzV3GZDNMyXqQ/ZAnQ/LNSB3jNCCdYKpfSL
+         0RXr6uqrnUGzbFITOL+MNysmLV6IwSU5DD4Uav/e5i834KH+QEkVxp/Sgyzz+TrH5lBz
+         2GpMHyAC+0Cse2qPmJ+P1SHRv3yS3BGGwNH99NRKVtRluq3iVB6IPfbhj64VpI5Wc6i9
+         va6ZpYnQcuxwik4IZcSv9y3rBwO5q/iHv6gK9dflwxR1i1s1kesWYnRLMfAysv9cV8mn
+         Bhag==
+X-Gm-Message-State: AO0yUKW5L08q4Jyo3R+pEKSB4INn+7k4RsFugLhcItfOWCiVIRdvbdUo
+	fhkauylW42Zh6Av7ve7Cn6sLFzV9+Q7Trv++VQ4=
+X-Google-Smtp-Source: AK7set8trQVnOcKp8mO+HaBVv5WCjMLHqqvMDzWfi+93k40aEAwux29LJBy04iy7erouElLMIp4o2dILuCn5Eb5RUo0=
+X-Received: by 2002:a9d:600a:0:b0:68b:d3e8:575f with SMTP id
+ h10-20020a9d600a000000b0068bd3e8575fmr1909069otj.5.1677654081410; Tue, 28 Feb
+ 2023 23:01:21 -0800 (PST)
+MIME-Version: 1.0
+References: <CAFVMu-rYbf_jDTT4p=CS2KV1asdS5Ovo5AyuCwgv2AXr8OOP0g@mail.gmail.com>
+ <CAFuCWxuDt=c1N=8AHmZEzbY1XTadcnD_A52XdvMf6jhOc6qZ1g@mail.gmail.com>
+In-Reply-To: <CAFuCWxuDt=c1N=8AHmZEzbY1XTadcnD_A52XdvMf6jhOc6qZ1g@mail.gmail.com>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Wed, 1 Mar 2023 09:01:10 +0200
+Message-ID: <CAFVMu-okEg37xUzG+DDB7dAmqDjXyzoZbCVxtBjuHvN36uEF-g@mail.gmail.com>
+Subject: Re: bazel-zig-cc v1.0.0
+To: Jeremy Volkman <jeremy@jvolkman.com>
+Cc: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 406
+Lines: 16
+
+On Wed, Mar 1, 2023 at 1:31=E2=80=AFAM Jeremy Volkman <jeremy@jvolkman.com>=
+ wrote:
+>
+> Hi Motiejus,
+> Has that move to GitHub happened yet? Should we still send patches to thi=
+s list?
+>
+
+Hi Jeremy,
+
+We are still working on it, there have been some bumps on the way.
+
+Worry not, it will be announced. Until that happens, please keep
+contributing to sourcehut/this mailing list.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f47.google.com (mail-oa1-f47.google.com [209.85.160.47])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 3424511EF96
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon,  6 Mar 2023 09:41:52 +0000 (UTC)
+Received: by mail-oa1-f47.google.com with SMTP id 586e51a60fabf-176b90e14a9so3082643fac.9
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Mon, 06 Mar 2023 01:41:52 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112; t=1678095711;
+        h=to:subject:message-id:date:from:mime-version:from:to:cc:subject
+         :date:message-id:reply-to;
+        bh=KHLWt4SFcy5d3KGmDzqpKrFQGir4fMGvuU4gHfpcVDQ=;
+        b=dPcQmUvpPUvBc0j66qVkBCIRRVyrscB5L/KPrL4xoeJuCSriXpWHQBdTbv8o+DDIif
+         glPcbOM10mSTuMWzjFA/+qxv2euUxkMF12IQzdilw+FPg96hF627qYQPwslHymLUf4qB
+         9K89tQrAsmw/ovJ2gs70nv49X5FO9/vSooyXl4WY7J3Gx1VWPZ5gZWNgB/k6tHFckG4v
+         3wc/WNenxlKUUjV4z+IJYUYJTWNgA4lD0wqKHrap1GhUbN2MHGaFoMPMclRcL9lrXeDc
+         FymEx/zQHxtoXYR4roffK7xvLjCmonkQ6nopGNbcS9fR8hweatrxayb6CsRnd5QXXEVh
+         sezw==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112; t=1678095711;
+        h=to:subject:message-id:date:from:mime-version:x-gm-message-state
+         :from:to:cc:subject:date:message-id:reply-to;
+        bh=KHLWt4SFcy5d3KGmDzqpKrFQGir4fMGvuU4gHfpcVDQ=;
+        b=bHllgOiXQ7QNb/Q2plRC1rMOzPk+LWRVT0YgGYHb1kA0qBFK9o2O1oUpU+9617R1As
+         F3pZAQ6hM5ShDaQLbpzhGHvIdrxSyVlWL2GDaY0/Oy+AtsiUB/ejMDPyO/vrZP1T8vnJ
+         wD5k/HjARvHCVS8FjuVynYbaNKoI8jIC3X+DxNZ+T+1P/KJVApnX8ExZktOcA6ZwSS6B
+         W1ec0NsQIWpBmTNgqYxD8Dn3Hfto+liDkD7K1+NBsxy63Yq3mEN6ymjckfPb6PuXJojI
+         QUMhYfN+ih1Lg7B2+gPJDpcKqo4PedcGvEYu2PBiB3hlx/kPBmd7tXp66JjQ1QI+zF85
+         rrGQ==
+X-Gm-Message-State: AO0yUKVOA3yV6SPNdYFas2qkyV4JI2jCflWZAsh50lYX7WmULP/Nncb5
+	vVJ7faIti9lv2J1NiMqOiQ6Hs6CvmUyVBvb/N21Vz6kmXhI=
+X-Google-Smtp-Source: AK7set8t8jRvCk/nLe+DUPUHvVQsD2vWjU4awePbjuoatEvjtjHG8xu0MBpJdOatCBhzGCyWjvh2f6WH4rbD+UJd7WM=
+X-Received: by 2002:a05:6870:3a12:b0:16e:9d0:2211 with SMTP id
+ du18-20020a0568703a1200b0016e09d02211mr3480199oab.11.1678095711441; Mon, 06
+ Mar 2023 01:41:51 -0800 (PST)
+MIME-Version: 1.0
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Mon, 6 Mar 2023 11:41:40 +0200
+Message-ID: <CAFVMu-qj835_+rWH5h01M4GA-YeoXKELPUnebzP0U8wVhRggxA@mail.gmail.com>
+Subject: bazel-zig-cc v1.0.1: relicense to Apache v2
+To: ~motiejus/bazel-zig-cc@lists.sr.ht
+Content-Type: text/plain; charset="UTF-8"
+Status: O
+Content-Length: 1742
+Lines: 34
+
+Hi folks,
+
+I just cut bazel-zig-cc v1.0.1:
+- partially relicensed[1] to Apache v2.
+- download zig sdk from mirror.bazel.build by default instead of
+dl.jakstys.lt. Thanks for no longer using the server from my closet --
+turns out Google is generous enough to mirror such files[3]. You can
+now safely omit the "version", "url_formats" and
+"host_platform_sha256" -- we intend to keep upgrading bazel-zig-cc to
+a reasonalby new Zig version, forever mirrored to mirror.bazel.build.
+- upgraded Zig to 0.11.0-dev.1796+c9e02d3e6. This Zig fails the linker
+step on unsupported linker flags[4], which will make
+autoconf/automake/cmake invocations with zig cc more robust (it used
+to emit a linker warning if it found an unsupported linker flag,
+sometimes with unexpected consequences).
+
+We created a #zig channel in Bazel Slack. Bazel says the invitation
+link[2] will be active for 14 days. Just find us on #zig in
+bazel.slack.com if you want to chat.
+
+All following contributions to bazel-zig-cc will be accepted only
+under Apache 2.0 license; this was the last required step before
+moving the repository to github/uber. The move took longer than I
+though it would, but rest assured, it is happening. Before the move,
+let's keep using this mailing list and Slack for comms. After the
+move, the this mailing list will be replaced by github issues/PRs,
+Slack will stay.
+
+Motiejus
+
+[1]: https://git.sr.ht/~motiejus/bazel-zig-cc/commit/dfdb1f26805c1ccf6d1113276d40c8ce4c1fa17e
+[2]: https://join.slack.com/share/enQtNDkwMTIxOTk0NTk1NS01OGUyNjM4ODQ2MDI1NjdiNmYyOTMxMGNiOWRiMDU2YmY0MmYwNWU1ZjI5NzNmMjMzZGExNDJkZGE0NzI5N2I3
+[3]: https://github.com/bazelbuild/bazel/issues/17635
+[4]: https://github.com/ziglang/zig/pull/11906
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=edgelesscompute.onmicrosoft.com header.i=@edgelesscompute.onmicrosoft.com
+Received: from EUR04-HE1-obe.outbound.protection.outlook.com (mail-he1eur04on2097.outbound.protection.outlook.com [40.107.7.97])
+	by mail-b.sr.ht (Postfix) with ESMTPS id F133511F008
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue,  7 Mar 2023 16:15:11 +0000 (UTC)
+ARC-Seal: i=1; a=rsa-sha256; s=arcselector9901; d=microsoft.com; cv=none;
+ b=YFyoDL4c9ZGF1XLga63UMYYIqSIKUKYzRvAEJwGsRZsSHCD+8ZX1gbidlGvNRMPFuAGZAo2uFzAiAdy4qcgVuWyNAKU/lJ2e+RF4f3/IPt7ciA+MwD71ywMMBMVKrxtvQeN9KxGqeU7XHI6Es6n/ji7rRCV8RyLWDQYTlSwsGSZ1cJGgkduCtgGrNw4J69APFV1uCdIytuwE4pZSguSb8izZGndSgfcE/hecZf+YGYWZ7sFbZ88fDHzjrR06XFrW+vYKur3ShGhuFbUYqotYagKqrHftVZXIMNL2w/wLW3Ha513JyyU2ljta7+LOzAXt9erSFkal+7gphXFj5h+nTg==
+ARC-Message-Signature: i=1; a=rsa-sha256; c=relaxed/relaxed; d=microsoft.com;
+ s=arcselector9901;
+ h=From:Date:Subject:Message-ID:Content-Type:MIME-Version:X-MS-Exchange-AntiSpam-MessageData-ChunkCount:X-MS-Exchange-AntiSpam-MessageData-0:X-MS-Exchange-AntiSpam-MessageData-1;
+ bh=kc32X+Y0WyUOgZl4j7AgAFhn/Pu5ywsL1ZGM9wQO6C4=;
+ b=fD164Kgsw0HYAXnHsFx15Ml7/UrDaNh1xkWkFDWUAsBgFeXK8O41hKmALDYpvvbkYFB97VPDui0S9uugrHN1yZ9bn0XG4yCYumOp19LsTG9CpD0/EFmjLsntO422qtHTLl3FLtxeI308m47Xa8Tc2nx0WJICjk588rMfP3SQyg7gsWXsZXN/zs/ynElsVyS8sgUmg6U5r5w6+i4naaF9YnepJjU/b0bJEgNcFoT/geeBXklU9fzWfJddzFoZcvcpGib7cyQkNGi829hHxiPpeBZ04X5IqTYmSuD4wUxfb8knhfaBPpUUSaMvqj4HUADKOiMQUARd4NTeDxZqDisAHg==
+ARC-Authentication-Results: i=1; mx.microsoft.com 1; spf=pass
+ smtp.mailfrom=edgeless.systems; dmarc=pass action=none
+ header.from=edgeless.systems; dkim=pass header.d=edgeless.systems; arc=none
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+ d=edgelesscompute.onmicrosoft.com;
+ s=selector1-edgelesscompute-onmicrosoft-com;
+ h=From:Date:Subject:Message-ID:Content-Type:MIME-Version:X-MS-Exchange-SenderADCheck;
+ bh=kc32X+Y0WyUOgZl4j7AgAFhn/Pu5ywsL1ZGM9wQO6C4=;
+ b=UR+6TzHq5DyTQZlVyDepW9TUnjyO7JfRCgtrJ3EHZ+/ntSJxq7oLqsgCCkEFpRH20H7YzZ1lqRqAlmeYcPQ+0vheMxNiCB0FTGTF+BtbuqxgcKkOi/rzNjFX875FvaOrU0QyOALb6g5okorIVBCxSHCTz4ywt9wUxcl1XlkoJWM=
+Received: from AM6PR02MB4470.eurprd02.prod.outlook.com (2603:10a6:20b:60::26)
+ by AS2PR02MB9692.eurprd02.prod.outlook.com (2603:10a6:20b:5e8::11) with
+ Microsoft SMTP Server (version=TLS1_2,
+ cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id 15.20.6156.27; Tue, 7 Mar
+ 2023 16:15:09 +0000
+Received: from AM6PR02MB4470.eurprd02.prod.outlook.com
+ ([fe80::77cb:f64d:66e1:45fe]) by AM6PR02MB4470.eurprd02.prod.outlook.com
+ ([fe80::77cb:f64d:66e1:45fe%4]) with mapi id 15.20.6156.028; Tue, 7 Mar 2023
+ 16:15:09 +0000
+From: Malte Poll <mp@edgeless.systems>
+To: "~motiejus/bazel-zig-cc@lists.sr.ht" <~motiejus/bazel-zig-cc@lists.sr.ht>
+Subject: bazel-zig-cc embeds bazel cache path in go binary
+Thread-Topic: bazel-zig-cc embeds bazel cache path in go binary
+Thread-Index: AQHZUQyCt72lM2cHQEOQ7xqzbgSQqq7vfVcN
+Date: Tue, 7 Mar 2023 16:15:08 +0000
+Message-ID: 
+ <AM6PR02MB44704BD42717C2D472D0CEB6B5B79@AM6PR02MB4470.eurprd02.prod.outlook.com>
+References: 
+ <AM6PR02MB4470CFBE0B194EA91E16F552B5B79@AM6PR02MB4470.eurprd02.prod.outlook.com>
+In-Reply-To: 
+ <AM6PR02MB4470CFBE0B194EA91E16F552B5B79@AM6PR02MB4470.eurprd02.prod.outlook.com>
+Accept-Language: en-US
+Content-Language: en-US
+X-MS-Has-Attach: yes
+X-MS-TNEF-Correlator: 
+msip_labels: 
+x-ms-publictraffictype: Email
+x-ms-traffictypediagnostic: AM6PR02MB4470:EE_|AS2PR02MB9692:EE_
+x-ms-office365-filtering-correlation-id: a6e36297-a00c-464c-c0e4-08db1f271f26
+x-ms-exchange-senderadcheck: 1
+x-ms-exchange-antispam-relay: 0
+x-microsoft-antispam: BCL:0;
+x-microsoft-antispam-message-info: 
+ ISz03HwFPOTDBB5O8gfF2GjpDkCaoJ4PpzRhTFaTkupaENU8Q88C6k5hUlKSJaK8f/E/lI0TjYifSCUxRv9OB+EqgMaADIr/W4aeSrlL0HzUovY4jkj6qp6dprdM0XHMUpOmUTZvt7APYoPJ7NKywZBAU7Z6Yl1jsxJNzMRTnIdaaHkgOz9lLc85+9Jb5LL/dKSktE+MEME6Dgat80upf5iZeZTrW+DqLXVCUn4SPVvzUOcJjZBanLwViKoyxlJvqH/ukqgDWRvIWXadCCAbqx5HXoDeIpUPCNkypztx86mpeyoBbP7IzhJd72ikyYF0txLUfIR8LRO00LWLdjM5qoH2eAi0oxs/iXxxrEZLThU7z/lWMTL9FUouQT9UMwqVnNFrRk9LEXaEfnMo4QGHFtBvntnxEzsvABP8a1jODRKvf7zmOyp8PgUCaO1tXl9t+dP9qfzclo+kxQ031Y0X3RGo4bvBzS+qb9L7iaeG2Wj3BceiItUwM+lcFV8L5X9BsQH0kI3CqhUuydlcWqBMzSPQGP/f/XceZHqZj37juhIO8JTFYyi3ghqbnsOC5UhVbgPIZC8vFIWDG93HGFqzeuOqM5uFP17JrIo/TAEWlKFqHURjQBldoQo29GM2TRo1NWO0GqNFol/qmfTzlU5KKZXtx0tE5InFS0XzupNYSSXtuYXKTpA6n1Zie5S9x8NzLOYK4kJSRdNZugiOrnCSn9u9efopbkFNPNCxMhD6VNE=
+x-forefront-antispam-report: 
+ CIP:255.255.255.255;CTRY:;LANG:en;SCL:1;SRV:;IPV:NLI;SFV:NSPM;H:AM6PR02MB4470.eurprd02.prod.outlook.com;PTR:;CAT:NONE;SFS:(13230025)(366004)(346002)(39840400004)(376002)(136003)(396003)(451199018)(8936002)(66556008)(5660300002)(52536014)(66446008)(91956017)(66946007)(66476007)(2906002)(8676002)(64756008)(76116006)(316002)(478600001)(71200400001)(7696005)(6506007)(41300700001)(26005)(86362001)(33656002)(99936003)(122000001)(38070700005)(55016003)(186003)(38100700002)(2940100002)(9686003)(46492015);DIR:OUT;SFP:1102;
+x-ms-exchange-antispam-messagedata-chunkcount: 1
+x-ms-exchange-antispam-messagedata-0: 
+ =?koi8-r?Q?0M9jpOLG1j60GnuKUfgLhF3p8V6n22wwZgOWHmgTjOodK2O5SE0qEOYPMvIVHl?=
+ =?koi8-r?Q?WSqUXFOeFAxRmrPse+AxeTYRPKDo6V5pyoIASh4KXLQA1obS7uGWLNFTicd9V+?=
+ =?koi8-r?Q?t78lO7l7OkgngeFIMsmaegczTCVPKwMDPoh7P3ccuJB3qKKGkDYgj7nmr3+SPy?=
+ =?koi8-r?Q?vrMa7+7IWYjXjeSsjisLbrTibGW0cWPKv4RP77zOW0whdC9KHlZ8PRUi/faFVD?=
+ =?koi8-r?Q?nfs7YEA0cbb0rCgpnHa4KYHdP3ItjUSo4JNpkD51oENQWdRyfYlkD+anvaoxwr?=
+ =?koi8-r?Q?kTPL3YDdqyjFWHvoABW1TubTx3Ukc06dvcrEheq5W9AWWsuwxiB+uGQnFRdTlZ?=
+ =?koi8-r?Q?STYA+0i0EHNZzlnUFBfaul2xBiDMj1qrxobu6UhxXXiFPMeYT0j4YL/2D4vQOE?=
+ =?koi8-r?Q?cuv5tc5xeJXvM0W6bFBbmgASLT9RLclZJUPD2Ejef6aI/7MidcuFJ4o7H3tjy1?=
+ =?koi8-r?Q?6CiSGgDR072OrwmHKdrV7luusNnNJiqRAJNdMBLnmbLpXwzeKoMc66xeP6RcFG?=
+ =?koi8-r?Q?bf0SqtnfYL2fEcqmNm7bQoedm8j5XnplsdNTdRM1FM0NCrC0gJPmgboP9zI8jB?=
+ =?koi8-r?Q?QOfOStKA8rKvSmDyl8ResDzLccDzSyKAimMKcSNiSrgq6E2E6WEpqWNDAMgH9x?=
+ =?koi8-r?Q?ggBg+RrexWFXxjjsHVryA01Mf/EMSCm8XZs30zR4PN0OqtxdTrT29K9T7rSSgv?=
+ =?koi8-r?Q?i5ozelFh4qTtrTMbMW7uuSojXZbDrye5McUtoWYxzCQygrN/I2+9O44p8C8DWG?=
+ =?koi8-r?Q?FluUajqtjQHEqf0wCQ2NI0nbNaIoV0REwQ7HP7226WO8t5d/JtfJEIV/1cqOHF?=
+ =?koi8-r?Q?aDHI3X6kTeN0F78QN8tRN2D1/y45vtTsM21vN5kVtodsq7XKPOYUnuoAabUuza?=
+ =?koi8-r?Q?RLvQs8nhbps+Nf06jNjGdHeqaiS7mg1taV7+R+7ZnOxe/UsN8RzYHp9Z0GOUO3?=
+ =?koi8-r?Q?itmpIwSIlSlgdrCaTPI7LWhzd2k0XpAsU8OjN9GGB2ZYy9Po1YLpbl0FEFYqYR?=
+ =?koi8-r?Q?5h0q3KVfkBu8w8FC8gKWCFXakYh/vY2CtINwenYuK7nfrbilHuJp3BDK6pJvWU?=
+ =?koi8-r?Q?C1IuXx6jm2hHDP+9/i7hRoEAp6jVxpmKWt5AGGT75qNrgHBJW0TMs4ZIZbZMAU?=
+ =?koi8-r?Q?Q4Pci/OP0vXP/TIeL7OYpGYPs6m/1eb4k3EZZZZybYF+mLRntfsUG0pc7fUwj8?=
+ =?koi8-r?Q?hDEJcBTHX2vuwTbCHX4Nz0X6yVYJcCZ/6wOnqyAHpIc52qdnW322kpQhALXI4E?=
+ =?koi8-r?Q?At2uVI+lZ1CxSe3qQ8UyIEDIYB+J1oiL2iJltG2Km4uhyI+pGUYUcL5GmNkbLH?=
+ =?koi8-r?Q?W/hslADCNCsdQJVRCm3AVyEXrAqteAgDAkVxweHTV8UpEwGrZUnMAcRz+8s4kT?=
+ =?koi8-r?Q?KiHBy95XJYzvCqH3iM3/tGBSNQR1kVPm7NQnDIbkbL7qQJAyeX/myKQtQS9nii?=
+ =?koi8-r?Q?t2ygmOF1mghHsPEKU1gh3KiH8/1YJwYf3Q2GADKrvjSOWuxtemtBR61kU9MSWa?=
+ =?koi8-r?Q?QdgPt4OFOZu6QrGa5+6+SZ8C1xhwBidZ/n5+iN6S2pSchVBNim?=
+Content-Type: multipart/mixed;
+	boundary="_002_AM6PR02MB44704BD42717C2D472D0CEB6B5B79AM6PR02MB4470eurp_"
+MIME-Version: 1.0
+X-OriginatorOrg: edgeless.systems
+X-MS-Exchange-CrossTenant-AuthAs: Internal
+X-MS-Exchange-CrossTenant-AuthSource: AM6PR02MB4470.eurprd02.prod.outlook.com
+X-MS-Exchange-CrossTenant-Network-Message-Id: a6e36297-a00c-464c-c0e4-08db1f271f26
+X-MS-Exchange-CrossTenant-originalarrivaltime: 07 Mar 2023 16:15:08.9407
+ (UTC)
+X-MS-Exchange-CrossTenant-fromentityheader: Hosted
+X-MS-Exchange-CrossTenant-id: adb650a8-5da3-4b15-b4b0-3daf65ff7626
+X-MS-Exchange-CrossTenant-mailboxtype: HOSTED
+X-MS-Exchange-CrossTenant-userprincipalname: WcbKeuQVhy3hOFEsKPySBOKtIhGY3yj6clxXG4yZ9bIH3ISmIn73HJmTMfCdrgw2I2JeMmFuVWM26Zyt8dKS9w==
+X-MS-Exchange-Transport-CrossTenantHeadersStamped: AS2PR02MB9692
+Status: O
+Content-Length: 21328
+Lines: 306
+
+--_002_AM6PR02MB44704BD42717C2D472D0CEB6B5B79AM6PR02MB4470eurp_
+Content-Type: text/plain; charset="koi8-r"
+Content-Transfer-Encoding: quoted-printable
+
+=0A=
+Hello,=0A=
+=0A=
+I was checking if bazel-zig-cc produces reproducible go binaries if used as=
+ a compiler for cgo.=0A=
+As a test, I compiled the same binary on the same commit on two different s=
+ystems (Ubuntu, Fedora) and in two different paths at different times.=0A=
+=0A=
+The binaries are not reproducible. At least some differences seem to be com=
+ing from bazel-zig-cc:=0A=
+=0A=
+The paths to pthread.h and signal.h on my build system are embedded in the =
+resulting binary. See below for an instance of this behavior.=0A=
+Do you think this can be prevented to make the resulting binary more hermet=
+ic / reproducible?=0A=
+=0A=
+ -  [15809be]  /root/.cache/bazel/_bazel_root/378578e4f433132b2cb209458a9b5=
+6bc/sandbox/processwrapper-sandbox/44/execroot/__main__/external/zig_sdk/to=
+ols/x86_64-linux-gnu.2.34/../../lib/libc/include/generic-glibc/pthread.h=0A=
+=81 -  [1580a8e]  gcc_libinit.c=0A=
+=81 -  [1580a9c]  pthread_create failed: %s=0A=
+=81 -  [1580ab6]  gcc_linux_amd64.c=0A=
+=81 -  [1580ac8]  /root/.cache/bazel/_bazel_root/378578e4f433132b2cb209458a=
+9b56bc/sandbox/processwrapper-sandbox/44/execroot/__main__/external/zig_sdk=
+/tools/x86_64-linux-gnu.2.34/../../lib/libc/include/generic-glibc/pthread.h=
+=0A=
+=81 -  [1580b98]  /root/.cache/bazel/_bazel_root/378578e4f433132b2cb209458a=
+9b56bc/sandbox/processwrapper-sandbox/44/execroot/__main__/external/zig_sdk=
+/tools/x86_64-linux-gnu.2.34/../../lib/libc/include/generic-glibc/signal.h=
+=0A=
+=81 -  [1580c67]  malloc failed: %s=0A=
+=81 -  [1580c79]  bad stack bounds: lo=3D%p hi=3D%p\n=0A=
+=81 -  [1580c98]  pthread_create failed: %s=0A=
+=81 -  [1580cb2]  gcc_util.c=0A=
+=81 -  [1580cbd]  runtime/cgo: out of memory in thread_start\n=0A=
+=81 +  [15809be]  gcc_libinit.c=0A=
+=81 +  [15809cc]  /home/malte/.cache/bazel/_bazel_malte/bb1175a64d2f0f71785=
+aea697a0484ea/sandbox/linux-sandbox/224/execroot/__main__/external/zig_sdk/=
+tools/x86_64-linux-gnu.2.34/../../lib/libc/include/generic-glibc/pthread.h=
+=0A=
+=81 +  [1580a9b]  pthread_create failed: %s=0A=
+=81 +  [1580ab5]  gcc_linux_amd64.c=0A=
+=81 +  [1580ac7]  malloc failed: %s=0A=
+=81 +  [1580ad9]  /home/malte/.cache/bazel/_bazel_malte/bb1175a64d2f0f71785=
+aea697a0484ea/sandbox/linux-sandbox/224/execroot/__main__/external/zig_sdk/=
+tools/x86_64-linux-gnu.2.34/../../lib/libc/include/generic-glibc/pthread.h=
+=0A=
+=81 +  [1580ba8]  bad stack bounds: lo=3D%p hi=3D%p\n=0A=
+=81 +  [1580bc7]  /home/malte/.cache/bazel/_bazel_malte/bb1175a64d2f0f71785=
+aea697a0484ea/sandbox/linux-sandbox/224/execroot/__main__/external/zig_sdk/=
+tools/x86_64-linux-gnu.2.34/../../lib/libc/include/generic-glibc/signal.h=
+=0A=
+=81 +  [1580c95]  pthread_create failed: %s=0A=
+=81 +  [1580caf]  gcc_util.c=0A=
+=81 +  [1580cba]  runtime/cgo: out of memory in thread_start\n=0A=
+=0A=
+Attached is the full output of diffoscope.=0A=
+=0A=
+Kind regards,=0A=
+Malte Poll=0A=
+=0A=
+=0A=
+
+--_002_AM6PR02MB44704BD42717C2D472D0CEB6B5B79AM6PR02MB4470eurp_
+Content-Type: text/plain; name="diffoscope.txt"
+Content-Description: diffoscope.txt
+Content-Disposition: attachment; filename="diffoscope.txt"; size=13002;
+	creation-date="Tue, 07 Mar 2023 16:05:00 GMT";
+	modification-date="Tue, 07 Mar 2023 16:13:14 GMT"
+Content-Transfer-Encoding: base64
+
+LS0tIGJvb3RzdHJhcHBlci1mZWRvcmEKKysrIGJvb3RzdHJhcHBlci11YnVudHUK4pSc4pSA4pSA
+IHJlYWRlbGYgLS13aWRlIC0tc2VjdGlvbnMge30K4pSCIEBAIC0xMCwxNSArMTAsMTUgQEAK4pSC
+ICAgIFsgNV0gLmdudS52ZXJzaW9uICAgICAgVkVSU1lNICAgICAgICAgIDAwMDAwMDAwMDA5NjIx
+NTggNzYyMTU4IDA5ZDdkOCAwMiAgIEEgIDQgICAwICAyCuKUgiAgICBbIDZdIC5nbnUudmVyc2lv
+bl9yICAgIFZFUk5FRUQgICAgICAgICAwMDAwMDAwMDAwOWZmOTMwIDdmZjkzMCAwMDAwYjAgMDAg
+ICBBICA5ICAgMiAgNArilIIgICAgWyA3XSAuZ251Lmhhc2ggICAgICAgICBHTlVfSEFTSCAgICAg
+ICAgMDAwMDAwMDAwMDlmZjllMCA3ZmY5ZTAgMjA5YTIwIDAwICAgQSAgNCAgIDAgIDgK4pSCICAg
+IFsgOF0gLmhhc2ggICAgICAgICAgICAgSEFTSCAgICAgICAgICAgIDAwMDAwMDAwMDBjMDk0MDAg
+YTA5NDAwIDI3NWY2OCAwNCAgIEEgIDQgICAwICA0CuKUgiAgICBbIDldIC5keW5zdHIgICAgICAg
+ICAgIFNUUlRBQiAgICAgICAgICAwMDAwMDAwMDAwZTdmMzY4IGM3ZjM2OCBkZTc2ZTQgMDAgICBB
+ICAwICAgMCAgMQrilIIgICAgWzEwXSAucmVsYS5keW4gICAgICAgICBSRUxBICAgICAgICAgICAg
+MDAwMDAwMDAwMWM2NmE1MCAxYTY2YTUwIDAwMDA0OCAxOCAgIEEgIDQgICAwICA4CuKUgiAgICBb
+MTFdIC5yZWxhLnBsdCAgICAgICAgIFJFTEEgICAgICAgICAgICAwMDAwMDAwMDAxYzY2YTk4IDFh
+NjZhOTggMDAwNzA4IDE4ICBBSSAgNCAgMjUgIDgK4pSCIC0gIFsxMl0gLnJvZGF0YSAgICAgICAg
+ICAgUFJPR0JJVFMgICAgICAgIDAwMDAwMDAwMDFjNjcxYTAgMWE2NzFhMCAxNTgwY2Y4IDAwIEFN
+UyAgMCAgIDAgMzIK4pSCICsgIFsxMl0gLnJvZGF0YSAgICAgICAgICAgUFJPR0JJVFMgICAgICAg
+IDAwMDAwMDAwMDFjNjcxYTAgMWE2NzFhMCAxNTgwY2YwIDAwIEFNUyAgMCAgIDAgMzIK4pSCICAg
+IFsxM10gLnR5cGVsaW5rICAgICAgICAgUFJPR0JJVFMgICAgICAgIDAwMDAwMDAwMDMxZTdlYTAg
+MmZlN2VhMCAwMmQwZWMgMDAgICBBICAwICAgMCAzMgrilIIgICAgWzE0XSAuaXRhYmxpbmsgICAg
+ICAgICBQUk9HQklUUyAgICAgICAgMDAwMDAwMDAwMzIxNGZhMCAzMDE0ZmEwIDAxMWUwMCAwMCAg
+IEEgIDAgICAwIDMyCuKUgiAgICBbMTVdIC5nb3BjbG50YWIgICAgICAgIFBST0dCSVRTICAgICAg
+ICAwMDAwMDAwMDAzMjI2ZGEwIDMwMjZkYTAgMWVhNTQ1OCAwMCAgIEEgIDAgICAwIDMyCuKUgiAg
+ICBbMTZdIC5laF9mcmFtZV9oZHIgICAgIFBST0dCSVRTICAgICAgICAwMDAwMDAwMDA1MGNjMWY4
+IDRlY2MxZjggMDAwMjg0IDAwICAgQSAgMCAgIDAgIDQK4pSCICAgIFsxN10gLmVoX2ZyYW1lICAg
+ICAgICAgUFJPR0JJVFMgICAgICAgIDAwMDAwMDAwMDUwY2M0ODAgNGVjYzQ4MCAwMDBhMTQgMDAg
+ICBBICAwICAgMCAgOArilIIgICAgWzE4XSAudGV4dCAgICAgICAgICAgICBQUk9HQklUUyAgICAg
+ICAgMDAwMDAwMDAwNTBjZGVhMCA0ZWNjZWEwIDM0NGM5YzIgMDAgIEFYICAwICAgMCAzMgrilIIg
+ICAgWzE5XSAuaW5pdCAgICAgICAgICAgICBQUk9HQklUUyAgICAgICAgMDAwMDAwMDAwODUxYTg2
+NCA4MzE5ODY0IDAwMDAxNyAwMCAgQVggIDAgICAwICA0CuKUnOKUgOKUgCByZWFkZWxmIC0td2lk
+ZSAtLXN5bWJvbHMge30K4pSCIEBAIC05NTMwOCwxNSArOTUzMDgsMTUgQEAK4pSCICAgOTUzMDQ6
+IDAwMDAwMDAwMDFkNDJhYWQgICAgMzMgT0JKRUNUICBHTE9CQUwgREVGQVVMVCAgIDEyIHR5cGU6
+LkUra0JnZ00xCuKUgiAgIDk1MzA1OiAwMDAwMDAwMDA1NGE5OWEwICAgMzk0IEZVTkMgICAgR0xP
+QkFMIERFRkFVTFQgICAxOCBnaXRodWIuY29tL2dvZ28vcHJvdG9idWYvcHJvdG8ubWFrZVN0ZERv
+dWJsZVZhbHVlTWFyc2hhbGVyLmZ1bmMxCuKUgiAgIDk1MzA2OiAwMDAwMDAwMDA3M2Q5YTQwICAz
+OTE5IEZVTkMgICAgR0xPQkFMIERFRkFVTFQgICAxOCBnaXRodWIuY29tL2F3cy9hd3Mtc2RrLWdv
+LXYyL3NlcnZpY2UvZWMyLigqYXdzRWMycXVlcnlfc2VyaWFsaXplT3BDcmVhdGVTdWJuZXRDaWRy
+UmVzZXJ2YXRpb24pLkhhbmRsZVNlcmlhbGl6ZQrilIIgICA5NTMwNzogMDAwMDAwMDAwODBiNmE2
+MCAgIDEyNyBGVU5DICAgIEdMT0JBTCBERUZBVUxUICAgMTggZ2l0aHViLmNvbS9hd3MvYXdzLXNk
+ay1nby9zZXJ2aWNlL2lhbS4oKkRlbGV0ZUluc3RhbmNlUHJvZmlsZUlucHV0KS5Hb1N0cmluZwri
+lIIgICA5NTMwODogMDAwMDAwMDAwNTRhOTdlMCAgIDQyOSBGVU5DICAgIEdMT0JBTCBERUZBVUxU
+ICAgMTggZ2l0aHViLmNvbS9nb2dvL3Byb3RvYnVmL3Byb3RvLm1ha2VTdGREb3VibGVWYWx1ZU1h
+cnNoYWxlci5mdW5jMgrilIIgICA5NTMwOTogMDAwMDAwMDAwODE3Y2Y4MCAgICA0OCBGVU5DICAg
+IEdMT0JBTCBERUZBVUxUICAgMTggZ2l0aHViLmNvbS9BenVyZS9henVyZS1zZGstZm9yLWdvL3Nl
+cnZpY2VzL2tleXZhdWx0L3Y3LjEva2V5dmF1bHQuKCpDZXJ0aWZpY2F0ZUlzc3Vlckxpc3RSZXN1
+bHQpLklzSFRUUFN0YXR1cwrilIIgICA5NTMxMDogMDAwMDAwMDAwMzA1NTdjMCAgICAzMiBPQkpF
+Q1QgIEdMT0JBTCBERUZBVUxUICAgMTIgZ286aXRhYi4qY2xvdWQuZ29vZ2xlLmNvbS9nby9jb21w
+dXRlL2FwaXYxL2NvbXB1dGVwYi5BZ2dyZWdhdGVkTGlzdFVybE1hcHNSZXF1ZXN0LGdvb2dsZS5n
+b2xhbmcub3JnL3Byb3RvYnVmL3JlZmxlY3QvcHJvdG9yZWZsZWN0LlByb3RvTWVzc2FnZQrilIIg
+LSA5NTMxMTogMDAwMDAwMDAwMzFlN2U5MCAgICAgOCBPQkpFQ1QgIEdMT0JBTCBERUZBVUxUICAg
+MTIgX2Nnb195aWVsZArilIIgKyA5NTMxMTogMDAwMDAwMDAwMzFlN2U4OCAgICAgOCBPQkpFQ1Qg
+IEdMT0JBTCBERUZBVUxUICAgMTIgX2Nnb195aWVsZArilIIgICA5NTMxMjogMDAwMDAwMDAwMWNh
+ZjRhNiAgICAxOCBPQkpFQ1QgIEdMT0JBTCBERUZBVUxUICAgMTIgdHlwZTouZnJGMkxFZ0sK4pSC
+ICAgOTUzMTM6IDAwMDAwMDAwMDU0ZDEyNDAgICAgOTkgRlVOQyAgICBHTE9CQUwgREVGQVVMVCAg
+IDE4IGs4cy5pby9hcGltYWNoaW5lcnkvcGtnL2FwaS9yZXNvdXJjZS5pbmZEZWNBbW91bnQuTWFy
+c2hhbFRleHQK4pSCICAgOTUzMTQ6IDAwMDAwMDAwMDU2MWZlMjAgICA3NjMgRlVOQyAgICBHTE9C
+QUwgREVGQVVMVCAgIDE4IGdvbGFuZy5vcmcveC9uZXQvaHR0cDIvaHBhY2suaHVmZm1hbkRlY29k
+ZQrilIIgICA5NTMxNTogMDAwMDAwMDAwNTk0Y2EyMCAgICAyNiBGVU5DICAgIEdMT0JBTCBERUZB
+VUxUICAgMTggZ29sYW5nLm9yZy94L3N5cy91bml4LigqVGltZXZhbCkuTmFubwrilIIgICA5NTMx
+NjogMDAwMDAwMDAwNjI3NTA4MCAgIDM3OSBGVU5DICAgIEdMT0JBTCBERUZBVUxUICAgMTggZW5j
+b2RpbmcveG1sLmlzTmFtZVN0cmluZwrilIIgICA5NTMxNzogMDAwMDAwMDAwMjA0ZDk4MCAgICA4
+MCBPQkpFQ1QgIEdMT0JBTCBERUZBVUxUICAgMTIgdHlwZTpZdXZRMG8wYQrilIIgICA5NTMxODog
+MDAwMDAwMDAwMWQ0ZDY2YSAgICAzNCBPQkpFQ1QgIEdMT0JBTCBERUZBVUxUICAgMTIgdHlwZTou
+eS9sNHhuUW0K4pSc4pSA4pSAIHN0cmluZ3MgLS1hbGwgLS1ieXRlcz04IHt9CuKUgiBAQCAtNDAz
+OTM2LDIyICs0MDM5MzYsMjIgQEAK4pSCICAkKDA3PkZNVV1lbQrilIIgICEmLjY8QkhNVVxkCuKU
+giAgIScuNDtDSVFWXWUK4pSCICAgIiQoKiwwMjQ2egrilIIgIAkJCQkJCQkwCuKUgiAgZ2NjX2Zh
+dGFsZi5jCuKUgiAgcnVudGltZS9jZ286IArilIIgLS9yb290Ly5jYWNoZS9iYXplbC9fYmF6ZWxf
+cm9vdC8zNzg1NzhlNGY0MzMxMzJiMmNiMjA5NDU4YTliNTZiYy9zYW5kYm94L3Byb2Nlc3N3cmFw
+cGVyLXNhbmRib3gvNDQvZXhlY3Jvb3QvX19tYWluX18vZXh0ZXJuYWwvemlnX3Nkay90b29scy94
+ODZfNjQtbGludXgtZ251LjIuMzQvLi4vLi4vbGliL2xpYmMvaW5jbHVkZS9nZW5lcmljLWdsaWJj
+L3B0aHJlYWQuaArilIIgIGdjY19saWJpbml0LmMK4pSCICsvaG9tZS9tYWx0ZS8uY2FjaGUvYmF6
+ZWwvX2JhemVsX21hbHRlL2JiMTE3NWE2NGQyZjBmNzE3ODVhZWE2OTdhMDQ4NGVhL3NhbmRib3gv
+bGludXgtc2FuZGJveC8yMjQvZXhlY3Jvb3QvX19tYWluX18vZXh0ZXJuYWwvemlnX3Nkay90b29s
+cy94ODZfNjQtbGludXgtZ251LjIuMzQvLi4vLi4vbGliL2xpYmMvaW5jbHVkZS9nZW5lcmljLWds
+aWJjL3B0aHJlYWQuaArilIIgIHB0aHJlYWRfY3JlYXRlIGZhaWxlZDogJXMK4pSCICBnY2NfbGlu
+dXhfYW1kNjQuYwrilIIgLS9yb290Ly5jYWNoZS9iYXplbC9fYmF6ZWxfcm9vdC8zNzg1NzhlNGY0
+MzMxMzJiMmNiMjA5NDU4YTliNTZiYy9zYW5kYm94L3Byb2Nlc3N3cmFwcGVyLXNhbmRib3gvNDQv
+ZXhlY3Jvb3QvX19tYWluX18vZXh0ZXJuYWwvemlnX3Nkay90b29scy94ODZfNjQtbGludXgtZ251
+LjIuMzQvLi4vLi4vbGliL2xpYmMvaW5jbHVkZS9nZW5lcmljLWdsaWJjL3B0aHJlYWQuaArilIIg
+LS9yb290Ly5jYWNoZS9iYXplbC9fYmF6ZWxfcm9vdC8zNzg1NzhlNGY0MzMxMzJiMmNiMjA5NDU4
+YTliNTZiYy9zYW5kYm94L3Byb2Nlc3N3cmFwcGVyLXNhbmRib3gvNDQvZXhlY3Jvb3QvX19tYWlu
+X18vZXh0ZXJuYWwvemlnX3Nkay90b29scy94ODZfNjQtbGludXgtZ251LjIuMzQvLi4vLi4vbGli
+L2xpYmMvaW5jbHVkZS9nZW5lcmljLWdsaWJjL3NpZ25hbC5oCuKUgiAgbWFsbG9jIGZhaWxlZDog
+JXMK4pSCICsvaG9tZS9tYWx0ZS8uY2FjaGUvYmF6ZWwvX2JhemVsX21hbHRlL2JiMTE3NWE2NGQy
+ZjBmNzE3ODVhZWE2OTdhMDQ4NGVhL3NhbmRib3gvbGludXgtc2FuZGJveC8yMjQvZXhlY3Jvb3Qv
+X19tYWluX18vZXh0ZXJuYWwvemlnX3Nkay90b29scy94ODZfNjQtbGludXgtZ251LjIuMzQvLi4v
+Li4vbGliL2xpYmMvaW5jbHVkZS9nZW5lcmljLWdsaWJjL3B0aHJlYWQuaArilIIgIGJhZCBzdGFj
+ayBib3VuZHM6IGxvPSVwIGhpPSVwCuKUgiArL2hvbWUvbWFsdGUvLmNhY2hlL2JhemVsL19iYXpl
+bF9tYWx0ZS9iYjExNzVhNjRkMmYwZjcxNzg1YWVhNjk3YTA0ODRlYS9zYW5kYm94L2xpbnV4LXNh
+bmRib3gvMjI0L2V4ZWNyb290L19fbWFpbl9fL2V4dGVybmFsL3ppZ19zZGsvdG9vbHMveDg2XzY0
+LWxpbnV4LWdudS4yLjM0Ly4uLy4uL2xpYi9saWJjL2luY2x1ZGUvZ2VuZXJpYy1nbGliYy9zaWdu
+YWwuaArilIIgIHB0aHJlYWRfY3JlYXRlIGZhaWxlZDogJXMK4pSCICBnY2NfdXRpbC5jCuKUgiAg
+cnVudGltZS9jZ286IG91dCBvZiBtZW1vcnkgaW4gdGhyZWFkX3N0YXJ0CuKUgiAgaW50ZXJuYWwv
+Y3B1LkluaXRpYWxpemUK4pSCICBpbnRlcm5hbC9jcHUucHJvY2Vzc09wdGlvbnMK4pSCICBpbnRl
+cm5hbC9jcHUuaW5kZXhCeXRlCuKUgiAgaW50ZXJuYWwvY3B1LmRvaW5pdArilJzilIDilIAgcmVh
+ZGVsZiAtLXdpZGUgLS1kZWNvbXByZXNzIC0tc3RyaW5nLWR1bXA9LnJvZGF0YSB7fQrilIIgQEAg
+LTExNTQ2NzcsMTUgKzExNTQ2NzcsMTUgQEAK4pSCICAgICAgICAgICAgICB277+9KSzvv70777+9
+Tl5WXlvvv73vv71eRjnvv71LeCvvv73vv71YXk1r77+9Ru+/ve+/ve+/vScK4pSCICAgIFsxM2Uw
+YWVlXSAgO++/ve+/vV5G77+977+977+977+977+9Oe+/vSd177+9LV5fJ++/vV5XXkHvv73vv71e
+UFksRV5I77+977+9Xkbvv71yXllw77+9Se+/vW7vv73vv73vv70i77+977+977+9Xlzvv70277+9
+Je+/vXnvv71sXu+/vQrilIIgICAgWzEzZTBiMmNdICBG77+9PO+/vV5fbEAr77+9O++/vSxfQ15V
+77+9Xl1o77+9d17vv71A77+9dnfvv71d77+9ak5eXWDvv73vv73vv71N77+977+9b++/vT9eUe+/
+vX1mXlDvv71AXk3vv71eXSbvv71eSVUxde+/vUcK4pSCICAgIFsxM2UwYjZiXSAgIu+/ve+/ve+/
+ve+/vV5JI++/ve+/vS9H77+9Xlnvv714Pe+/vVxuCuKUgiAgICAgICAgICAgICAgZ3Pvv73vv71e
+WO+/ve+/vV5B77+9I++/ve+/vS1eWF4gYu+/ve+/vUMu77+977+977+977+977+977+9Ku+/ve+/
+ve+/ve+/vV5X77+977+977+9XUrvv73vv73vv73vv73vv71z77+977+9YO+/vUDvv73vv71I77+9
+77+977+9al5O77+9NE3vv73vv71d77+9Ne+/ve+/vV5MXkheRu+/vUDvv70p77+9be+/vW/vv70x
+77+9Xkvvv73vv73vv73vv70777+9XlBgXlx5ce+/ve+/vTXvv73vv73vv709PyXvv73vv70uXl/v
+v73vv718XlxeWy16RV5E77+977+9XlDvv71eS++/vW7vv73vv71eQV5F77+9WzB7Xkd877+977+9
+Xkzvv718Xkfvv70i77+977+977+977+9Me+/ve+/vUpW77+9cFdD77+977+9RkHvv71YXlTvv73v
+v711L++/vSfvv71977+977+9Xu+/vXNJ77+977+9VXTvv71eTUbvv73vv73vv71eUu+/vWp077+9
+77+977+9QSJe77+977+977+977+9WV5a77+977+9Xlbvv71+cCQ277+977+977+977+977+977+9
+77+9TSlBXG4K4pSCICAgICAgICAgICAgICBsKu+/vTQkWu+/vV5S77+9PVLvv71K77+977+977+9
+Ju+/ve+/vUdOXknvv71nXl0K4pSCICAgIFsxM2UwYzg3XSAgJ15T77+9UO+/ve+/vV5PXF5QXkhe
+TV5HRO+/ve+/ve+/vV5T77+9WWIi77+9XlXvv71m77+977+9b1/vv71h77+9Ke+/vXvvv73vv71e
+TV5U77+977+9TiJe77+9R++/vTtW77+977+977+9Qe+/vTpwJO+/vVc077+977+9XkXvv71eXlrv
+v73vv73vv71k77+9Xlgo77+977+977+9Qu+/vV5NaGZX77+977+977+9Ou+/vXMuee+/ve+/ve+/
+vVNeXl/vv73vv71eTe+/ve+/ve+/vV5F77+9CuKUgiAtICBbMTNlMGNmOF0gIEbvv70v77+977+9
+77+9XltD77+977+977+9XUxAaO+/vSrvv71xXlDvv71wWu+/vWpA77+977+977+9cmgz77+9Xkle
+Te+/ve+/ve+/vTws77+977+9Xl4p77+9aF5PXlheUl5U77+977+9fu+/vdyp77+9Kkbvv71D77+9
+77+9Xe+/vWF177+9Xk0mSu+/vV5BPe+/vV5M77+977+9NSXvv73vv70077+9Q++/ve+/vUdeRu+/
+vVpJL++/ve+/ve+/vVxeRmU977+977+9cFfGil5e77+9fD5p77+9V++/ve+/ve+/ve+/ve+/vUte
+XVtV77+977+977+977+9VO+/vVp5Xkbvv71eVe+/ve+/ve+/ve+/vV5Z77+9Jl5E77+9Xlzvv71q
+77+9Ju+/vWteXe+/ve+/vWDvv73vv73vv73vv71O77+9Xk5eWu+/vXReUe+/ve+/vV5PXkcyxqFC
+77+977+977+9JUvvv73vv73vv71eRW5aVk1eVu+/ve+/ve+/vXs477+9Xu+/ve+/vW3vv71OXklU
+Xk7vv706XlpaU++/ve+/vXRcbgrilIIgKyAgWzEzZTBjZjhdICBG77+9L++/ve+/ve+/vV5bQ++/
+ve+/ve+/vV1MQGjvv70q77+9cV5Q77+9cFrvv71qQO+/ve+/ve+/vXJoM++/vV5JXk3vv73vv73v
+v708LO+/ve+/vV5eKe+/vWheT15YXlJeVO+/ve+/vX7vv73cqe+/vSpG77+9Q++/ve+/vV3vv71h
+de+/vV5NJkrvv71eQT3vv71eTO+/ve+/vTUl77+977+9NO+/vV5VXu+/ve+/ve+/ve+/vU9aSS/v
+v73vv73vv71cXkZlPe+/ve+/vXBXxopeXu+/vXw+ae+/vVfvv73vv73vv73vv73vv71LXl1bVe+/
+ve+/ve+/ve+/vVTvv71aeV5G77+9XlXvv73vv73vv73vv71eWe+/vSZeRO+/vV5c77+9au+/vSbv
+v71rXl3vv73vv71g77+977+977+977+9Tu+/vV5OXlrvv710XlHvv73vv71eT15HMsahQu+/ve+/
+ve+/vSVL77+977+977+9XkVuWlZNXlbvv73vv73vv717OO+/vV7vv73vv71t77+9Tl5JVF5O77+9
+Ol5aWlPvv73vv710XG4K4pSCICAgICAgICAgICAgICBXUO+/vV5GZmV777+9XlZeS++/ve+/vUDv
+v73vv71aWe+/vXDvv71+77+977+9OFhcbgrilIIgICAgICAgICAgICAgIFReQ++/vSNx77+977+9
+b15NNu+/vV5d77+977+9LmN577+977+977+9XlXvv73vv71taS/vv73vv70o77+9Xl0tRe+/ve+/
+ve+/vVc+TO+/vWxeRHws77+977+977+9MTZ6UlXvv73vv70xW15J77+977+977+977+977+977+9
+JO+/ve+/ve+/vXleVXDvv71777+9aWvvv73vv71bQl5Z77+9XlQrR15X77+9Xknvv73vv71eVu+/
+vTfvv73vv71eQ3NXXG4K4pSCICAgICAgICAgICAgICAxzrHvv70q77+9Ke+/vSNeU3c7RHzvv71e
+TF5X77+977+977+9fO+/ve+/ve+/ve+/vXjvv73vv73vv73vv71eRO+/ve+/vUJeV3Dvv73vv71J
+Qu+/vcedIWLvv73vv71N77+9XkY7I0nvv73vv700TmU177+9XO+/ve+/vTnvv71benctNyFCIV9e
+V++/vSReR++/vV5Y77+9Uu+/vVfvv73vv73vv71V77+9IO+/ve+/vXdk77+9cD7vv71z77+9Xe+/
+vTo7d++/ve+/ve+/vTBeR++/vTwi77+977+977+9UO+/vVVwMl5Yfu+/vTdeXV5CaV5Na34k77+9
+77+9Ze+/vVIt77+977+977+9X++/vXTvv71L77+977+9XklWXk/emO+/vTReWO+/ve+/vUBgYe+/
+vW5QXkHvv73vv73vv73vv73vv71K77+977+9ce+/ve+/ve+/ve+/vSFPNXrvv73vv73vv73vv73v
+v709Xlx577+977+9Vn3vv71e77+977+977+977+977+9XlDvv73vv71X77+977+977+977+9R++/
+ve+/ve+/vV5ZdGTvv73vv73vv71o77+977+9XlPvv73vv713fV5I77+977+977+9ckvvv71NbF5X
+ee+/ve+/vVxeTO+/ve+/vXNNKO+/ve+/vXZeVO+/ve+/vV5S77+977+9c++/ve+/vV5FCuKUgiAg
+ICBbMTNlMGY2Zl0gIE/vv715XO+/vV5bX++/ve+/ve+/vT3vv71B77+9fGdg77+9Pnbvv73vv73v
+v73vv71eXO+/vXgp77+977+9Ku+/vV5S77+9SDNcaynvv73vv71pUTPvv71eVO+/vV7vv71T77+9
+Lu+/vX3vv71V77+9Xu+/vULvv70oTQrilIIgICAgWzEzZTBmYjNdICA/N2rvv73vv73vv73vv712
+77+977+977+9Je+/ve+/vV5O77+977+9SV5Hb++/ve+/vUVeRCvvv71eQ++/ve+/vXzvv71eWu+/
+vWnvv73vv71cbgrilIIgICAgICAgICAgICAgIGzvv719NV5DXl1s77+977+977+9XldeTe+/ve+/
+vV9eWSteVdC677+9NHQjK++/ve+/ve+/ve+/vXEkXlnvv73vv73vv73vv73vv73vv73vv73vv71H
+IHLvv73vv73vv71eQu+/vTDvv73vv71Z77+9KkhC77+9NO+/vTLvv70977+977+9bUNtOO+/ve+/
+vXHvv73vv73vv71eQk4hS1ZKau+/ve+/vVTvv73vv71F77+9CuKUgiAgICBbMTNlMTAzY10gIFvv
+v71eX1zvv71E77+977+977+9XG4K4pSCIEBAIC0xMjM0NDI3LDE5ICsxMjM0NDI3LDE5IEBACuKU
+giAgICBbMTU4MDk0MF0gIDdeXl5CCuKUgiAgICBbMTU4MDk1NF0gIEFeXl5CCuKUgiAgICBbMTU4
+MDk2OF0gIEteXl5CCuKUgiAgICBbMTU4MDk3Y10gIEteXl5CCuKUgiAgICBbMTU4MDk5MF0gIE5e
+Xl5CCuKUgiAgICBbMTU4MDlhMV0gIGdjY19mYXRhbGYuYwrilIIgICAgWzE1ODA5YWVdICBydW50
+aW1lL2NnbzogCuKUgiAtICBbMTU4MDliZV0gIC9yb290Ly5jYWNoZS9iYXplbC9fYmF6ZWxfcm9v
+dC8zNzg1NzhlNGY0MzMxMzJiMmNiMjA5NDU4YTliNTZiYy9zYW5kYm94L3Byb2Nlc3N3cmFwcGVy
+LXNhbmRib3gvNDQvZXhlY3Jvb3QvX19tYWluX18vZXh0ZXJuYWwvemlnX3Nkay90b29scy94ODZf
+NjQtbGludXgtZ251LjIuMzQvLi4vLi4vbGliL2xpYmMvaW5jbHVkZS9nZW5lcmljLWdsaWJjL3B0
+aHJlYWQuaArilIIgLSAgWzE1ODBhOGVdICBnY2NfbGliaW5pdC5jCuKUgiAtICBbMTU4MGE5Y10g
+IHB0aHJlYWRfY3JlYXRlIGZhaWxlZDogJXMK4pSCIC0gIFsxNTgwYWI2XSAgZ2NjX2xpbnV4X2Ft
+ZDY0LmMK4pSCIC0gIFsxNTgwYWM4XSAgL3Jvb3QvLmNhY2hlL2JhemVsL19iYXplbF9yb290LzM3
+ODU3OGU0ZjQzMzEzMmIyY2IyMDk0NThhOWI1NmJjL3NhbmRib3gvcHJvY2Vzc3dyYXBwZXItc2Fu
+ZGJveC80NC9leGVjcm9vdC9fX21haW5fXy9leHRlcm5hbC96aWdfc2RrL3Rvb2xzL3g4Nl82NC1s
+aW51eC1nbnUuMi4zNC8uLi8uLi9saWIvbGliYy9pbmNsdWRlL2dlbmVyaWMtZ2xpYmMvcHRocmVh
+ZC5oCuKUgiAtICBbMTU4MGI5OF0gIC9yb290Ly5jYWNoZS9iYXplbC9fYmF6ZWxfcm9vdC8zNzg1
+NzhlNGY0MzMxMzJiMmNiMjA5NDU4YTliNTZiYy9zYW5kYm94L3Byb2Nlc3N3cmFwcGVyLXNhbmRi
+b3gvNDQvZXhlY3Jvb3QvX19tYWluX18vZXh0ZXJuYWwvemlnX3Nkay90b29scy94ODZfNjQtbGlu
+dXgtZ251LjIuMzQvLi4vLi4vbGliL2xpYmMvaW5jbHVkZS9nZW5lcmljLWdsaWJjL3NpZ25hbC5o
+CuKUgiAtICBbMTU4MGM2N10gIG1hbGxvYyBmYWlsZWQ6ICVzCuKUgiAtICBbMTU4MGM3OV0gIGJh
+ZCBzdGFjayBib3VuZHM6IGxvPSVwIGhpPSVwXG4K4pSCIC0gIFsxNTgwYzk4XSAgcHRocmVhZF9j
+cmVhdGUgZmFpbGVkOiAlcwrilIIgLSAgWzE1ODBjYjJdICBnY2NfdXRpbC5jCuKUgiAtICBbMTU4
+MGNiZF0gIHJ1bnRpbWUvY2dvOiBvdXQgb2YgbWVtb3J5IGluIHRocmVhZF9zdGFydFxuCuKUgiAr
+ICBbMTU4MDliZV0gIGdjY19saWJpbml0LmMK4pSCICsgIFsxNTgwOWNjXSAgL2hvbWUvbWFsdGUv
+LmNhY2hlL2JhemVsL19iYXplbF9tYWx0ZS9iYjExNzVhNjRkMmYwZjcxNzg1YWVhNjk3YTA0ODRl
+YS9zYW5kYm94L2xpbnV4LXNhbmRib3gvMjI0L2V4ZWNyb290L19fbWFpbl9fL2V4dGVybmFsL3pp
+Z19zZGsvdG9vbHMveDg2XzY0LWxpbnV4LWdudS4yLjM0Ly4uLy4uL2xpYi9saWJjL2luY2x1ZGUv
+Z2VuZXJpYy1nbGliYy9wdGhyZWFkLmgK4pSCICsgIFsxNTgwYTliXSAgcHRocmVhZF9jcmVhdGUg
+ZmFpbGVkOiAlcwrilIIgKyAgWzE1ODBhYjVdICBnY2NfbGludXhfYW1kNjQuYwrilIIgKyAgWzE1
+ODBhYzddICBtYWxsb2MgZmFpbGVkOiAlcwrilIIgKyAgWzE1ODBhZDldICAvaG9tZS9tYWx0ZS8u
+Y2FjaGUvYmF6ZWwvX2JhemVsX21hbHRlL2JiMTE3NWE2NGQyZjBmNzE3ODVhZWE2OTdhMDQ4NGVh
+L3NhbmRib3gvbGludXgtc2FuZGJveC8yMjQvZXhlY3Jvb3QvX19tYWluX18vZXh0ZXJuYWwvemln
+X3Nkay90b29scy94ODZfNjQtbGludXgtZ251LjIuMzQvLi4vLi4vbGliL2xpYmMvaW5jbHVkZS9n
+ZW5lcmljLWdsaWJjL3B0aHJlYWQuaArilIIgKyAgWzE1ODBiYThdICBiYWQgc3RhY2sgYm91bmRz
+OiBsbz0lcCBoaT0lcFxuCuKUgiArICBbMTU4MGJjN10gIC9ob21lL21hbHRlLy5jYWNoZS9iYXpl
+bC9fYmF6ZWxfbWFsdGUvYmIxMTc1YTY0ZDJmMGY3MTc4NWFlYTY5N2EwNDg0ZWEvc2FuZGJveC9s
+aW51eC1zYW5kYm94LzIyNC9leGVjcm9vdC9fX21haW5fXy9leHRlcm5hbC96aWdfc2RrL3Rvb2xz
+L3g4Nl82NC1saW51eC1nbnUuMi4zNC8uLi8uLi9saWIvbGliYy9pbmNsdWRlL2dlbmVyaWMtZ2xp
+YmMvc2lnbmFsLmgK4pSCICsgIFsxNTgwYzk1XSAgcHRocmVhZF9jcmVhdGUgZmFpbGVkOiAlcwri
+lIIgKyAgWzE1ODBjYWZdICBnY2NfdXRpbC5jCuKUgiArICBbMTU4MGNiYV0gIHJ1bnRpbWUvY2dv
+OiBvdXQgb2YgbWVtb3J5IGluIHRocmVhZF9zdGFydFxuCuKUnOKUgOKUgCBvYmpkdW1wIC0tbGlu
+ZS1udW1iZXJzIC0tZGlzYXNzZW1ibGUgLS1kZW1hbmdsZSAtLXJlbG9jIC0tbm8tc2hvdy1yYXct
+aW5zbiAtLXNlY3Rpb249LnRleHQge30K4pSCIEBAIC00MTk0Mjk2LDggKzQxOTQyOTYsOCBAQAri
+lIIgIAl0ZXN0ICAgJXIxMiwlcjEyCuKUgiAgCWpuZSAgICA1ZmIyMWFhIDxrOHMuaW8vYXBpL3N0
+b3JhZ2UvdjFiZXRhMS4oKlN0b3JhZ2VDbGFzcykuU2V0R2VuZXJhdGVOYW1lQEBCYXNlKzB4NmE+
+CuKUgiAgCW1vdiAgICAlcmJ4LDB4MTgoJXJzcCkK4pSCICAJbW92ICAgICVyY3gsMHgzOCglcmF4
+KQrilIIgIAljbXBsICAgJDB4MCwweDI3YWQ3ZTUoJXJpcCkgICAgICAgIArilIIgIAlqbmUgICAg
+NWZiMjE3MyA8azhzLmlvL2FwaS9zdG9yYWdlL3YxYmV0YTEuKCpTdG9yYWdlQ2xhc3MpLlNldEdl
+bmVyYXRlTmFtZUBAQmFzZSsweDMzPgrilIIgIAltb3YgICAgJXJieCwweDMwKCVyYXgpCuKUgiAt
+WyBUb28gbXVjaCBpbnB1dCBmb3IgZGlmZiAoU0hBMjU2OiA0NTJmMWE4YzE0NWZkYmRlNmJmZmYy
+ZGRjYjUzMWJhMzAyMDUwZGYyZmVhOTdhNDdkNWY4NDMzNjRkMTk5NDM5KSBdCuKUgiArWyBUb28g
+bXVjaCBpbnB1dCBmb3IgZGlmZiAoU0hBMjU2OiAxMzg2YjJlNDkyNTYxM2Y5ZWEwMDNlOTY1MzVi
+MTFhMDEzZDJkMWJhZTcyYTU1NWUxZmRjY2ZhMmYxNWE1ODhhKSBdCuKUnOKUgOKUgCByZWFkZWxm
+IC0td2lkZSAtLWRlY29tcHJlc3MgLS1oZXgtZHVtcD0uZGF0YSB7fQrilIIgQEAgLTE2MywxNSAr
+MTYzLDE1IEBACuKUgiAgICAweDA4NTFkYzYwIDIwMzY3MjA4IDAwMDAwMDAwIDY4NDZhNTAyIDAw
+MDAwMDAwICA2ci4uLi4uaEYuLi4uLi4K4pSCICAgIDB4MDg1MWRjNzAgNzAzM2E1MDIgMDAwMDAw
+MDAgZTBmNjUyMDggMDAwMDAwMDAgcDMuLi4uLi4uLlIuLi4uLgrilIIgICAgMHgwODUxZGM4MCBh
+MGY2NTIwOCAwMDAwMDAwMCA5MDkxNTEwOCAwMDAwMDAwMCAuLlIuLi4uLi4uUS4uLi4uCuKUgiAg
+ICAweDA4NTFkYzkwIGMwYTA1MTA4IDAwMDAwMDAwIDAwOWM1MTA4IDAwMDAwMDAwIC4uUS4uLi4u
+Li5RLi4uLi4K4pSCICAgIDB4MDg1MWRjYTAgNjg0NmE1MDIgMDAwMDAwMDAgZjBhMjUxMDggMDAw
+MDAwMDAgaEYuLi4uLi4uLlEuLi4uLgrilIIgICAgMHgwODUxZGNiMCAzMGE1NTEwOCAwMDAwMDAw
+MCAxMGE3NTEwOCAwMDAwMDAwMCAwLlEuLi4uLi4uUS4uLi4uCuKUgiAgICAweDA4NTFkY2MwIDYw
+MWM1MzA4IDAwMDAwMDAwIDAwNGE1MTA4IDAwMDAwMDAwIGAuUy4uLi4uLkpRLi4uLi4K4pSCIC0g
+IDB4MDg1MWRjZDAgZjA0YTUxMDggMDAwMDAwMDAgOTA3ZTFlMDMgMDAwMDAwMDAgLkpRLi4uLi4u
+fi4uLi4uLgrilIIgKyAgMHgwODUxZGNkMCBmMDRhNTEwOCAwMDAwMDAwMCA4ODdlMWUwMyAwMDAw
+MDAwMCAuSlEuLi4uLi5+Li4uLi4uCuKUgiAgICAweDA4NTFkY2UwIDIwNTA1NTA4IDAwMDAwMDAw
+IGEwMTg1MzA4IDAwMDAwMDAwICBQVS4uLi4uLi5TLi4uLi4K4pSCICAgIDB4MDg1MWRjZjAgZTAx
+ODUzMDggMDAwMDAwMDAgZTAxNzUzMDggMDAwMDAwMDAgLi5TLi4uLi4uLlMuLi4uLgrilIIgICAg
+MHgwODUxZGQwMCA2MDE4NTMwOCAwMDAwMDAwMCAyMDE5NTMwOCAwMDAwMDAwMCBgLlMuLi4uLiAu
+Uy4uLi4uCuKUgiAgICAweDA4NTFkZDEwIDIwMTg1MzA4IDAwMDAwMDAwIDg4NTBhNTAyIDAwMDAw
+MDAwICAuUy4uLi4uLlAuLi4uLi4K4pSCICAgIDB4MDg1MWRkMjAgNjg1MWE1MDIgMDAwMDAwMDAg
+OTg1MGE1MDIgMDAwMDAwMDAgaFEuLi4uLi4uUC4uLi4uLgrilIIgICAgMHgwODUxZGQzMCA3MDUx
+YTUwMiAwMDAwMDAwMCBhMDUwYTUwMiAwMDAwMDAwMCBwUS4uLi4uLi5QLi4uLi4uCuKUgiAgICAw
+eDA4NTFkZDQwIGMwNTFhNTAyIDAwMDAwMDAwIDQwZTQ3NTA4IDAwMDAwMDAwIC5RLi4uLi4uQC51
+Li4uLi4K
+
+--_002_AM6PR02MB44704BD42717C2D472D0CEB6B5B79AM6PR02MB4470eurp_--
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=jakstys-lt.20210112.gappssmtp.com header.i=@jakstys-lt.20210112.gappssmtp.com
+Received: from mail-oa1-f49.google.com (mail-oa1-f49.google.com [209.85.160.49])
+	by mail-b.sr.ht (Postfix) with ESMTPS id D268211EE06
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed,  8 Mar 2023 04:55:55 +0000 (UTC)
+Received: by mail-oa1-f49.google.com with SMTP id 586e51a60fabf-176d1a112bfso8752780fac.5
+        for <~motiejus/bazel-zig-cc@lists.sr.ht>; Tue, 07 Mar 2023 20:55:55 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=jakstys-lt.20210112.gappssmtp.com; s=20210112; t=1678251355;
+        h=content-transfer-encoding:cc:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:from:to:cc:subject:date
+         :message-id:reply-to;
+        bh=9OWNyKG0S693D/TEf4qFWuPngIzLU6DKh5d9/x/dRMY=;
+        b=hiOVHjkZW3TBRG68rVQbPC7jNk/imh0iNTxYZ0TqolGEejfwsv/WXyrOkbXCN578ND
+         C3rpFVlF6c2pc9lextzNtJxoBeJ1c+uvSLdhvP6gEnrkk3VTrh8iYag7q0HySFDuDM3h
+         bySWt0+JvvKKhKbwlIyDOAD6id+d0PRaf+HUWGVv5sl/97VScCckKs1k7RKeq5mNF82L
+         OW5QUEy3+MqHGzkOcHZF5V7Q7i+7udyprEI+p4HopskKWTIGtzgV13eSBvh478WwX+M3
+         7CK8Ur1G+jiYlo2BqL9Fp/w0HNngic+hA+dRKjex9B8pC9nP8mfDPk+v/P15jm877HlD
+         NMmQ==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112; t=1678251355;
+        h=content-transfer-encoding:cc:to:subject:message-id:date:from
+         :in-reply-to:references:mime-version:x-gm-message-state:from:to:cc
+         :subject:date:message-id:reply-to;
+        bh=9OWNyKG0S693D/TEf4qFWuPngIzLU6DKh5d9/x/dRMY=;
+        b=zCUX0f3S7iBRK6wuvhei7PwbMCKQL1Lu2ui/zMC+bfiWYPvZi1jUtEHsVrKD30E0pG
+         bTDj96Eumr5heA1ROn6+oZ/wfyWmUtbjeRSbgDg4vRmR6ZTy0pMkR3FjVTx8G4YszFSW
+         hiUp1VzkLviBo5Im7wDu/j2P96NYu/Capb8DTtKQ9j54QK5cps2OPLPlUoQLI4zESI5Y
+         SoWcBnhEoo2WxjabR/R+2DbNLcUDU+Yvl8En2kEZr13OiUeEHgR8ZieJart1m9Q2PIAe
+         slqVtXu5mbx32rEGoKJjqNhsnvCyg0a+nCST+Soth/FYJ5TLQw28p08uByHlU7CNdXSp
+         T0LA==
+X-Gm-Message-State: AO0yUKXrrP1V1aj9s3EDZsZRkhibFUuoLdVM6otyfqNwg4s5+g8V+KgQ
+	Nsk7nYZ3ewuNk/sVeDZ1XpYdk/1oarEyQFGs3HL0m1U/qIQ=
+X-Google-Smtp-Source: AK7set/7QmoDwktRotABksnlu72yg9mHpeO9E3lP97jqCIRcYlWF3kElgG/pX7uvSH8Vmw1CVIoLwCl0NaOvKGymtrA=
+X-Received: by 2002:a05:6870:470b:b0:16e:8993:9d7c with SMTP id
+ b11-20020a056870470b00b0016e89939d7cmr10158666oaq.1.1678251354846; Tue, 07
+ Mar 2023 20:55:54 -0800 (PST)
+MIME-Version: 1.0
+References: <AM6PR02MB4470CFBE0B194EA91E16F552B5B79@AM6PR02MB4470.eurprd02.prod.outlook.com>
+ <AM6PR02MB44704BD42717C2D472D0CEB6B5B79@AM6PR02MB4470.eurprd02.prod.outlook.com>
+In-Reply-To: <AM6PR02MB44704BD42717C2D472D0CEB6B5B79@AM6PR02MB4470.eurprd02.prod.outlook.com>
+From: =?UTF-8?Q?Motiejus_Jak=C5=A1tys?= <motiejus@jakstys.lt>
+Date: Wed, 8 Mar 2023 06:55:43 +0200
+Message-ID: <CAFVMu-puXsmnArzMSXw7=TX1ph6BfNTBySxvgxXOgYvMjj_ZwQ@mail.gmail.com>
+Subject: Re: bazel-zig-cc embeds bazel cache path in go binary
+To: Malte Poll <mp@edgeless.systems>
+Cc: "~motiejus/bazel-zig-cc@lists.sr.ht" <~motiejus/bazel-zig-cc@lists.sr.ht>
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Status: O
+Content-Length: 3911
+Lines: 103
+
+On Tue, Mar 7, 2023 at 6:15=E2=80=AFPM Malte Poll <mp@edgeless.systems> wro=
+te:
+>
+>
+> Hello,
+>
+> I was checking if bazel-zig-cc produces reproducible go binaries if used =
+as a compiler for cgo.
+> As a test, I compiled the same binary on the same commit on two different=
+ systems (Ubuntu, Fedora) and in two different paths at different times.
+>
+> The binaries are not reproducible. At least some differences seem to be c=
+oming from bazel-zig-cc:
+>
+> The paths to pthread.h and signal.h on my build system are embedded in th=
+e resulting binary. See below for an instance of this behavior.
+> Do you think this can be prevented to make the resulting binary more herm=
+etic / reproducible?
+
+Hi Malte,
+
+Thanks for the report. I am 99% confident the problem is with Go,
+because Go compiles CGo files 2 ways:
+1. in the Bazel sandbox.
+2. in /tmp/work-<...>, outside the sandbox.
+
+>  -  [15809be]  /root/.cache/bazel/_bazel_root/378578e4f433132b2cb209458a9=
+b56bc/sandbox/processwrapper-sandbox/44/execroot/__main__/external/zig_sdk/=
+tools/x86_64-linux-gnu.2.34/../../lib/libc/include/generic-glibc/pthread.h
+
+When we invoke "zig c++", the ZIG_LIB_DIR needs to be passed to Zig.
+It needs to be a relative directory, but it can't always do that. This
+is how it's determined:
+https://git.sr.ht/~motiejus/bazel-zig-cc/tree/v1.0.1/item/toolchain/launche=
+r.zig#L190-215
+
+Here are the relevant lines with comments. First, determine the "root"
+of the zig sdk:
+
+    const root =3D blk: {
+        var dir =3D cwd.openDir(
+            "external" ++ sep ++ "zig_sdk" ++ sep ++ "lib",
+            .{ .access_sub_paths =3D false, .no_follow =3D true },
+        );
+
+        if (dir) |*dir_exists| {
+            dir_exists.close();
+            break :blk "external" ++ sep ++ "zig_sdk";
+        } else |_| {}
+
+If "external/zig_sdk/lib" exists, then "root" is exactly that. If it
+does not exist:
+
+        // directory does not exist or there was an error opening it
+        const here =3D fs.path.dirname(arg0) orelse ".";
+        break :blk try fs.path.join(arena, &[_][]const u8{ here, "..", ".."=
+ });
+    };
+
+... then the zig sdk root will be the full path to the executed file
+(e.g. /root/.cache/bazel/_bazel_root/378578e4f433132b2cb209458a9b56bc/sandb=
+ox/processwrapper-sandbox/44/execroot/__main__/external/zig_sdk/tools/x86_6=
+4-linux-gnu.2.34/c++),
+it's dirname, plus "../../". Then append the "lib" to that path:
+
+    const zig_lib_dir =3D try fs.path.join(arena, &[_][]const u8{ root, "li=
+b" });
+    <...>
+
+And then use that path for ZIG_LIB_DIR:
+
+    try env.put("ZIG_LIB_DIR", zig_lib_dir);
+
+So following the logic ZIG_LIB_DIR in your example will be
+/root/.cache/bazel/_bazel_root/378578e4f433132b2cb209458a9b56bc/sandbox/pro=
+cesswrapper-sandbox/44/execroot/__main__/external/zig_sdk/tools/x86_64-linu=
+x-gnu.2.34/../../
+; and this is how Zig will embed that path.
+
+Other than changing how Go builds it's CGO binaries, I don't see a
+good way to work around this. At the point Go is invoking the external
+linker we are already in $WORK, so we don't have control over that
+working directory.
+
+The horrible part is, of course, changing the working directory at the
+bottom leaves of the compilation chain. The good part about this
+design is that Bazel does not see non-hermeticity (at this point Bazel
+lost control). So as far as Bazel is concerned, it's the same
+dependency hash. The bad part, is, of course, non-reproducible
+binaries.
+
+> <...>
+> Attached is the full output of diffoscope.
+
+Thanks, TIL.
+
+Are the paths still there if you strip the binaries (are they
+stripped? hard to tell, because your diffoscope output does not
+include all sections)? IIRC filenames are only present in binaries
+compiled with debug info. But I am not sure if `strip` removes strings
+from rodata. Please let us know.
+
+Motiejus
+
+From MAILER-DAEMON Wed Mar  8 11:59:04 2023
+Authentication-Results: mail-b.sr.ht; dkim=pass header.d=edgelesscompute.onmicrosoft.com header.i=@edgelesscompute.onmicrosoft.com
+Received: from EUR02-AM0-obe.outbound.protection.outlook.com (mail-am0eur02on2105.outbound.protection.outlook.com [40.107.247.105])
+	by mail-b.sr.ht (Postfix) with ESMTPS id 51BE711EFFA
+	for <~motiejus/bazel-zig-cc@lists.sr.ht>; Wed,  8 Mar 2023 11:58:14 +0000 (UTC)
+ARC-Seal: i=1; a=rsa-sha256; s=arcselector9901; d=microsoft.com; cv=none;
+ b=dn1vNkrxngqLKmX3h8dbuJ3mhZQ4k85ctNac4otz3xlB5C0giH4SsPqIBxUppD0Jy4SGTE4HyAkVYHGJXg/21A9wQvwnjegWZsxKOcdjUNYnb7RDgqQk1TVqCEc3BNGCC39gdfctq9XF2tuk8qnxSw7VGuj4XkTD2Jgp4h/GOBOrQv6qSl9z9DiPXw+I3/9GqmOnt8YnAxJ/111/4D9AL2dkJZN2WqTKdYy18qn5Gemc4IV9m93mjWk9hwPTHVwfdZzhIipsZmkbRwZGreg9lgDHlCte/IUx58MlsY3lLX2eXSmxqcT4B2hIMpFzAIwTNYGe10PIOhd7gPKpqT4GSg==
+ARC-Message-Signature: i=1; a=rsa-sha256; c=relaxed/relaxed; d=microsoft.com;
+ s=arcselector9901;
+ h=From:Date:Subject:Message-ID:Content-Type:MIME-Version:X-MS-Exchange-AntiSpam-MessageData-ChunkCount:X-MS-Exchange-AntiSpam-MessageData-0:X-MS-Exchange-AntiSpam-MessageData-1;
+ bh=FTB0McV89iIW8bxpSgjRpV/XTRfoa4YP68Z9tGj8XTY=;
+ b=Bd+F6WxAxpreCUqlxCyWb/r5vVg6sLCJYR8+8oOrQUqNb05o4bL+kA70klExyBlBYYCt8m/A+x8SUTE17w19zGeMI5+FsTaSvoOhhR1SyYW7YzyA7OzQjwf32seFs7BNG8eww9/Gn+Y7jUqAv45BsXAPKC8GHBZkn6ezqHv/XARiGKGSC8mAEZlWxtBem1vE+aPLhC0pMSnlowcfTsv1GeNTLLvZhu82gqhLNd6+5n35UNeSztlwsTGgw/dl00aK6mWLJRY4gNu+jT/tot8HgQ4MuK6NI7uWT2jPC71VN9ypEFCrmWoNUpYMM/DeQ0dWwUp7ert2Z4B9r1kC2RKUaA==
+ARC-Authentication-Results: i=1; mx.microsoft.com 1; spf=pass
+ smtp.mailfrom=edgeless.systems; dmarc=pass action=none
+ header.from=edgeless.systems; dkim=pass header.d=edgeless.systems; arc=none
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+ d=edgelesscompute.onmicrosoft.com;
+ s=selector1-edgelesscompute-onmicrosoft-com;
+ h=From:Date:Subject:Message-ID:Content-Type:MIME-Version:X-MS-Exchange-SenderADCheck;
+ bh=FTB0McV89iIW8bxpSgjRpV/XTRfoa4YP68Z9tGj8XTY=;
+ b=IK1Tuf2RXVBt3DhdmNTeQAQL8fHVmwyA97WKu3RQnFBqSlVCtGgADiVLPKnVDavC6SKJCw4Bh2/LK1xLL72nQb8MPpecjwCpZuM+wCAqZSyujrC+A6jWQ6mE/BicmD0q8DyFNj+fJgtSVMQajuOokjhjPnmHV3HUBHbBscvAo/w=
+Received: from AM6PR02MB4470.eurprd02.prod.outlook.com (2603:10a6:20b:60::26)
+ by AM9PR02MB7363.eurprd02.prod.outlook.com (2603:10a6:20b:3e5::24) with
+ Microsoft SMTP Server (version=TLS1_2,
+ cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id 15.20.6178.16; Wed, 8 Mar
+ 2023 11:58:12 +0000
+Received: from AM6PR02MB4470.eurprd02.prod.outlook.com
+ ([fe80::77cb:f64d:66e1:45fe]) by AM6PR02MB4470.eurprd02.prod.outlook.com
+ ([fe80::77cb:f64d:66e1:45fe%4]) with mapi id 15.20.6178.016; Wed, 8 Mar 2023
+ 11:58:12 +0000
+From: Malte Poll <mp@edgeless.systems>
+To: "~motiejus/bazel-zig-cc@lists.sr.ht" <~motiejus/bazel-zig-cc@lists.sr.ht>
+CC: =?Windows-1252?Q?Motiejus_Jak=9Atys?= <motiejus@jakstys.lt>
+Subject: Re: bazel-zig-cc embeds bazel cache path in go binary
+Thread-Topic: bazel-zig-cc embeds bazel cache path in go binary
+Thread-Index: AQHZUbVBY9IsLRvgFEeHbjMThTnaAg==
+Date: Wed, 8 Mar 2023 11:58:12 +0000
+Message-ID: 
+ <AM6PR02MB4470F24D4FF986DE7C4F78D7B5B49@AM6PR02MB4470.eurprd02.prod.outlook.com>
+Accept-Language: en-US
+Content-Language: en-US
+X-MS-Has-Attach: 
+X-MS-TNEF-Correlator: 
+msip_labels: 
+x-ms-publictraffictype: Email
+x-ms-traffictypediagnostic: AM6PR02MB4470:EE_|AM9PR02MB7363:EE_
+x-ms-office365-filtering-correlation-id: 42782796-0a89-41a9-f6c2-08db1fcc645b
+x-ms-exchange-senderadcheck: 1
+x-ms-exchange-antispam-relay: 0
+x-microsoft-antispam: BCL:0;
+x-microsoft-antispam-message-info: 
+ wn8TeJ9onkVDJ+qmEhpYMmOLXbHlW58go1SifJ+RmTXlnVrB2vej1Js2bGvXfvujKo7LgnbwRh+P4Zuv78XsVkmXwPBYdy0JJYMkaXYO4Xg8XV5FY92J5qdXc75dLaBSnYsrIkSIr3lQqZp7My7etM9wYkbj0sKFPussr+NxqGTXR66QSsmyCWv1uBSd2MlOYkYSU7JckywSR0SFc9IPr9mprHxMsSaAK2QVAERWj7aa3t9Kdjf+rJNKGtrDpQxdSvtEyQxlAhD5ZwONjVuHV3165okOOnxSY8T2fwu2sTSYoMrmeH7aqSO3gZYRginz3S/2TM3HSCA2oI4isTjncTmu1RPquAMRvfUpY3+J6lCF+InpmkiCBLLsGg/QZKmpHx+8WfJEEBnStPo4hj/BxyGETnBv1n/EN+IwfPXZIysyfLwYJWMLju8TudROa0H8qK88iUnexwojReQIRnSUPIL/Tb5IG6qE5tpBKAyUa1MGyYPMjR5gjwfnYWQd3rDr6VIU4r87T1z0TpxEkDCn6O/QJwhoNyo3FR7DgJN0fMQnB7po80E5JW0DGm31OIL0siRJfm5OHYeocmTAE2Nz6xaW0sXV/XyxRlzmk6ciL16r8tJTfbKtsiWpkntV0inMuYa2Mu0whxmtGAcAFGQqR4rORb6Ot5Do65C88wggNqKxVhwc//sz3IKvukrG9QO1faM15mGt5NSiiXV3Ooq5+g==
+x-forefront-antispam-report: 
+ CIP:255.255.255.255;CTRY:;LANG:en;SCL:1;SRV:;IPV:NLI;SFV:NSPM;H:AM6PR02MB4470.eurprd02.prod.outlook.com;PTR:;CAT:NONE;SFS:(13230025)(346002)(136003)(376002)(396003)(39840400004)(366004)(451199018)(8936002)(52536014)(2906002)(5660300002)(41300700001)(66946007)(91956017)(66446008)(64756008)(66476007)(4744005)(66556008)(4326008)(76116006)(8676002)(316002)(478600001)(71200400001)(7696005)(26005)(33656002)(6506007)(86362001)(122000001)(38070700005)(55016003)(38100700002)(186003)(9686003)(46492015);DIR:OUT;SFP:1102;
+x-ms-exchange-antispam-messagedata-chunkcount: 1
+x-ms-exchange-antispam-messagedata-0: 
+ =?Windows-1252?Q?tkJnzjjJ1ljVqHPhJ5hWd4Nown0M/JEHAcVfcEMe//K0p4nkhvnVk0Ez?=
+ =?Windows-1252?Q?lycKWnjlHmam/U0XS8QJb0BZKlItrjCE5GLX+q8Y+7rViBl6MNxYB4L8?=
+ =?Windows-1252?Q?xE+YMbN/L2zHFFHr8P6DKmo4fY1lp7yJLm47L38iPVbtrIDx8TxOJDTB?=
+ =?Windows-1252?Q?t4hleSa8DtASEHDzFiwWeVcQDYKCg3x2bipg4doY+PxxzWZxut24HXaq?=
+ =?Windows-1252?Q?dL7s8KG9PT6Ypvu+YlRpsUkVdRpcporpqjAKuyY/oqPMpvwvu7JSHLcy?=
+ =?Windows-1252?Q?v+o/hLP96m7g7lJmsCg52qPiP4sMGDx6d76dMmQmnIyl+ePuyO9muI+s?=
+ =?Windows-1252?Q?gm/otyGemrHYNPTl+LJzOyFvc1bngotgX0FC5QEssbcl9GfO8/2Gr3Fs?=
+ =?Windows-1252?Q?EFMCXZafQYlbaHs8sDprUlyuXQiR/wznKXci3/j0x100rJI0cC+Qf2ju?=
+ =?Windows-1252?Q?ZICwci91UhGgDu00eEvH0HZksoZm9mZ0xdd+v58E/gQ/d9+KLvO9rwvF?=
+ =?Windows-1252?Q?vPJFeGv5xJkq+dDHtmLFacd0fU062qqn22Dws7RPtsvZ1/c4QjUcUblP?=
+ =?Windows-1252?Q?zUU84/VTo4jWfbfRY1Lmoo7ufCRcRO9smitJW8Zgx5Id9Vg4odpKL5vC?=
+ =?Windows-1252?Q?rxAsl8z67XAnJqFvWL+Hw6M3rZETJHPgJFTGvCNF4EkYabBsvZH2937s?=
+ =?Windows-1252?Q?fUWWfdZPTQpLZJviJjovQL/DCxd+cb5dTvvY6zXCZmyIwzM+JcjbMj6+?=
+ =?Windows-1252?Q?L2Bqb2+e3e/sHRVhmRxSf4DZ9k8dBrGBC52OLKRt4XWhYgUP9A2ZqF9n?=
+ =?Windows-1252?Q?nhcWTRExH4gQgWBNZPp94k+UqMGZY3FOQcRraxlkQB6J8IHcPpYcjfW+?=
+ =?Windows-1252?Q?QiNz8ZV3K9U5AWmJaBvQerNuCixFzYHie6A1I9tInrOsVZ0LYGJRvAt7?=
+ =?Windows-1252?Q?dV7AgafvbECVIkUNDx2jwuRp7fVQGN/uKT9m8ePyEjjxQOI51fY/ObH9?=
+ =?Windows-1252?Q?GHbo2ovnscMwY6/l2U083gPSoJeuJ3MTcYFqORWKUxZG2CJJ0HVOabkd?=
+ =?Windows-1252?Q?CdsUkszP65uN+qEwgwqfaIRC8/jgyFOonRmZelc1HdDIxoleOtdE7AAD?=
+ =?Windows-1252?Q?kZZ0Ctv5Yy3AZ4Y60vxl0KFHo3RugXYrbwRXJzLJ48szgVwI6fZAq45L?=
+ =?Windows-1252?Q?tXSbVMB9VQ/3GnH9ITqr3l/wrGwfV+fpPNYyuW+QZk/hMN7bglumPW0p?=
+ =?Windows-1252?Q?blDYwTIq8J4D4z28Mf6qf7EccdxqR6iCs/QGlz0KcUDB+wbCYM6PB89o?=
+ =?Windows-1252?Q?J3nfRIbQwE8tVVyoGxPaarAURilqOIFQ+GC9V9+U2Rti4oprtdnmOzhy?=
+ =?Windows-1252?Q?BgnEdIBLtBiPgK65ZwonNGZI8PXCCDBo4JHA6rKbDni9mbuHDRXc1csa?=
+ =?Windows-1252?Q?QRzPUh4YIhyvp+1GgSJVMeR+IGX9xQJHajagnNJRPeWvaUz/KKbDA6s7?=
+ =?Windows-1252?Q?vjuqpKKNw054rGFR0zyaLDcsHQIyxTi0u//7as99SepWyD1RtfwSDEwY?=
+ =?Windows-1252?Q?4eu8VzYsyd6AmCo7cNXhdHRiaaHAvnxhUqAqffzCp514fca/SwDzEg5D?=
+ =?Windows-1252?Q?9/0IqQ2X/7h5KGy5fYXL+XmvAmKMxk89QyPNIwQOqYoFC4I8adWb6TSm?=
+ =?Windows-1252?Q?0KswpxH9yNaAG5pjU6lLoC3taVC6NN6K?=
+Content-Type: text/plain; charset="Windows-1252"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+X-OriginatorOrg: edgeless.systems
+X-MS-Exchange-CrossTenant-AuthAs: Internal
+X-MS-Exchange-CrossTenant-AuthSource: AM6PR02MB4470.eurprd02.prod.outlook.com
+X-MS-Exchange-CrossTenant-Network-Message-Id: 42782796-0a89-41a9-f6c2-08db1fcc645b
+X-MS-Exchange-CrossTenant-originalarrivaltime: 08 Mar 2023 11:58:12.0438
+ (UTC)
+X-MS-Exchange-CrossTenant-fromentityheader: Hosted
+X-MS-Exchange-CrossTenant-id: adb650a8-5da3-4b15-b4b0-3daf65ff7626
+X-MS-Exchange-CrossTenant-mailboxtype: HOSTED
+X-MS-Exchange-CrossTenant-userprincipalname: WWcc5krjd8xdDSjmWaccPMK6mgycI8hoJtxPSxhDr8akuwiHmfFlfMbVPmAeQA10RMhR5pdnz8sUUSe3Dc0l2g==
+X-MS-Exchange-Transport-CrossTenantHeadersStamped: AM9PR02MB7363
+Status: O
+Content-Length: 424
+Lines: 10
+
+So, I chased this issue a bit more.=0A=
+Simply setting the bazel flag "--strip=3Dalways" does not seem to be suffic=
+ient. However, when I set "--compilation_mode=3Dopt", the strings disappear=
+.=0A=
+I'll report findings if I get to the bottom of this, although I agree that =
+this may not be something that can be fixed in the toolchain. For now I can=
+ live with the compilation mode.=0A=
+=0A=
+Thanks=0A=
+Malte=
+


### PR DESCRIPTION
I will be shutting down ~motiejus/bazel-zig-cc@lists.sr.ht within days. Now that comms are in Slack and github issues/PRs, let's add the archive for historical reference.

It can be opened and read through like this:

  mutt -R -f mailing-list-archive.mbox