### PR TITLE
Fixing the url template in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ http_archive(
     sha256 = "e9f82bfb74b3df5ca0e67f4d4989e7f1f7ce3386c295fd7fda881ab91f83e509",
     strip_prefix = "bazel-zig-cc-{}".format(BAZEL_ZIG_CC_VERSION),
     urls = [
-        "https://mirror.bazel.build/github.com/uber/bazel-zig-cc/releases/download/{}/{}.tar.gz".format(BAZEL_ZIG_CC_VERSION),
-        "https://github.com/uber/bazel-zig-cc/releases/download/{}/{}.tar.gz".format(BAZEL_ZIG_CC_VERSION),
+        "https://mirror.bazel.build/github.com/uber/bazel-zig-cc/releases/download/{0}/{0}.tar.gz".format(BAZEL_ZIG_CC_VERSION),
+        "https://github.com/uber/bazel-zig-cc/releases/download/{0}/{0}.tar.gz".format(BAZEL_ZIG_CC_VERSION),
     ],
 )
 


### PR DESCRIPTION
Fixing the following error:

```
ERROR: Traceback (most recent call last):
	File "/Users/$me/dev/$org/$my_repo/WORKSPACE", line 261, column 104, in <toplevel>
		"https://mirror.bazel.build/github.com/uber/bazel-zig-cc/releases/download/{}/{}.tar.gz".format(BAZEL_ZIG_CC_VERSION),
Error in format: No replacement found for index 1
ERROR: Error computing the main repository mapping: Encountered error while reading extension file 'toolchain/defs.bzl': no such package '@bazel-zig-cc//toolchain': error loading package 'external': Could not load //external package
```